### PR TITLE
fix(location): show unknown when no live GPS/WiFi source

### DIFF
--- a/src/bantz/__main__.py
+++ b/src/bantz/__main__.py
@@ -549,7 +549,10 @@ async def _doctor() -> None:
     # Location
     from bantz.core.location import location_service
     loc = await location_service.get()
-    print(f"✓ Location: {loc.display}  (via {loc.source})")
+    if loc.is_live:
+        print(f"✓ Location: {loc.display}  (via {loc.source})")
+    else:
+        print(f"○ Location: unknown  (no live source — enable phone GPS)")
 
     # Google integrations
     print("  Google integrations:")

--- a/src/bantz/core/brain.py
+++ b/src/bantz/core/brain.py
@@ -533,18 +533,22 @@ class Brain:
         if gps_loc:
             acc = round(gps_loc.get("accuracy", 0))
             lines.append(f"📍 Phone GPS: {gps_loc['lat']:.6f}, {gps_loc['lon']:.6f} (±{acc}m)")
-        elif loc:
+        elif loc and loc.is_live:
             lines.append(f"📍 {loc.display}")
             if loc.lat and loc.lon:
                 lines.append(f"   Coordinates: {loc.lat:.6f}, {loc.lon:.6f}")
             lines.append(f"   Source: {loc.source}")
         else:
-            lines.append("📍 Location unknown")
-
-        if not gps_loc:
+            lines.append(
+                "I can't pinpoint where you are right now — "
+                "I need your phone GPS to figure that out."
+            )
             try:
                 from bantz.core.gps_server import gps_server
-                lines.append(f"   Phone GPS: not connected — open {gps_server.url} on phone")
+                lines.append(
+                    f"Open {gps_server.url} on your phone and "
+                    f"hit 'Share Location' so I can see where you are."
+                )
             except Exception:
                 pass
 

--- a/src/bantz/core/location.py
+++ b/src/bantz/core/location.py
@@ -53,6 +53,11 @@ class Location:
     source: str = "unknown"   # "config" | "geoclue" | "ipinfo" | "fallback"
 
     @property
+    def is_live(self) -> bool:
+        """True when location comes from a real-time source (GPS, WiFi, GeoClue)."""
+        return self.source in ("phone_gps", "geoclue") or self.source.startswith("wifi:")
+
+    @property
     def is_turkey(self) -> bool:
         return self.country == "TR"
 


### PR DESCRIPTION
When GPS is off, don't claim a city from static config.

- `--doctor` now shows `○ Location: unknown (no live source — enable phone GPS)`
- `where am I` gives Bantz-style: 'I can't pinpoint where you are right now — I need your phone GPS to figure that out.'
- Added `Location.is_live` property: True only for phone_gps, wifi:*, geoclue