### PR TITLE
feat: location-based reminders, Telegram notifications, Neo4j Reminder nodes (#86)

### DIFF
--- a/src/bantz/core/places.py
+++ b/src/bantz/core/places.py
@@ -65,6 +65,9 @@ class PlaceService:
         self._asked_for_anchor: bool = False
         self._last_ask_time: float = 0.0
 
+        # Location-triggered reminders that fired
+        self._place_fired: list[dict] = []
+
     def _load(self) -> None:
         if self._loaded:
             return
@@ -133,6 +136,7 @@ class PlaceService:
         entered a *new* known place, else None.
 
         Call this each time new GPS data arrives.
+        Also triggers location-based reminders from the scheduler.
         """
         self._load()
         now = _time.time()
@@ -147,6 +151,8 @@ class PlaceService:
             if place_key and place:
                 transition = place["label"]
                 log.info("Entered place: %s", place["label"])
+                # Fire location-based reminders
+                self._fire_place_reminders(place_key, place["label"])
             elif self._current_place_key:
                 log.info("Left place: %s", self._current_place_key)
             self._last_place_key = self._current_place_key
@@ -178,6 +184,32 @@ class PlaceService:
         if place:
             return place.get("label", self._current_place_key)
         return self._current_place_key
+
+    # ── Location-based reminders ──────────────────────────────────────
+
+    def _fire_place_reminders(self, place_key: str, place_label: str) -> None:
+        """Check scheduler for reminders triggered by entering this place."""
+        try:
+            from bantz.core.scheduler import scheduler
+            due = scheduler.check_place_due(place_key)
+            for item in due:
+                item["_place_label"] = place_label
+                self._place_fired.append(item)
+                log.info(
+                    "Location reminder #%d fired at %s: %s",
+                    item["id"], place_label, item["title"],
+                )
+        except Exception as exc:
+            log.debug("Place reminder check failed: %s", exc)
+
+    def pop_place_reminders(self) -> list[dict]:
+        """Return and clear any location-triggered reminders that fired.
+
+        The TUI and Telegram bot poll this to display notifications.
+        """
+        fired = self._place_fired[:]
+        self._place_fired.clear()
+        return fired
 
     def check_stationary(self) -> Optional[str]:
         """

--- a/src/bantz/core/scheduler.py
+++ b/src/bantz/core/scheduler.py
@@ -69,13 +69,19 @@ class Scheduler:
                 repeat_interval  INTEGER DEFAULT 0,
                 created_at       TEXT NOT NULL,
                 fired            INTEGER NOT NULL DEFAULT 0,
-                snoozed_until    TEXT
+                snoozed_until    TEXT,
+                trigger_place    TEXT
             )
         """)
         self._conn.execute("""
             CREATE INDEX IF NOT EXISTS idx_reminders_fire
                 ON reminders(fire_at, fired)
         """)
+        # Migration: add trigger_place column to existing tables
+        try:
+            self._conn.execute("ALTER TABLE reminders ADD COLUMN trigger_place TEXT")
+        except Exception:
+            pass  # column already exists
 
     # ── Public API ────────────────────────────────────────────────────────
 
@@ -85,25 +91,38 @@ class Scheduler:
         fire_at: datetime,
         repeat: str = "none",
         repeat_interval: int = 0,
+        trigger_place: str | None = None,
     ) -> int:
-        """Create a new reminder. Returns the reminder ID."""
+        """Create a new reminder. Returns the reminder ID.
+
+        If trigger_place is set, the reminder fires when the user enters
+        that named place (from places.py) instead of at fire_at.
+        fire_at is still stored as a fallback expiry.
+        """
         if repeat not in _REPEAT_MODES:
             repeat = "none"
 
         with self._lock:
             cur = self._conn.execute(
-                """INSERT INTO reminders (title, fire_at, repeat, repeat_interval, created_at)
-                   VALUES (?, ?, ?, ?, ?)""",
+                """INSERT INTO reminders
+                       (title, fire_at, repeat, repeat_interval, created_at, trigger_place)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
                 (
                     title,
                     fire_at.isoformat(),
                     repeat,
                     repeat_interval,
                     datetime.now().isoformat(),
+                    trigger_place,
                 ),
             )
             rid = cur.lastrowid
