### PR TITLE
fix(core): wire memory into --doctor + migrate store.db → bantz.db

### DIFF
--- a/src/bantz/__main__.py
+++ b/src/bantz/__main__.py
@@ -169,9 +169,13 @@ async def _doctor() -> None:
     if any(st != "ok" for st in g_status.values()):
         print("  → Run: bantz --setup google gmail  /  bantz --setup google classroom")
 
-    # DB
+    # Memory DB
     config.ensure_dirs()
-    print(f"✓ DB: {config.db_path}")
+    from bantz.core.memory import memory as _mem
+    _mem.init(config.db_path)
+    s = _mem.stats()
+    print(f"✓ Memory DB: {s['db_path']}")
+    print(f"  {s['total_conversations']} konuşma  |  {s['total_messages']} toplam mesaj")
     print("─" * 44)
 
 

--- a/src/bantz/config.py
+++ b/src/bantz/config.py
@@ -47,7 +47,13 @@ class Config(BaseSettings):
             if self.data_dir
             else Path.home() / ".local" / "share" / "bantz"
         )
-        return base / "store.db"
+        new = base / "bantz.db"
+        # One-time migration: store.db → bantz.db
+        if not new.exists():
+            old = base / "store.db"
+            if old.exists():
+                old.rename(new)
+        return new
 
     def ensure_dirs(self) -> None:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Changes
- **config.py**: `db_path` now returns `bantz.db` with one-time auto-migration from `store.db`
- **__main__.py**: `_doctor()` initializes memory and shows conversation/message stats

## Before
```
✓ DB: ~/.local/share/bantz/store.db
```

## After
```
✓ Memory DB: ~/.local/share/bantz/bantz.db
  3 konuşma  |  47 toplam mesaj
```

Closes #37