### PR TITLE
feat(scheduler): APScheduler-style task scheduler + reminder tool (#61)

### DIFF
--- a/src/bantz/__main__.py
+++ b/src/bantz/__main__.py
@@ -497,6 +497,7 @@ async def _doctor() -> None:
     import bantz.tools.gmail
     import bantz.tools.calendar
     import bantz.tools.classroom
+    import bantz.tools.reminder
 
     print("Bantz v2 — System Check")
     print("─" * 44)
@@ -578,6 +579,11 @@ async def _doctor() -> None:
     # GPS
     from bantz.core.gps_server import gps_server
     print(f"○ {gps_server.status_line()}")
+
+    # Scheduler
+    from bantz.core.scheduler import scheduler as _sched
+    _sched.init(config.db_path)
+    print(f"✓ {_sched.status_line()}")
 
     print("─" * 44)
 

--- a/src/bantz/app.py
+++ b/src/bantz/app.py
@@ -235,6 +235,7 @@ class BantzApp(App):
         self._start_gps_server()
         self._start_stationary_checker()
         self._start_morning_briefing_timer()
+        self._start_reminder_checker()
         self.query_one("#chat-input", Input).focus()
 
     async def action_quit(self) -> None:
@@ -316,6 +317,34 @@ class BantzApp(App):
     def _start_morning_briefing_timer(self) -> None:
         """Check every 60s if the scheduled morning briefing is due (#80)."""
         self.set_interval(60, self._check_morning_briefing)
+
+    def _start_reminder_checker(self) -> None:
+        """Check periodically for due reminders (#61)."""
+        self.set_interval(config.reminder_check_interval, self._check_reminders)
+
+    @work(exclusive=False)
+    async def _check_reminders(self) -> None:
+        """Periodic check: fire due reminders in the TUI."""
+        try:
+            from bantz.core.scheduler import scheduler
+            from bantz.core.memory import memory
+
+            due = scheduler.check_due()
+            if not due:
+                return
+
+            chat = self.query_one("#chat-log", ChatLog)
+            for r in due:
+                repeat_tag = f" (repeats {r['repeat']})" if r['repeat'] != 'none' else ''
+                text = f"\u23f0 Reminder: {r['title']}{repeat_tag}"
+                chat.add_bantz(text)
+                try:
+                    memory.add("assistant", text, tool_used="reminder")
+                except Exception:
+                    pass
+            chat.scroll_end()
+        except Exception:
+            pass
 
     @work(exclusive=False)
     async def _check_morning_briefing(self) -> None:

--- a/src/bantz/config.py
+++ b/src/bantz/config.py
@@ -54,6 +54,9 @@ class Config(BaseSettings):
     morning_briefing_hour: int = Field(8, alias="BANTZ_MORNING_HOUR")
     morning_briefing_minute: int = Field(0, alias="BANTZ_MORNING_MINUTE")
 
+    # ── Scheduler / Reminders ─────────────────────────────────────────────
+    reminder_check_interval: int = Field(30, alias="BANTZ_REMINDER_CHECK_INTERVAL")
+
     # ── Telegram ──────────────────────────────────────────────────────────
     telegram_bot_token: str = Field("", alias="TELEGRAM_BOT_TOKEN")
     telegram_allowed_users: str = Field("", alias="TELEGRAM_ALLOWED_USERS")

--- a/src/bantz/core/brain.py
+++ b/src/bantz/core/brain.py
@@ -138,6 +138,7 @@ class Brain:
         import bantz.tools.gmail        # noqa: F401
         import bantz.tools.calendar     # noqa: F401
         import bantz.tools.classroom    # noqa: F401
+        import bantz.tools.reminder     # noqa: F401
         try:
             import bantz.tools.document     # noqa: F401
         except (ImportError, ModuleNotFoundError):
@@ -154,6 +155,8 @@ class Brain:
         if not self._memory_ready:
             memory.init(config.db_path)
             memory.new_session()
+            from bantz.core.scheduler import scheduler
+            scheduler.init(config.db_path)
             self._memory_ready = True
 
     async def _ensure_graph(self) -> None:
@@ -464,6 +467,30 @@ class Brain:
             if any(k in both for k in ("read", "open", "show")):
                 return {"tool": "document", "args": {"path": path, "action": "read"}}
             return {"tool": "document", "args": {"path": path, "action": "summarize"}}
+
+        # Reminders
+        _is_reminder = any(k in both for k in (
+            "remind me", "set a reminder", "set reminder",
+            "reminder", "set a timer", "set timer",
+            "alarm", "hatırlat", "zamanlayıcı",
+        ))
+        if _is_reminder:
+            if any(k in both for k in ("list", "show", "my reminder", "upcoming", "what reminder")):
+                return {"tool": "reminder", "args": {"action": "list"}}
+            if any(k in both for k in ("cancel", "delete", "remove", "stop")):
+                title_m = re.search(
+                    r"(?:cancel|delete|remove|stop)\s+(?:reminder\s+)?(?:#?(\d+)|(.+?))"
+                    r"(?:\s*$|\s*(?:please|lütfen))",
+                    both, re.IGNORECASE,
+                )
+                if title_m:
+                    if title_m.group(1):
+                        return {"tool": "reminder", "args": {"action": "cancel", "id": title_m.group(1)}}
+                    return {"tool": "reminder", "args": {"action": "cancel", "title": title_m.group(2).strip()}}
+                return {"tool": "reminder", "args": {"action": "cancel"}}
+            if any(k in both for k in ("snooze", "ertele")):
+                return {"tool": "reminder", "args": {"action": "snooze"}}
+            return {"tool": "reminder", "args": {"action": "add", "intent": orig}}
 
         # Briefing
         if any(k in both for k in ("good morning", "morning briefing", "daily briefing",

--- a/src/bantz/core/briefing.py
+++ b/src/bantz/core/briefing.py
@@ -47,6 +47,7 @@ class Briefing:
         schedule_str = self._get_schedule(now) if "schedule" in sections else None
         next_class_str = await self._get_next_class(now) if "schedule" in sections else None
         habit_str = self._get_habit_hint(now) if "habits" in sections else None
+        reminder_str = self._get_reminders()
 
         return self._format(
             tc=tc,
@@ -58,6 +59,7 @@ class Briefing:
             schedule=schedule_str,
             next_class=next_class_str,
             habits=habit_str,
+            reminders=reminder_str,
         )
 
     # ── Formatters ────────────────────────────────────────────────────────
@@ -71,6 +73,7 @@ class Briefing:
         schedule: Optional[str],
         next_class: Optional[str],
         habits: Optional[str] = None,
+        reminders: Optional[str] = None,
     ) -> str:
         lines = []
 
@@ -107,7 +110,9 @@ class Briefing:
         # Habit-based hint
         if habits:
             lines.append(f"🔁  {habits}")
-
+        # Reminders due today
+        if reminders:
+            lines.append(f"{reminders}")
         # Footer if everything failed
         if not any([weather, calendar, gmail, classroom]):
             lines.append("(Services not responding — check your internet connection)")
@@ -228,6 +233,14 @@ class Briefing:
 
             names = ", ".join(t["tool"] for t in top)
             return f"Frequently used at this hour: {names}"
+        except Exception:
+            return None
+
+    def _get_reminders(self) -> Optional[str]:
+        """Show reminders due today — from Scheduler (#61)."""
+        try:
+            from bantz.core.scheduler import scheduler
+            return scheduler.format_due_today()
         except Exception:
             return None
 

--- a/src/bantz/core/scheduler.py
+++ b/src/bantz/core/scheduler.py
@@ -1,0 +1,296 @@
+"""
+Bantz v2 — Task Scheduler & Reminders (#61)
+SQLite-backed persistent scheduler. Supports one-shot and recurring reminders.
+
+DB table:
+  reminders(id, title, fire_at, repeat, repeat_interval, created_at, fired, snoozed_until)
+
+repeat modes: "none", "daily", "weekly", "weekdays", "custom"
+repeat_interval: seconds (only used when repeat="custom")
+
+Usage:
+    from bantz.core.scheduler import scheduler
+
+    # Add a one-shot reminder
+    scheduler.add("call dentist", fire_at=datetime(2026, 3, 3, 15, 0))
+
+    # Add a daily recurring reminder
+    scheduler.add("check email", fire_at=datetime(2026, 3, 3, 9, 0), repeat="daily")
+
+    # Check for due reminders (called periodically by app.py)
+    due = scheduler.check_due()  # list[dict]
+
+    # List upcoming reminders
+    upcoming = scheduler.list_upcoming(limit=10)
+
+    # Cancel a reminder
+    scheduler.cancel(reminder_id)
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+import threading
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Optional
+
+log = logging.getLogger("bantz.scheduler")
+
+_REPEAT_MODES = ("none", "daily", "weekly", "weekdays", "custom")
+
+
+class Scheduler:
+    def __init__(self) -> None:
+        self._conn: Optional[sqlite3.Connection] = None
+        self._lock = threading.Lock()
+
+    # ── Init ──────────────────────────────────────────────────────────────
+
+    def init(self, db_path: Path) -> None:
+        """Call once at startup — uses the same DB as memory."""
+        self._conn = sqlite3.connect(
+            str(db_path),
+            check_same_thread=False,
+            isolation_level=None,
+        )
+        self._conn.row_factory = sqlite3.Row
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._migrate()
+        log.debug("Scheduler initialized: %s", db_path)
+
+    def _migrate(self) -> None:
+        self._conn.execute("""
+            CREATE TABLE IF NOT EXISTS reminders (
+                id               INTEGER PRIMARY KEY AUTOINCREMENT,
+                title            TEXT NOT NULL,
+                fire_at          TEXT NOT NULL,
+                repeat           TEXT NOT NULL DEFAULT 'none',
+                repeat_interval  INTEGER DEFAULT 0,
+                created_at       TEXT NOT NULL,
+                fired            INTEGER NOT NULL DEFAULT 0,
+                snoozed_until    TEXT
+            )
+        """)
+        self._conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_reminders_fire
+                ON reminders(fire_at, fired)
+        """)
+
+    # ── Public API ────────────────────────────────────────────────────────
+
+    def add(
+        self,
+        title: str,
+        fire_at: datetime,
+        repeat: str = "none",
+        repeat_interval: int = 0,
+    ) -> int:
+        """Create a new reminder. Returns the reminder ID."""
+        if repeat not in _REPEAT_MODES:
+            repeat = "none"
+
+        with self._lock:
+            cur = self._conn.execute(
+                """INSERT INTO reminders (title, fire_at, repeat, repeat_interval, created_at)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (
+                    title,
+                    fire_at.isoformat(),
+                    repeat,
+                    repeat_interval,
+                    datetime.now().isoformat(),
+                ),
+            )
+            rid = cur.lastrowid
+            log.info("Reminder #%d added: '%s' at %s (repeat=%s)", rid, title, fire_at, repeat)
+            return rid
+
+    def check_due(self) -> list[dict]:
+        """Return all reminders that are due NOW and mark them fired.
+
+        For recurring reminders, advance fire_at to the next occurrence instead
+        of marking fired.
+        """
+        now = datetime.now()
+        now_iso = now.isoformat()
+
+        with self._lock:
+            rows = self._conn.execute(
+                """SELECT * FROM reminders
+                   WHERE fired = 0
+                     AND fire_at <= ?
+                     AND (snoozed_until IS NULL OR snoozed_until <= ?)
+                   ORDER BY fire_at""",
+                (now_iso, now_iso),
+            ).fetchall()
+
+            due = []
+            for row in rows:
+                item = dict(row)
+                due.append(item)
+
+                repeat = item["repeat"]
+                if repeat == "none":
+                    self._conn.execute(
+                        "UPDATE reminders SET fired = 1 WHERE id = ?",
+                        (item["id"],),
+                    )
+                else:
+                    # Advance to next occurrence
+                    next_fire = self._next_occurrence(
+                        datetime.fromisoformat(item["fire_at"]),
+                        repeat,
+                        item["repeat_interval"],
+                    )
+                    self._conn.execute(
+                        "UPDATE reminders SET fire_at = ?, snoozed_until = NULL WHERE id = ?",
+                        (next_fire.isoformat(), item["id"]),
+                    )
+
+            return due
+
+    def list_upcoming(self, limit: int = 10) -> list[dict]:
+        """Return upcoming (unfired) reminders sorted by fire_at."""
+        rows = self._conn.execute(
+            """SELECT * FROM reminders
+               WHERE fired = 0
+               ORDER BY fire_at
+               LIMIT ?""",
+            (limit,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    def list_all(self, limit: int = 20) -> list[dict]:
+        """Return all reminders (including fired), newest first."""
+        rows = self._conn.execute(
+            """SELECT * FROM reminders
+               ORDER BY created_at DESC
+               LIMIT ?""",
+            (limit,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    def cancel(self, reminder_id: int) -> bool:
+        """Delete a reminder by ID. Returns True if found."""
+        with self._lock:
+            cur = self._conn.execute(
+                "DELETE FROM reminders WHERE id = ?", (reminder_id,)
+            )
+            deleted = cur.rowcount > 0
+            if deleted:
+                log.info("Reminder #%d cancelled", reminder_id)
+            return deleted
+
+    def cancel_by_title(self, title: str) -> int:
+        """Delete all reminders matching title (case-insensitive). Returns count."""
+        with self._lock:
+            cur = self._conn.execute(
+                "DELETE FROM reminders WHERE lower(title) = lower(?)", (title,)
+            )
+            count = cur.rowcount
+            if count:
+                log.info("Cancelled %d reminder(s) matching '%s'", count, title)
+            return count
+
+    def snooze(self, reminder_id: int, minutes: int = 10) -> bool:
+        """Snooze a reminder by N minutes."""
+        until = datetime.now() + timedelta(minutes=minutes)
+        with self._lock:
+            cur = self._conn.execute(
+                "UPDATE reminders SET snoozed_until = ?, fired = 0 WHERE id = ?",
+                (until.isoformat(), reminder_id),
+            )
+            return cur.rowcount > 0
+
+    def due_today(self) -> list[dict]:
+        """Return reminders due today (for briefing)."""
+        today_start = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+        today_end = today_start + timedelta(days=1)
+        rows = self._conn.execute(
+            """SELECT * FROM reminders
+               WHERE fired = 0
+                 AND fire_at >= ? AND fire_at < ?
+               ORDER BY fire_at""",
+            (today_start.isoformat(), today_end.isoformat()),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    def count_active(self) -> int:
+        """Count unfired reminders."""
+        row = self._conn.execute(
+            "SELECT COUNT(*) FROM reminders WHERE fired = 0"
+        ).fetchone()
+        return row[0] if row else 0
+
+    def status_line(self) -> str:
+        """Short status for --doctor."""
+        if not self._conn:
+            return "Scheduler: not initialized"
+        n = self.count_active()
+        return f"Scheduler: {n} active reminder(s)"
+
+    # ── Format helpers ────────────────────────────────────────────────────
+
+    def format_upcoming(self, limit: int = 10) -> str:
+        """Human-readable list of upcoming reminders."""
+        items = self.list_upcoming(limit)
+        if not items:
+            return "No upcoming reminders."
+
+        lines = ["⏰ Upcoming reminders:"]
+        for r in items:
+            fire = datetime.fromisoformat(r["fire_at"])
+            now = datetime.now()
+            delta = fire - now
+
+            if delta.total_seconds() < 0:
+                time_str = "overdue"
+            elif delta.days > 0:
+                time_str = f"in {delta.days}d"
+            elif delta.seconds >= 3600:
+                time_str = f"in {delta.seconds // 3600}h {(delta.seconds % 3600) // 60}m"
+            else:
+                time_str = f"in {delta.seconds // 60}m"
+
+            repeat_tag = f" 🔁 {r['repeat']}" if r["repeat"] != "none" else ""
+            lines.append(
+                f"  #{r['id']} — {r['title']}  ⏱ {fire.strftime('%d %b %H:%M')} ({time_str}){repeat_tag}"
+            )
+        return "\n".join(lines)
+
+    def format_due_today(self) -> Optional[str]:
+        """Format reminders due today — used by briefing."""
+        items = self.due_today()
+        if not items:
+            return None
+        lines = []
+        for r in items:
+            fire = datetime.fromisoformat(r["fire_at"])
+            repeat_tag = f" (🔁 {r['repeat']})" if r["repeat"] != "none" else ""
+            lines.append(f"  • {fire.strftime('%H:%M')} — {r['title']}{repeat_tag}")
+        return "⏰ Reminders today:\n" + "\n".join(lines)
+
+    # ── Internal ──────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _next_occurrence(
+        current: datetime, repeat: str, interval: int
+    ) -> datetime:
+        """Calculate next fire time for a recurring reminder."""
+        if repeat == "daily":
+            return current + timedelta(days=1)
+        elif repeat == "weekly":
+            return current + timedelta(weeks=1)
+        elif repeat == "weekdays":
+            nxt = current + timedelta(days=1)
+            while nxt.weekday() >= 5:  # skip Sat/Sun
+                nxt += timedelta(days=1)
+            return nxt
+        elif repeat == "custom" and interval > 0:
+            return current + timedelta(seconds=interval)
+        else:
+            return current + timedelta(days=1)  # fallback
+
+
+scheduler = Scheduler()

--- a/src/bantz/tools/reminder.py
+++ b/src/bantz/tools/reminder.py
@@ -1,0 +1,300 @@
+"""
+Bantz v2 — Reminder Tool (#61)
+CRUD operations for reminders, powered by the Scheduler.
+
+Supports:
+  - add: create a new reminder (one-shot or recurring)
+  - list: show upcoming reminders
+  - cancel: remove a reminder by ID or title
+  - snooze: snooze a fired reminder by N minutes
+
+Natural-language time parsing is handled by _parse_reminder_time().
+"""
+from __future__ import annotations
+
+import re
+from datetime import datetime, timedelta
+from typing import Any
+
+from bantz.tools import BaseTool, ToolResult, registry
+
+
+class ReminderTool(BaseTool):
+    name = "reminder"
+    description = (
+        "Create, list, cancel, or snooze reminders and timers. "
+        "Use for: remind me, set a reminder, set a timer, my reminders, "
+        "cancel reminder, snooze, alarm."
+    )
+    risk_level = "safe"
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        from bantz.core.scheduler import scheduler
+
+        action = kwargs.get("action", "add")
+        intent = kwargs.get("intent", "")
+
+        if action == "list":
+            return self._list(scheduler)
+        elif action == "cancel":
+            return self._cancel(scheduler, kwargs)
+        elif action == "snooze":
+            return self._snooze(scheduler, kwargs)
+        else:
+            return self._add(scheduler, kwargs, intent)
+
+    # ── Add ───────────────────────────────────────────────────────────────
+
+    def _add(self, scheduler, kwargs: dict, intent: str) -> ToolResult:
+        title = kwargs.get("title", "").strip()
+        time_str = kwargs.get("time", "").strip()
+        repeat = kwargs.get("repeat", "none")
+
+        # Parse from natural language if we have intent text
+        if intent and (not title or not time_str):
+            parsed_title, parsed_time, parsed_repeat = _parse_reminder_intent(intent)
+            if not title:
+                title = parsed_title
+            if not time_str:
+                time_str = parsed_time
+            if repeat == "none" and parsed_repeat != "none":
+                repeat = parsed_repeat
+
+        if not title:
+            title = "Reminder"
+
+        # Resolve the fire time
+        fire_at = _resolve_time(time_str) if time_str else None
+        if not fire_at:
+            # Default: 1 hour from now
+            fire_at = datetime.now() + timedelta(hours=1)
+
+        rid = scheduler.add(title, fire_at, repeat=repeat)
+        time_display = fire_at.strftime("%d %b %H:%M")
+        repeat_info = f" (repeats: {repeat})" if repeat != "none" else ""
+
+        return ToolResult(
+            success=True,
+            output=f"⏰ Reminder #{rid} set: \"{title}\" at {time_display}{repeat_info}",
+            data={"id": rid, "title": title, "fire_at": fire_at.isoformat(), "repeat": repeat},
+        )
+
+    # ── List ──────────────────────────────────────────────────────────────
+
+    def _list(self, scheduler) -> ToolResult:
+        text = scheduler.format_upcoming(limit=10)
+        return ToolResult(success=True, output=text)
+
+    # ── Cancel ────────────────────────────────────────────────────────────
+
+    def _cancel(self, scheduler, kwargs: dict) -> ToolResult:
+        rid = kwargs.get("id")
+        title = kwargs.get("title", "")
+
+        if rid:
+            try:
+                rid = int(rid)
+            except (ValueError, TypeError):
+                return ToolResult(success=False, output="", error="Invalid reminder ID")
+            ok = scheduler.cancel(rid)
+            if ok:
+                return ToolResult(success=True, output=f"✓ Reminder #{rid} cancelled.")
+            return ToolResult(success=False, output="", error=f"Reminder #{rid} not found.")
+
+        if title:
+            count = scheduler.cancel_by_title(title)
+            if count:
+                return ToolResult(
+                    success=True,
+                    output=f"✓ Cancelled {count} reminder(s) matching \"{title}\".",
+                )
+            return ToolResult(
+                success=False, output="",
+                error=f"No reminders found matching \"{title}\".",
+            )
+
+        return ToolResult(success=False, output="", error="Specify a reminder ID or title to cancel.")
+
+    # ── Snooze ────────────────────────────────────────────────────────────
+
+    def _snooze(self, scheduler, kwargs: dict) -> ToolResult:
+        rid = kwargs.get("id")
+        minutes = int(kwargs.get("minutes", 10))
+
+        if not rid:
+            return ToolResult(success=False, output="", error="Specify a reminder ID to snooze.")
+
+        try:
+            rid = int(rid)
+        except (ValueError, TypeError):
+            return ToolResult(success=False, output="", error="Invalid reminder ID")
+
+        ok = scheduler.snooze(rid, minutes=minutes)
+        if ok:
+            return ToolResult(success=True, output=f"⏰ Reminder #{rid} snoozed for {minutes} minutes.")
+        return ToolResult(success=False, output="", error=f"Reminder #{rid} not found.")
+
+
+# ── Natural language parsing ──────────────────────────────────────────────────
+
+def _parse_reminder_intent(text: str) -> tuple[str, str, str]:
+    """
+    Extract title, time, and repeat mode from natural language.
+    Returns (title, time_str, repeat).
+
+    Examples:
+        "remind me to call dentist at 3pm" → ("call dentist", "3pm", "none")
+        "remind me every day at 9am to check email" → ("check email", "9am", "daily")
+        "set a timer for 30 minutes" → ("Timer", "30 minutes", "none")
+        "remind me in 2 hours to buy groceries" → ("buy groceries", "2 hours", "none")
+    """
+    t = text.strip()
+    repeat = "none"
+
+    # Detect repeat mode
+    if re.search(r"\bevery\s*day\b", t, re.IGNORECASE):
+        repeat = "daily"
+    elif re.search(r"\bevery\s*week\b", t, re.IGNORECASE):
+        repeat = "weekly"
+    elif re.search(r"\b(?:weekday|workday)s?\b", t, re.IGNORECASE):
+        repeat = "weekdays"
+
+    # Strip common prefixes
+    cleaned = re.sub(
+        r"^(?:remind\s+me\s+)?(?:to\s+)?(?:every\s*(?:day|week)\s+)?",
+        "", t, flags=re.IGNORECASE,
+    ).strip()
+
+    # Extract "at HH:MM" or "at Xpm/am"
+    time_str = ""
+    time_match = re.search(
+        r"\bat\s+(\d{1,2}(?::\d{2})?\s*(?:am|pm)?)\b",
+        cleaned, re.IGNORECASE,
+    )
+    if time_match:
+        time_str = time_match.group(1).strip()
+        cleaned = cleaned[:time_match.start()] + cleaned[time_match.end():]
+
+    # Extract "in X minutes/hours"
+    if not time_str:
+        dur_match = re.search(
+            r"\bin\s+(\d+)\s*(minute|min|hour|hr|second|sec)s?\b",
+            cleaned, re.IGNORECASE,
+        )
+        if dur_match:
+            time_str = f"{dur_match.group(1)} {dur_match.group(2)}"
+            cleaned = cleaned[:dur_match.start()] + cleaned[dur_match.end():]
+
+    # Extract "for X minutes" (timer style)
+    if not time_str:
+        timer_match = re.search(
+            r"\bfor\s+(\d+)\s*(minute|min|hour|hr|second|sec)s?\b",
+            cleaned, re.IGNORECASE,
+        )
+        if timer_match:
+            time_str = f"{timer_match.group(1)} {timer_match.group(2)}"
+            cleaned = cleaned[:timer_match.start()] + cleaned[timer_match.end():]
+
+    # Extract "tomorrow at HH:MM"
+    if not time_str:
+        tmrw_match = re.search(
+            r"\btomorrow\s+(?:at\s+)?(\d{1,2}(?::\d{2})?\s*(?:am|pm)?)\b",
+            cleaned, re.IGNORECASE,
+        )
+        if tmrw_match:
+            time_str = f"tomorrow {tmrw_match.group(1)}"
+            cleaned = cleaned[:tmrw_match.start()] + cleaned[tmrw_match.end():]
+
+    # Clean up title
+    title = re.sub(r"\s+", " ", cleaned).strip()
+    title = re.sub(r"^(?:to\s+|that\s+|about\s+)", "", title, flags=re.IGNORECASE).strip()
+    title = re.sub(r"^(?:set\s+a?\s*timer|set\s+a?\s*reminder)\s*", "", title, flags=re.IGNORECASE).strip()
+    title = title.rstrip(".,!? ")
+
+    if not title or len(title) < 2:
+        title = "Reminder"
+
+    return title, time_str, repeat
+
+
+def _resolve_time(time_str: str) -> datetime | None:
+    """
+    Resolve a time string to an absolute datetime.
+
+    Supports:
+      - "3pm", "15:00", "3:30pm"
+      - "30 minutes", "2 hours"
+      - "tomorrow 3pm"
+    """
+    now = datetime.now()
+    t = time_str.strip().lower()
+
+    # "X minutes/hours/seconds" → relative
+    dur_match = re.match(r"(\d+)\s*(minute|min|hour|hr|second|sec)s?$", t)
+    if dur_match:
+        amount = int(dur_match.group(1))
+        unit = dur_match.group(2)
+        if unit.startswith("hour") or unit.startswith("hr"):
+            return now + timedelta(hours=amount)
+        elif unit.startswith("sec"):
+            return now + timedelta(seconds=amount)
+        else:
+            return now + timedelta(minutes=amount)
+
+    # "tomorrow HH:MM" or "tomorrow Xpm"
+    tmrw_match = re.match(r"tomorrow\s+(.+)$", t)
+    if tmrw_match:
+        base = now + timedelta(days=1)
+        parsed = _parse_clock_time(tmrw_match.group(1))
+        if parsed:
+            return base.replace(hour=parsed[0], minute=parsed[1], second=0, microsecond=0)
+        return base.replace(hour=9, minute=0, second=0, microsecond=0)
+
+    # Absolute clock time: "3pm", "15:00", "3:30pm"
+    parsed = _parse_clock_time(t)
+    if parsed:
+        result = now.replace(hour=parsed[0], minute=parsed[1], second=0, microsecond=0)
+        # If the time is already past today, schedule for tomorrow
+        if result <= now:
+            result += timedelta(days=1)
+        return result
+
+    return None
+
+
+def _parse_clock_time(s: str) -> tuple[int, int] | None:
+    """Parse "3pm", "15:00", "3:30pm" → (hour, minute)."""
+    s = s.strip()
+
+    # "3:30pm" or "3:30 pm"
+    m = re.match(r"(\d{1,2}):(\d{2})\s*(am|pm)?$", s, re.IGNORECASE)
+    if m:
+        h, mn = int(m.group(1)), int(m.group(2))
+        if m.group(3):
+            if m.group(3).lower() == "pm" and h < 12:
+                h += 12
+            elif m.group(3).lower() == "am" and h == 12:
+                h = 0
+        return (h, mn)
+
+    # "3pm" or "3 pm"
+    m = re.match(r"(\d{1,2})\s*(am|pm)$", s, re.IGNORECASE)
+    if m:
+        h = int(m.group(1))
+        if m.group(2).lower() == "pm" and h < 12:
+            h += 12
+        elif m.group(2).lower() == "am" and h == 12:
+            h = 0
+        return (h, 0)
+
+    # "15:00"
+    m = re.match(r"(\d{1,2}):(\d{2})$", s)
+    if m:
+        return (int(m.group(1)), int(m.group(2)))
+
+    return None
+
+
+# Register
+reminder_tool = ReminderTool()
+registry.register(reminder_tool)


### PR DESCRIPTION
## Summary
Full SQLite-backed scheduler & reminder system.

### New modules
- **`core/scheduler.py`** — `Scheduler` class: CRUD for reminders, recurring support (daily/weekly/weekdays/custom), SQLite persistence, snooze, due-today for briefing
- **`tools/reminder.py`** — `ReminderTool` (BaseTool): natural-language time parsing (`remind me at 3pm to call dentist`), add/list/cancel/snooze actions

### Integration
- **brain.py**: quick_route patterns for 'remind me', 'set timer', 'alarm', 'list/cancel/snooze'; tool registered; scheduler.init() alongside memory.init()
- **app.py**: configurable interval timer fires due reminders in TUI chat
- **briefing.py**: 'Reminders today' section in daily briefing
- **config.py**: `BANTZ_REMINDER_CHECK_INTERVAL` (default 30s)
- **__main__.py**: `--doctor` shows scheduler status line

Closes #61