### PR TITLE
feat(core): temporal awareness — Turkish date parser

### DIFF
--- a/src/bantz/core/date_parser.py
+++ b/src/bantz/core/date_parser.py
@@ -1,0 +1,105 @@
+"""
+Bantz v2 — Turkish Date Parser
+Resolves relative and named dates from Turkish natural language.
+
+Usage:
+    from bantz.core.date_parser import resolve_date
+    dt = resolve_date("yarın derslerim")       # → tomorrow
+    dt = resolve_date("perşembe toplantım var") # → next Thursday
+    dt = resolve_date("dün ne yaptık")          # → yesterday
+"""
+from __future__ import annotations
+
+import re
+from datetime import datetime, timedelta
+from typing import Optional
+
+
+# Turkish weekday names → Python weekday index (Monday=0 .. Sunday=6)
+_TR_WEEKDAYS: dict[str, int] = {
+    "pazartesi": 0,
+    "salı":      1,
+    "salı":      1,
+    "çarşamba":  2,
+    "perşembe":  3,
+    "cuma":      4,
+    "cumartesi": 5,
+    "pazar":     6,
+}
+
+# Relative date tokens
+_RELATIVE: list[tuple[str, int]] = [
+    ("öbür gün",    2),
+    ("önceki gün", -2),
+    ("evvelsi gün",-2),
+    ("yarın",       1),
+    ("dün",        -1),
+    ("bugün",       0),
+]
+
+# Week-based references
+_WEEK_REFS: list[tuple[str, str]] = [
+    ("gelecek hafta", "next"),
+    ("haftaya",       "next"),
+    ("geçen hafta",   "last"),
+    ("bu hafta",      "this"),
+]
+
+
+def resolve_date(text: str, now: datetime | None = None) -> Optional[datetime]:
+    """
+    Extract and resolve a date reference from Turkish text.
+    Returns a datetime (date at 00:00) or None if no date found.
+
+    Priority: explicit relative ("yarın") > named weekday ("perşembe") > week ref.
+    """
+    now = now or datetime.now()
+    today = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    t = text.lower().strip()
+
+    # 1. Relative dates (ordered longest-first to avoid partial matches)
+    for token, delta_days in _RELATIVE:
+        if token in t:
+            return today + timedelta(days=delta_days)
+
+    # 2. Named weekdays — resolve to next occurrence (today if today is that day)
+    for day_name, weekday_idx in _TR_WEEKDAYS.items():
+        if day_name in t:
+            return _next_weekday(today, weekday_idx)
+
+    # 3. Week-based references
+    for token, direction in _WEEK_REFS:
+        if token in t:
+            return _week_start(today, direction)
+
+    # 4. ISO date in text (2025-01-15)
+    m = re.search(r"(\d{4}-\d{2}-\d{2})", t)
+    if m:
+        try:
+            return datetime.strptime(m.group(1), "%Y-%m-%d")
+        except ValueError:
+            pass
+
+    return None
+
+
+def _next_weekday(today: datetime, target_weekday: int) -> datetime:
+    """
+    Return the next occurrence of target_weekday from today.
+    If today IS that weekday, return today.
+    """
+    current = today.weekday()
+    delta = (target_weekday - current) % 7
+    return today + timedelta(days=delta)
+
+
+def _week_start(today: datetime, direction: str) -> datetime:
+    """
+    Return the Monday of 'this', 'next', or 'last' week.
+    """
+    monday = today - timedelta(days=today.weekday())
+    if direction == "next":
+        return monday + timedelta(weeks=1)
+    elif direction == "last":
+        return monday - timedelta(weeks=1)
+    return monday  # "this"

--- a/src/bantz/core/memory.py
+++ b/src/bantz/core/memory.py
@@ -203,6 +203,23 @@ class Memory:
             ).fetchall()
         return [dict(r) for r in rows]
 
+    def search_by_date(self, date: "datetime", limit: int = 20) -> list[dict]:
+        """
+        Return messages from a specific date (all conversations).
+        Useful for "dün ne yaptık" type queries.
+        """
+        date_str = date.strftime("%Y-%m-%d")
+        rows = self._conn.execute(
+            """SELECT m.role, m.content, m.tool_used, m.created_at,
+                      c.id as conv_id
+               FROM messages m
+               JOIN conversations c ON c.id = m.conversation_id
+               WHERE m.created_at LIKE ?
+               ORDER BY m.created_at ASC LIMIT ?""",
+            (f"{date_str}%", limit),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
     def conversation_list(self, limit: int = 20) -> list[dict]:
         """Return recent conversations with message count (for a history UI)."""
         rows = self._conn.execute(

--- a/src/bantz/core/schedule.py
+++ b/src/bantz/core/schedule.py
@@ -138,6 +138,43 @@ class Schedule:
         day_tr = DAYS_TR[self._day_key(now)]
         return f"{day_tr} derslerin:\n" + "\n".join(lines)
 
+    def format_for_date(self, target: datetime) -> str:
+        """Return formatted string of classes for an arbitrary date."""
+        return self.format_today(target)
+
+    def format_week(self, start: datetime | None = None) -> str:
+        """Return formatted string for an entire week starting from Monday."""
+        self._load()
+        start = start or datetime.now()
+        # Find Monday of the given week
+        monday = start - timedelta(days=start.weekday())
+
+        sections: list[str] = []
+        total = 0
+        for i in range(7):
+            day_dt = monday + timedelta(days=i)
+            key = self._day_key(day_dt)
+            classes = sorted(
+                self._data.get(key, []),
+                key=lambda c: c.get("time", ""),
+            )
+            if not classes:
+                continue
+            total += len(classes)
+            day_tr = DAYS_TR[key]
+            lines = []
+            for cls in classes:
+                emoji = TYPE_EMOJI.get(cls.get("type", ""), "📚")
+                name = cls.get("name", "")
+                time = cls.get("time", "")
+                lines.append(f"    {emoji} {time}  {name}")
+            sections.append(f"  {day_tr}:\n" + "\n".join(lines))
+
+        if not sections:
+            return "Bu hafta ders yok."
+        header = f"Haftalık program ({total} ders):"
+        return header + "\n" + "\n".join(sections)
+
     def format_next(self, now: datetime | None = None) -> str:
         """Return formatted string of next upcoming class."""
         now = now or datetime.now()


### PR DESCRIPTION
Fixes #23

**New file:** `src/bantz/core/date_parser.py`
- `resolve_date(text)` parses Turkish relative dates (bugün, yarın, dün, öbür gün)
- Named weekdays (pazartesi–pazar) → next occurrence
- Week refs (bu hafta, gelecek hafta, geçen hafta)
- ISO dates in text

**Integration:**
- `brain.py`: schedule routing resolves dates → `_schedule_date`, `_schedule_week`
- `schedule.py`: `format_for_date()`, `format_week()`
- `memory.py`: `search_by_date()` for 'dün ne yaptık'

**Also fixed:** Schedule/Classroom keyword overlap, 'ram' substring false positive in 'programım'