-            log.info("Reminder #%d added: '%s' at %s (repeat=%s)", rid, title, fire_at, repeat)
+            if trigger_place:
+                log.info("Reminder #%d added: '%s' when at '%s' (repeat=%s)",
+                         rid, title, trigger_place, repeat)
+            else:
+                log.info("Reminder #%d added: '%s' at %s (repeat=%s)",
+                         rid, title, fire_at, repeat)
             return rid
 
     def check_due(self) -> list[dict]:
@@ -216,6 +235,35 @@ class Scheduler:
         ).fetchall()
         return [dict(r) for r in rows]
 
+    def check_place_due(self, place_key: str) -> list[dict]:
+        """Return location-triggered reminders for the given place and mark fired.
+
+        Called by places.py when the user enters a known place.
+        """
+        with self._lock:
+            rows = self._conn.execute(
+                """SELECT * FROM reminders
+                   WHERE fired = 0
+                     AND trigger_place = ?
+                     AND (snoozed_until IS NULL OR snoozed_until <= ?)
+                   ORDER BY created_at""",
+                (place_key, datetime.now().isoformat()),
+            ).fetchall()
+
+            due = []
+            for row in rows:
+                item = dict(row)
+                due.append(item)
+
+                repeat = item["repeat"]
+                if repeat == "none":
+                    self._conn.execute(
+                        "UPDATE reminders SET fired = 1 WHERE id = ?",
+                        (item["id"],),
+                    )
+                # Recurring location reminders stay active
+            return due
+
     def count_active(self) -> int:
         """Count unfired reminders."""
         row = self._conn.execute(
@@ -254,9 +302,15 @@ class Scheduler:
                 time_str = f"in {delta.seconds // 60}m"
 
             repeat_tag = f" 🔁 {r['repeat']}" if r["repeat"] != "none" else ""
-            lines.append(
-                f"  #{r['id']} — {r['title']}  ⏱ {fire.strftime('%d %b %H:%M')} ({time_str}){repeat_tag}"
-            )
+            place = r.get("trigger_place")
+            if place:
+                lines.append(
+                    f"  #{r['id']} — {r['title']}  📍 when at {place}{repeat_tag}"
+                )
+            else:
+                lines.append(
+                    f"  #{r['id']} — {r['title']}  ⏱ {fire.strftime('%d %b %H:%M')} ({time_str}){repeat_tag}"
+                )
         return "\n".join(lines)
 
     def format_due_today(self) -> Optional[str]:

--- a/src/bantz/interface/telegram_bot.py
+++ b/src/bantz/interface/telegram_bot.py
@@ -61,6 +61,9 @@ if config.telegram_allowed_users.strip():
         if uid.strip().isdigit()
     }
 
+# ── Active chat IDs for proactive notifications ──────────────────────────────
+_active_chats: set[int] = set()
+
 
 def _authorized(func: Callable[..., Coroutine]) -> Callable[..., Coroutine]:
     """Decorator: reject messages from non-whitelisted users."""
@@ -87,6 +90,7 @@ async def _safe_reply(update: Update, text: str) -> None:
 
 @_authorized
 async def cmd_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    _active_chats.add(update.effective_chat.id)
     await update.message.reply_text(
         "🦌 Bantz is live!\n\n"
         "Commands:\n"
@@ -97,7 +101,8 @@ async def cmd_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         "/odev — upcoming assignments\n"
         "/ders — today's schedule\n"
         "/siradaki — next class\n"
-        "/haber — latest news"
+        "/haber — latest news\n"
+        "/hatirlatici — list reminders"
     )
 
 
