### PR TITLE
feat(core): user profile — persistent identity and preferences

### DIFF
--- a/src/bantz/__main__.py
+++ b/src/bantz/__main__.py
@@ -349,12 +349,12 @@ def _write_location_to_env(city: str, lat: float, lon: float) -> None:
 
 def _setup_profile() -> None:
     """Interactive profile setup — writes profile.json."""
-    from bantz.core.profile import profile
+    from bantz.core.profile import profile, ALL_BRIEFING_SECTIONS, ALL_NEWS_SOURCES
 
     print("\n👤 User Profile Setup")
     print("─" * 40)
     if profile.is_configured():
-        print(f"Current profile: {profile.get('name')} ({profile.get('tone')})")
+        print(f"Current profile: {profile.get('name')} ({profile.response_style})")
         print()
 
     name = input("Name: ").strip()
@@ -367,25 +367,56 @@ def _setup_profile() -> None:
     year_raw = input("Year (1-6, blank=skip): ").strip()
     year = int(year_raw) if year_raw.isdigit() else 0
 
-    print("\nAddress style:")
-    print("  1) casual")
-    print("  2) formal")
-    pronoun_choice = input("Choice [1]: ").strip()
-    pronoun = "formal" if pronoun_choice == "2" else "casual"
+    print("\nResponse style:")
+    print("  1) casual  — friendly, like an old friend")
+    print("  2) formal  — professional, respectful")
+    style_choice = input("Choice [1]: ").strip()
+    response_style = "formal" if style_choice == "2" else "casual"
 
-    print("\nTone:")
-    print("  1) casual")
-    print("  2) formal")
-    tone_choice = input("Choice [1]: ").strip()
-    tone = "formal" if tone_choice == "2" else "casual"
+    # Briefing sections
+    print("\nBriefing sections (comma-separated numbers, or Enter for all):")
+    for i, sec in enumerate(ALL_BRIEFING_SECTIONS, 1):
+        print(f"  {i}) {sec}")
+    sec_input = input(f"Sections [1-{len(ALL_BRIEFING_SECTIONS)}, default=all]: ").strip()
+    if sec_input:
+        indices = [int(x.strip()) - 1 for x in sec_input.split(",") if x.strip().isdigit()]
+        briefing_sections = [
+            ALL_BRIEFING_SECTIONS[i] for i in indices
+            if 0 <= i < len(ALL_BRIEFING_SECTIONS)
+        ]
+        if not briefing_sections:
+            briefing_sections = list(ALL_BRIEFING_SECTIONS)
+    else:
+        briefing_sections = list(ALL_BRIEFING_SECTIONS)
+
+    # News sources
+    print("\nNews sources (comma-separated numbers, or Enter for all):")
+    for i, src in enumerate(ALL_NEWS_SOURCES, 1):
+        print(f"  {i}) {src}")
+    src_input = input(f"Sources [1-{len(ALL_NEWS_SOURCES)}, default=all]: ").strip()
+    if src_input:
+        indices = [int(x.strip()) - 1 for x in src_input.split(",") if x.strip().isdigit()]
+        news_sources = [
+            ALL_NEWS_SOURCES[i] for i in indices
+            if 0 <= i < len(ALL_NEWS_SOURCES)
+        ]
+        if not news_sources:
+            news_sources = list(ALL_NEWS_SOURCES)
+    else:
+        news_sources = list(ALL_NEWS_SOURCES)
 
     profile.save({
         "name": name,
         "university": university,
         "department": department,
         "year": year,
-        "pronoun": pronoun,
-        "tone": tone,
+        "pronoun": response_style,
+        "tone": response_style,
+        "preferences": {
+            "briefing_sections": briefing_sections,
+            "news_sources": news_sources,
+            "response_style": response_style,
+        },
     })
     print(f"\n✅ Profile saved: {profile.path}")
     print(f"  → {profile.prompt_hint()}")

--- a/src/bantz/core/brain.py
+++ b/src/bantz/core/brain.py
@@ -35,10 +35,18 @@ def strip_markdown(text: str) -> str:
     return text.strip()
 
 
