### PR TITLE
fix(config): switch default model to qwen2.5:7b Instruct (#77)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,7 +23,7 @@ What actually happened.
 ## Environment
 - OS: (e.g., Linux Mint 21.3)
 - Python: (e.g., 3.11)
-- Ollama model: (e.g., qwen2.5-coder:7b)
+- Ollama model: (e.g., qwen2.5:7b)
 - Bantz version: (e.g., v2.0)
 
 ## Logs / Screenshots

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ pip install -e ".[dev]"
 
 - Python 3.11+
 - Ollama running locally (`ollama serve`)
-- A model pulled (e.g., `ollama pull qwen2.5-coder:7b`)
+- A model pulled (e.g., `ollama pull qwen2.5:7b`)
 
 ## Project Structure
 

--- a/src/bantz/config.py
+++ b/src/bantz/config.py
@@ -12,7 +12,7 @@ from pydantic_settings import BaseSettings
 
 class Config(BaseSettings):
     # ── Ollama ────────────────────────────────────────────────────────────
-    ollama_model: str = Field("qwen2.5-coder:7b", alias="BANTZ_OLLAMA_MODEL")
+    ollama_model: str = Field("qwen2.5:7b", alias="BANTZ_OLLAMA_MODEL")
     ollama_base_url: str = Field("http://localhost:11434", alias="BANTZ_OLLAMA_BASE_URL")
 
     # ── Gemini (optional) ─────────────────────────────────────────────────


### PR DESCRIPTION
Updates all remaining references from `qwen2.5-coder:7b` to `qwen2.5:7b` (Instruct variant).

- **config.py**: default fallback value
- **CONTRIBUTING.md**: setup instructions
- **bug_report.md**: template model reference

`.env` and `.env.example` were already correct.

Closes #77