@@ -197,6 +202,55 @@ async def cmd_haber(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         await update.message.reply_text(f"News error: {exc}")
 
 
+@_authorized
+async def cmd_hatirlatici(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """List upcoming reminders."""
+    _active_chats.add(update.effective_chat.id)
+    try:
+        from bantz.core.scheduler import scheduler
+        text = scheduler.format_upcoming(limit=10)
+        await _safe_reply(update, text)
+    except Exception as exc:
+        await update.message.reply_text(f"Reminder error: {exc}")
+
+
+# ── Proactive reminder notifications ─────────────────────────────────────────
+
+async def _check_reminders_job(context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Periodic job: check for due reminders and send notifications."""
+    if not _active_chats:
+        return
+
+    try:
+        from bantz.core.scheduler import scheduler
+        due = scheduler.check_due()
+    except Exception:
+        due = []
+
+    # Also check location-triggered reminders
+    try:
+        from bantz.core.places import places
+        place_due = places.pop_place_reminders()
+        due.extend(place_due)
+    except Exception:
+        pass
+
+    for item in due:
+        title = item.get("title", "Reminder")
+        place_label = item.get("_place_label")
+
+        if place_label:
+            text = f"📍⏰ Reminder (at {place_label}): {title}"
+        else:
+            text = f"⏰ Reminder: {title}"
+
+        for chat_id in _active_chats:
+            try:
+                await context.bot.send_message(chat_id=chat_id, text=text)
+            except Exception as exc:
+                log.debug("Failed to send reminder to %d: %s", chat_id, exc)
+
+
 # ── Bot runner ────────────────────────────────────────────────────────────────
 
 def run_bot() -> None:
@@ -219,6 +273,15 @@ def run_bot() -> None:
     app.add_handler(CommandHandler("ders", cmd_ders))
     app.add_handler(CommandHandler("siradaki", cmd_siradaki))
     app.add_handler(CommandHandler("haber", cmd_haber))
+    app.add_handler(CommandHandler("hatirlatici", cmd_hatirlatici))
+
+    # Proactive reminder check — runs every 30 seconds
+    app.job_queue.run_repeating(
+        _check_reminders_job,
+        interval=config.reminder_check_interval,
+        first=10,
+        name="reminder_check",
+    )
 
     log.info("🦌 Bantz Telegram bot starting...")
     if _PROXY:

--- a/src/bantz/tools/reminder.py
+++ b/src/bantz/tools/reminder.py
@@ -23,8 +23,9 @@ class ReminderTool(BaseTool):
     name = "reminder"
     description = (
         "Create, list, cancel, or snooze reminders and timers. "
+        "Supports time-based and location-based triggers. "
         "Use for: remind me, set a reminder, set a timer, my reminders, "
-        "cancel reminder, snooze, alarm."
+        "cancel reminder, snooze, alarm, remind me when at X."
     )
     risk_level = "safe"
 
@@ -49,29 +50,52 @@ class ReminderTool(BaseTool):
         title = kwargs.get("title", "").strip()
         time_str = kwargs.get("time", "").strip()
         repeat = kwargs.get("repeat", "none")
+        place = kwargs.get("place", "").strip()
 
         # Parse from natural language if we have intent text
-        if intent and (not title or not time_str):
-            parsed_title, parsed_time, parsed_repeat = _parse_reminder_intent(intent)
+        if intent and (not title or (not time_str and not place)):
+            parsed_title, parsed_time, parsed_repeat, parsed_place = _parse_reminder_intent(intent)
             if not title:
                 title = parsed_title
-            if not time_str:
+            if not time_str and not place:
                 time_str = parsed_time
+                place = parsed_place
             if repeat == "none" and parsed_repeat != "none":
                 repeat = parsed_repeat
 
         if not title:
             title = "Reminder"
 
-        # Resolve the fire time
+        # ── Location-based reminder ──
+        if place:
+            place_key = _resolve_place(place)
+            if not place_key:
+                return ToolResult(
+                    success=False, output="",
+                    error=f"Unknown place: \"{place}\". Save it first with 'save here as {place}'.",
+                )
+            # Use a far-future fire_at as fallback expiry
+            fire_at = datetime.now() + timedelta(days=365)
+            rid = scheduler.add(title, fire_at, repeat=repeat, trigger_place=place_key)
+            # Dual-write to Neo4j
+            _store_reminder_neo4j(rid, title, trigger_place=place_key, repeat=repeat)
+            return ToolResult(
+                success=True,
+                output=f"📍 Reminder #{rid} set: \"{title}\" — when you arrive at {place}",
+                data={"id": rid, "title": title, "trigger_place": place_key, "repeat": repeat},
+            )
+
+        # ── Time-based reminder ──
         fire_at = _resolve_time(time_str) if time_str else None
         if not fire_at:
-            # Default: 1 hour from now
             fire_at = datetime.now() + timedelta(hours=1)
 
         rid = scheduler.add(title, fire_at, repeat=repeat)
         time_display = fire_at.strftime("%d %b %H:%M")
         repeat_info = f" (repeats: {repeat})" if repeat != "none" else ""
+
+        # Dual-write to Neo4j
+        _store_reminder_neo4j(rid, title, fire_at=fire_at, repeat=repeat)
 
         return ToolResult(
             success=True,
@@ -137,19 +161,20 @@ class ReminderTool(BaseTool):
 
 # ── Natural language parsing ──────────────────────────────────────────────────
 
-def _parse_reminder_intent(text: str) -> tuple[str, str, str]:
+def _parse_reminder_intent(text: str) -> tuple[str, str, str, str]:
     """
-    Extract title, time, and repeat mode from natural language.
-    Returns (title, time_str, repeat).
+    Extract title, time, repeat mode, and place from natural language.
+    Returns (title, time_str, repeat, place).
 
     Examples:
-        "remind me to call dentist at 3pm" → ("call dentist", "3pm", "none")
-        "remind me every day at 9am to check email" → ("check email", "9am", "daily")
-        "set a timer for 30 minutes" → ("Timer", "30 minutes", "none")
-        "remind me in 2 hours to buy groceries" → ("buy groceries", "2 hours", "none")
+        "remind me to call dentist at 3pm" → ("call dentist", "3pm", "none", "")
+        "remind me every day at 9am to check email" → ("check email", "9am", "daily", "")
+        "remind me to buy milk when I'm at the market" → ("buy milk", "", "none", "market")
+        "when I get to university remind me about office hours" → ("about office hours", "", "none", "university")
     """
     t = text.strip()
     repeat = "none"
+    place = ""
 
     # Detect repeat mode
     if re.search(r"\bevery\s*day\b", t, re.IGNORECASE):
@@ -158,6 +183,20 @@ def _parse_reminder_intent(text: str) -> tuple[str, str, str]:
         repeat = "weekly"
     elif re.search(r"\b(?:weekday|workday)s?\b", t, re.IGNORECASE):
         repeat = "weekdays"
+
+    # ── Detect location triggers ──
+    # "when at X", "when I'm at X", "when I get to X", "when I arrive at X",
+    # "when I'm near X", "when at the X"
+    place_patterns = [
+        r"when\s+(?:i(?:'m|\s+am))?\s*(?:at|near|around)\s+(?:the\s+)?(.+?)(?:\s+remind|\s+tell|\s*$)",
+        r"when\s+(?:i\s+)?(?:get|arrive|go)\s+(?:to|at)\s+(?:the\s+)?(.+?)(?:\s+remind|\s*$|\s*,)",
+    ]
+    for pat in place_patterns:
+        m = re.search(pat, t, re.IGNORECASE)
+        if m:
+            place = m.group(1).strip().rstrip(".,!? ")
+            t = t[:m.start()] + t[m.end():]
+            break
 
     # Strip common prefixes
     cleaned = re.sub(
@@ -214,7 +253,7 @@ def _parse_reminder_intent(text: str) -> tuple[str, str, str]:
     if not title or len(title) < 2:
         title = "Reminder"
 
-    return title, time_str, repeat
+    return title, time_str, repeat, place
 
 
 def _resolve_time(time_str: str) -> datetime | None:
@@ -298,3 +337,84 @@ def _parse_clock_time(s: str) -> tuple[int, int] | None:
 # Register
 reminder_tool = ReminderTool()
 registry.register(reminder_tool)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _resolve_place(name: str) -> str | None:
+    """Resolve a place name to its key from the places database.
+
+    Returns the place key if found, None otherwise.
+    """
+    try:
+        from bantz.core.places import places
+        all_places = places.all_places()
+        name_lower = name.lower().strip()
+
+        # Exact key match
+        if name_lower in all_places:
+            return name_lower
+
+        # Label match (case-insensitive)
+        for key, place in all_places.items():
+            label = place.get("label", key).lower()
+            if label == name_lower or name_lower in label or label in name_lower:
+                return key
+
+        return None
+    except Exception:
+        return None
+
+
+def _store_reminder_neo4j(
+    rid: int,
+    title: str,
+    fire_at: datetime | None = None,
+    trigger_place: str | None = None,
+    repeat: str = "none",
+) -> None:
+    """Dual-write reminder to Neo4j graph as a Reminder node."""
+    try:
+        from bantz.memory.graph import graph_memory
+        if not graph_memory.enabled:
+            return
+
+        import asyncio
+        from datetime import datetime as dt
+
+        props = {
+            "rid": rid,
+            "title": title,
+            "repeat": repeat,
+            "status": "active",
+            "created_at": dt.now().isoformat(),
+        }
+        if fire_at:
+            props["fire_at"] = fire_at.isoformat()
+        if trigger_place:
+            props["trigger_place"] = trigger_place
+            props["trigger_type"] = "location"
+        else:
+            props["trigger_type"] = "time"
+
+        async def _write():
+            try:
+                driver = graph_memory._driver
+                if driver:
+                    async with driver.session() as s:
+                        await s.run(
+                            "MERGE (r:Reminder {rid: $rid}) "
+                            "ON CREATE SET r += $props "
+                            "ON MATCH SET r += $props",
+                            rid=rid, props=props,
+                        )
+            except Exception:
+                pass
+
+        try:
+            loop = asyncio.get_running_loop()
+            loop.create_task(_write())
+        except RuntimeError:
+            asyncio.run(_write())
+    except Exception:
+        pass


### PR DESCRIPTION
Closes #86

### What changed

**Location-based reminders:**
- `scheduler.py`: new `trigger_place` TEXT column — reminders can fire when user enters a named place
- `scheduler.check_place_due(place_key)` returns location-triggered reminders for a given place
- `reminder.py`: parses 'when at X', 'when I get to X', 'when I'm near X' via `_parse_reminder_intent()`
- `reminder._resolve_place()` matches input to known places by key or label
- `places.py`: on place transition `update_gps()` fires `_fire_place_reminders()` → calls `scheduler.check_place_due()`
- `places.pop_place_reminders()` — queue for TUI/Telegram to poll

**Neo4j Reminder nodes:**
- `reminder._store_reminder_neo4j()` dual-writes every reminder to Neo4j as `(:Reminder {rid, title, trigger_type, ...})`
- Works for both time-based and location-based reminders

**Telegram notifications:**
- `_check_reminders_job()` runs every 30s via job_queue — checks `scheduler.check_due()` + `places.pop_place_reminders()`
- Sends `⏰ Reminder: ...` or `📍⏰ Reminder (at place): ...` to all active chats
- `_active_chats` populated from `/start` and `/hatirlatici`
- New `/hatirlatici` command lists upcoming reminders

### Acceptance ✅
- [x] Time-based reminders (existed)
- [x] Location-based reminders (new)
- [x] Reminders stored in Neo4j as Reminder nodes (new)
- [x] Telegram notification delivery (new)
- [x] TUI notification display (existed)
- [x] Reminder can be snoozed or dismissed (existed)