+def _style_hint() -> str:
+    """Return a style instruction based on profile response_style."""
+    style = profile.response_style
+    if style == "formal":
+        return "Tone: professional, respectful. Address the user formally."
+    return 'Tone: casual, friendly. Call the user "boss", "chief", or "dude".'
+
+
 CHAT_SYSTEM = """\
 You are Bantz — a sharp, proactive personal host. You live in the terminal and manage the user's digital life.
 You are helpful, direct, and specific. No fluff, no cheerleading. Say what needs to be said.
-Call the user "ma'am" or "boss". Casual but professional.
+{style_hint}
 {time_hint}
 {profile_hint}
 CRITICAL: You have NO access to real emails, calendar events, live news, or any external data.
@@ -57,8 +65,7 @@ RULES:
 - Flag urgent items first. Skip noise unless notable.
 - End with: "Want me to read any?" / "Which one?" / "Need anything else?"
 - If tool returned an error, say that honestly. Never claim success on failure.
-- Max 5 sentences. English only. Plain text, no markdown.
-{time_hint}
+- Max 5 sentences. English only. Plain text, no markdown.{style_hint}{time_hint}
 {profile_hint}\
 """
 
@@ -496,7 +503,8 @@ class Brain:
 
         messages = [
             {"role": "system", "content": CHAT_SYSTEM.format(
-                time_hint=tc["prompt_hint"], profile_hint=profile.prompt_hint())},
+                time_hint=tc["prompt_hint"], profile_hint=profile.prompt_hint(),
+                style_hint=_style_hint())},
             *prior,
             {"role": "user", "content": en_input},
         ]
@@ -530,7 +538,8 @@ class Brain:
 
         messages = [
             {"role": "system", "content": FINALIZER_SYSTEM.format(
-                time_hint=tc["prompt_hint"], profile_hint=profile.prompt_hint())},
+                time_hint=tc["prompt_hint"], profile_hint=profile.prompt_hint(),
+                style_hint=_style_hint())},
             {"role": "user", "content": (
                 f"User asked: {en_input}\n\nTool output:\n{output[:3000]}"
             )},

--- a/src/bantz/core/butler.py
+++ b/src/bantz/core/butler.py
@@ -65,30 +65,33 @@ class Butler:
     ) -> str:
         greeting = self._time_greeting(segment)
 
+        # Use profile name or fallback to generic
+        tag = profile.name or "boss"
+
         if is_first:
-            return f"{greeting}, ma'am. Bantz here — ready to go."
+            return f"{greeting}, {tag}. Bantz here — ready to go."
 
         if absence_hours < 1:
-            return f"Welcome back, ma'am."
+            return f"Welcome back, {tag}."
 
         if absence_hours < 6:
-            return f"{greeting}, ma'am. Been a few hours."
+            return f"{greeting}, {tag}. Been a few hours."
 
         if absence_hours < 20:
-            return f"{greeting}, boss. Here's what's going on."
+            return f"{greeting}, {tag}. Here's what's going on."
 
         if absence_hours < 30:
             if segment == "sabah":
-                return "Good morning, ma'am. Let me catch you up."
-            return f"{greeting}, ma'am. Here's your status."
+                return f"Good morning, {tag}. Let me catch you up."
+            return f"{greeting}, {tag}. Here's your status."
 
         if absence_hours < 72:
-            return f"{greeting}, boss. It's been a couple days — here's the rundown."
+            return f"{greeting}, {tag}. It's been a couple days — here's the rundown."
 
         if absence_hours < 168:
-            return f"{greeting}, ma'am. Been about a week. Let me brief you."
+            return f"{greeting}, {tag}. Been about a week. Let me brief you."
 
-        return f"{greeting}, boss. Long time no see. Here's what you've missed."
+        return f"{greeting}, {tag}. Long time no see. Here's what you've missed."
 
     @staticmethod
     def _time_greeting(segment: str) -> str:

--- a/src/bantz/core/time_context.py
+++ b/src/bantz/core/time_context.py
@@ -78,9 +78,13 @@ class TimeContext:
 
     def greeting_line(self) -> str:
         """Ready-to-use greeting for startup or hello responses."""
+        from bantz.core.profile import profile
         now = datetime.now()
         seg = get_segment(now.hour)
         greeting = _GREETINGS[seg]
+        name = profile.name
+        if name:
+            return f"{greeting}, {name}! It's {now.strftime('%H:%M')}."
         return f"{greeting}! It's {now.strftime('%H:%M')}."
 
 


### PR DESCRIPTION
Implements issue #33 — persistent user profile with identity and preferences.

Changes:
- profile.py: preferences sub-dict (briefing_sections, news_sources, response_style), name property, English prompts
- __main__.py: Extended setup with multi-select briefing sections, news sources, response style
- briefing.py: Filters sections by profile.briefing_sections
- time_context.py: greeting_line() includes profile.name
- butler.py: Opener uses profile.name instead of hardcoded names
- brain.py: _style_hint() + {style_hint} in CHAT_SYSTEM and FINALIZER_SYSTEM

Closes #33