### PR TITLE
feat(i18n): complete English-first migration (#64)

### DIFF
--- a/src/bantz/app.py
+++ b/src/bantz/app.py
@@ -460,8 +460,8 @@ class BantzApp(App):
     async def _handle_confirm(self, text: str, chat: ChatLog) -> None:
         pending = self._pending
         self._pending = None
-        evet = text.lower().strip() in ("evet", "e", "yes", "y", "ok", "tamam")
-        if evet:
+        confirmed = text.lower().strip() in ("yes", "y", "ok", "evet", "e", "tamam")
+        if confirmed:
             self._busy = True
             self._show_thinking(True)
             try:

--- a/src/bantz/core/brain.py
+++ b/src/bantz/core/brain.py
@@ -2,7 +2,7 @@
 Bantz v2 — Brain (Orchestrator)
 
 Pipeline:
-  TR input → [bridge: TR→EN] → quick_route OR router (Ollama) → tool → finalizer → output
+  user input → [bridge: optional TR→EN] → quick_route OR router (Ollama) → tool → finalizer → output
 
 Fixes vs previous version:
   - Model refusal detection: if Ollama refuses a system query, fallback to direct tool
@@ -472,7 +472,7 @@ class Brain:
         _is_reminder = any(k in both for k in (
             "remind me", "set a reminder", "set reminder",
             "reminder", "set a timer", "set timer",
-            "alarm", "hatırlat", "zamanlayıcı",
+            "alarm",
         ))
         if _is_reminder:
             if any(k in both for k in ("list", "show", "my reminder", "upcoming", "what reminder")):
@@ -480,7 +480,7 @@ class Brain:
             if any(k in both for k in ("cancel", "delete", "remove", "stop")):
                 title_m = re.search(
                     r"(?:cancel|delete|remove|stop)\s+(?:reminder\s+)?(?:#?(\d+)|(.+?))"
-                    r"(?:\s*$|\s*(?:please|lütfen))",
+                    r"(?:\s*$|\s*(?:please))",
                     both, re.IGNORECASE,
                 )
                 if title_m:
@@ -488,7 +488,7 @@ class Brain:
                         return {"tool": "reminder", "args": {"action": "cancel", "id": title_m.group(1)}}
                     return {"tool": "reminder", "args": {"action": "cancel", "title": title_m.group(2).strip()}}
                 return {"tool": "reminder", "args": {"action": "cancel"}}
-            if any(k in both for k in ("snooze", "ertele")):
+            if any(k in both for k in ("snooze",)):
                 return {"tool": "reminder", "args": {"action": "snooze"}}
             return {"tool": "reminder", "args": {"action": "add", "intent": orig}}
 

--- a/src/bantz/core/briefing.py
+++ b/src/bantz/core/briefing.py
@@ -219,13 +219,13 @@ class Briefing:
         try:
             hour = now.hour
             if 6 <= hour < 12:
-                segment = "sabah"
+                segment = "morning"
             elif 12 <= hour < 17:
-                segment = "oglen"
+                segment = "afternoon"
             elif 17 <= hour < 21:
-                segment = "aksam"
+                segment = "evening"
             else:
-                segment = "gece_gec"
+                segment = "night"
 
             top = _habits.top_tools_for_segment(segment, n=3, days=14)
             if not top:

--- a/src/bantz/core/butler.py
+++ b/src/bantz/core/butler.py
@@ -81,7 +81,7 @@ class Butler:
             return f"{greeting}, {tag}. Here's what's going on."
 
         if absence_hours < 30:
-            if segment == "sabah":
+            if segment == "morning":
                 return f"Good morning, {tag}. Let me catch you up."
             return f"{greeting}, {tag}. Here's your status."
 
@@ -96,11 +96,11 @@ class Butler:
     @staticmethod
     def _time_greeting(segment: str) -> str:
         return {
-            "gece_erken": "Good evening",
-            "sabah": "Good morning",
-            "oglen": "Good afternoon",
-            "aksam": "Good evening",
-            "gece_gec": "Good evening",
+            "late_night": "Good evening",
+            "morning": "Good morning",
+            "afternoon": "Good afternoon",
+            "evening": "Good evening",
+            "night": "Good evening",
         }.get(segment, "Hello")
 
     # ── Formatters ────────────────────────────────────────────────────────

--- a/src/bantz/core/date_parser.py
+++ b/src/bantz/core/date_parser.py
@@ -45,7 +45,7 @@ _WEEK_REFS: list[tuple[str, str]] = [
 
 def resolve_date(text: str, now: datetime | None = None) -> Optional[datetime]:
     """
-    Extract and resolve a date reference from Turkish text.
+    Extract and resolve a date reference from natural language text.
     Returns a datetime (date at 00:00) or None if no date found.
 
     Priority: explicit relative ("tomorrow") > named weekday ("thursday") > week ref.

--- a/src/bantz/core/habits.py
+++ b/src/bantz/core/habits.py
@@ -6,7 +6,7 @@ No new tables — queries the existing messages table.
 
 Usage:
     from bantz.core.habits import habits
-    top = habits.top_tools_for_segment("sabah")
+    top = habits.top_tools_for_segment("morning")
     should = habits.should_add_to_briefing("weather")
 """
 from __future__ import annotations
@@ -20,11 +20,11 @@ from bantz.config import config
 
 # Time segment boundaries (hour ranges)
 _SEGMENTS: dict[str, tuple[int, int]] = {
-    "gece_erken": (0, 6),
-    "sabah": (6, 12),
-    "oglen": (12, 17),
-    "aksam": (17, 21),
-    "gece_gec": (21, 24),
+    "late_night": (0, 6),
+    "morning": (6, 12),
+    "afternoon": (12, 17),
+    "evening": (17, 21),
+    "night": (21, 24),
 }
 
 
@@ -100,7 +100,7 @@ class HabitEngine:
         """
         Full pattern analysis across all segments.
         Returns: {
-            "segments": {"sabah": [...], "oglen": [...], ...},
+            "segments": {"morning": [...], "afternoon": [...], ...},
             "briefing_candidates": ["weather", "news"],
             "top_overall": [...],
             "total_interactions": int,
@@ -111,7 +111,7 @@ class HabitEngine:
 
         # Per-segment breakdown
         segments = {}
-        for seg in ("sabah", "oglen", "aksam", "gece_gec"):
+        for seg in ("morning", "afternoon", "evening", "night"):
             segments[seg] = self.top_tools_for_segment(seg, n=5, days=days)
 
         # Briefing candidates: tools used 3+ morning days

--- a/src/bantz/core/time_context.py
+++ b/src/bantz/core/time_context.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Literal
 
-Segment = Literal["gece_erken", "sabah", "oglen", "aksam", "gece_gec"]
+Segment = Literal["late_night", "morning", "afternoon", "evening", "night"]
 
 
 def get_segment(hour: int | None = None) -> Segment:
@@ -16,31 +16,31 @@ def get_segment(hour: int | None = None) -> Segment:
     if hour is None:
         hour = datetime.now().hour
     if 0 <= hour < 6:
-        return "gece_erken"
+        return "late_night"
     elif 6 <= hour < 12:
-        return "sabah"
+        return "morning"
     elif 12 <= hour < 17:
-        return "oglen"
+        return "afternoon"
     elif 17 <= hour < 21:
-        return "aksam"
+        return "evening"
     else:
-        return "gece_gec"
+        return "night"
 
 
 _GREETINGS: dict[Segment, str] = {
-    "gece_erken": "Working late at night",
-    "sabah":      "Good morning",
-    "oglen":      "Good afternoon",
-    "aksam":      "Good evening",
-    "gece_gec":   "Good night",
+    "late_night": "Working late at night",
+    "morning":    "Good morning",
+    "afternoon":  "Good afternoon",
+    "evening":    "Good evening",
+    "night":      "Good night",
 }
 
 _SEGMENT_EN: dict[Segment, str] = {
-    "gece_erken": "late night",
-    "sabah":      "morning",
-    "oglen":      "afternoon",
-    "aksam":      "evening",
-    "gece_gec":   "night",
+    "late_night": "late night",
+    "morning":    "morning",
+    "afternoon":  "afternoon",
+    "evening":    "evening",
+    "night":      "night",
 }
 
 

--- a/src/bantz/tools/gmail.py
+++ b/src/bantz/tools/gmail.py
@@ -311,7 +311,7 @@ class GmailTool(BaseTool):
     # ── Filter (natural language → Gmail query) ──────────────────────────
 
     async def _filter(self, creds, raw_query: str, limit: int = 10) -> ToolResult:
-        """Parse Turkish natural language into Gmail query and search."""
+        """Parse natural language into Gmail query and search."""
         q = self._build_gmail_query(raw_query)
         messages = await asyncio.get_event_loop().run_in_executor(
             None, self._fetch_messages_sync, creds, q, limit, False


### PR DESCRIPTION
## Summary
Completes the English-first migration by replacing all Turkish identifiers in the codebase.

### Segment name migration (6 files)
| Turkish | English |
|---|---|
| `gece_erken` | `late_night` |
| `sabah` | `morning` |
| `oglen` | `afternoon` |
| `aksam` | `evening` |
| `gece_gec` | `night` |

### Files changed
- **time_context.py** — Segment type, get_segment(), greeting/label dicts
- **habits.py** — _SEGMENTS dict, docstrings, analyze() loop
- **butler.py** — segment checks, _time_greeting dict
- **briefing.py** — _get_habit_hint segment resolution
- **brain.py** — removed Turkish keywords from quick_route (hatırlat, zamanlayıcı, ertele, lütfen), updated pipeline docstring
- **date_parser.py** — docstring fix
- **gmail.py** — docstring fix
- **app.py** — renamed `evet` variable → `confirmed`

### Backward compatibility
- `_to_en()` bridge kept for Turkish-speaking users
- `evet`/`tamam` remain accepted confirmation inputs

Closes #64