### PR TITLE
fix(tools): system tool returns empty output for memory metric

### DIFF
--- a/src/bantz/core/brain.py
+++ b/src/bantz/core/brain.py
@@ -142,7 +142,7 @@ class Brain:
         if any(k in both for k in ("bellek", "memory", "ram", "free -",
                                     "ne kadar ram", "ram kullanım",
                                     "ram ne kadar", "bellek kullanım")):
-            return {"tool": "system", "args": {"metric": "memory"}}
+            return {"tool": "system", "args": {"metric": "ram"}}
         if any(k in both for k in ("cpu", "işlemci", "uptime", "yük", "load")):
             return {"tool": "system", "args": {"metric": "all"}}
 

--- a/src/bantz/tools/system.py
+++ b/src/bantz/tools/system.py
@@ -25,9 +25,13 @@ class SystemTool(BaseTool):
 
     async def execute(self, metric: str = "all", **kwargs: Any) -> ToolResult:
         """
-        metric: "all" | "cpu" | "ram" | "disk" | "uptime"
+        metric: "all" | "cpu" | "ram" | "memory" | "disk" | "uptime"
         """
         try:
+            # Normalise aliases
+            if metric == "memory":
+                metric = "ram"
+
             data: dict[str, Any] = {}
             lines: list[str] = []
 


### PR DESCRIPTION
Fixes #22

**Root cause:** `brain._quick_route` sent `metric='memory'` but `system.py` only accepted `'ram'`. The tool returned empty lines, and `_finalize` showed *Tamam, işlem tamamlandı. ✓* instead of actual stats.

**Changes:**
- `system.py`: accept `'memory'` as alias for `'ram'` (normalize early)
- `brain.py`: send `metric='ram'` instead of `'memory'` for consistency
- All 6 metric values (`all/cpu/ram/memory/disk/uptime`) tested, all return non-empty formatted output