### PR TITLE
feat: cross-network GPS relay + downloadable phone app

### DIFF
--- a/src/bantz/app.py
+++ b/src/bantz/app.py
@@ -208,6 +208,7 @@ class BantzApp(App):
             if ok:
                 chat = self.query_one("#chat-log", ChatLog)
                 chat.add_system(f"GPS: {gps_server.url}")
+                chat.add_system(f"Relay: {gps_server.relay_topic}")
         except Exception:
             pass
 

--- a/src/bantz/config.py
+++ b/src/bantz/config.py
@@ -37,6 +37,9 @@ class Config(BaseSettings):
     location_lat: float = Field(0.0, alias="BANTZ_LAT")
     location_lon: float = Field(0.0, alias="BANTZ_LON")
 
+    # ── GPS Relay ─────────────────────────────────────────────────────────
+    gps_relay_token: str = Field("", alias="BANTZ_GPS_RELAY_TOKEN")
+
     # ── Neo4j Graph Memory ────────────────────────────────────────────────
     neo4j_enabled: bool = Field(False, alias="BANTZ_NEO4J_ENABLED")
     neo4j_uri: str = Field("bolt://localhost:7687", alias="BANTZ_NEO4J_URI")


### PR DESCRIPTION
## Cross-Network GPS via ntfy.sh Relay

### Problem
Previous GPS feature required phone & laptop on same WiFi. When user leaves dorm (mobile data), GPS stops working.

### Solution
**Dual-path architecture**: phone sends GPS to both LAN (fast path) and ntfy.sh relay (any network).

```
Phone (any network) ──POST──> ntfy.sh/bantz-gps-{token}
                                       │ (JSON stream)
                                Laptop relay listener
                                       │
                              gps_server._save_location()

Phone (same WiFi)   ──POST──> http://laptop:9777/update (fast path)
```

### Features
- **ntfy.sh relay**: free pub/sub service, no signup needed
- **Downloadable phone app**: `/app` endpoint serves `bantz-gps.html` (3.6KB standalone file)
  - Works from phone files/browser, no server needed
  - GPS → ntfy.sh → laptop, from any network
- **Dual send**: main page sends to both direct + relay simultaneously
- **Connection indicators**: green/gray dots showing direct/relay status
- **Auto-generated token**: persisted in `~/.local/share/bantz/gps_relay_token`
- **Config override**: `BANTZ_GPS_RELAY_TOKEN` env var

### How to use
1. Same WiFi: open `http://<laptop-ip>:9777` — works as before
2. Download app: tap 'Download Phone App' button → saves `bantz-gps.html`
3. Open that file from phone anytime, anywhere → GPS flows via ntfy.sh relay
4. Laptop needs `159.203.148.75 ntfy.sh` in `/etc/hosts` (dorm DNS workaround)