### PR TITLE
feat: complete Neo4j graph schema — 9 nodes, 9 rels, CRUD, relationship extraction (#87)

### DIFF
--- a/src/bantz/memory/context_builder.py
+++ b/src/bantz/memory/context_builder.py
@@ -110,7 +110,35 @@ async def build_context(
             lines = [f"  - {e['title']} ({e['date'] or '?'})" for e in events]
             parts.append("Recent events:\n" + "\n".join(lines))
 
-        # 5. Keyword-matching
+        # 5. Active commitments
+        commitments = await query_fn(
+            "MATCH (c:Commitment {status: 'active'}) "
+            "RETURN c.what AS what, c.date AS date "
+            "ORDER BY c.date DESC LIMIT 5"
+        )
+        if commitments:
+            lines = [f"  - {c['what']}" for c in commitments]
+            parts.append("Active commitments:\n" + "\n".join(lines))
+
+        # 6. Active reminders
+        reminders = await query_fn(
+            "MATCH (r:Reminder {status: 'active'}) "
+            "RETURN r.title AS title, r.trigger_type AS trigger, "
+            "r.fire_at AS fire_at, r.trigger_place AS place "
+            "ORDER BY r.created_at DESC LIMIT 5"
+        )
+        if reminders:
+            lines = []
+            for r in reminders:
+                if r.get("place"):
+                    lines.append(f"  - {r['title']} (at {r['place']})")
+                elif r.get("fire_at"):
+                    lines.append(f"  - {r['title']} ({r['fire_at']})")
+                else:
+                    lines.append(f"  - {r['title']}")
+            parts.append("Active reminders:\n" + "\n".join(lines))
+
+        # 7. Keyword-matching
         keywords = extract_keywords(user_msg)
         if keywords:
             relevant = await keyword_search(keywords, query_fn)

--- a/src/bantz/memory/graph.py
+++ b/src/bantz/memory/graph.py
@@ -84,13 +84,15 @@ class GraphMemory:
     async def _ensure_indexes(self) -> None:
         """Create indexes for fast lookups."""
         queries = [
-            "CREATE INDEX IF NOT EXISTS FOR (p:Person)   ON (p.name)",
-            "CREATE INDEX IF NOT EXISTS FOR (t:Topic)    ON (t.name)",
-            "CREATE INDEX IF NOT EXISTS FOR (d:Decision) ON (d.what)",
-            "CREATE INDEX IF NOT EXISTS FOR (tk:Task)    ON (tk.description)",
-            "CREATE INDEX IF NOT EXISTS FOR (e:Event)    ON (e.title)",
-            "CREATE INDEX IF NOT EXISTS FOR (l:Location) ON (l.name)",
-            "CREATE INDEX IF NOT EXISTS FOR (dc:Document) ON (dc.path)",
+            "CREATE INDEX IF NOT EXISTS FOR (p:Person)     ON (p.name)",
+            "CREATE INDEX IF NOT EXISTS FOR (t:Topic)      ON (t.name)",
+            "CREATE INDEX IF NOT EXISTS FOR (d:Decision)   ON (d.what)",
+            "CREATE INDEX IF NOT EXISTS FOR (tk:Task)      ON (tk.description)",
+            "CREATE INDEX IF NOT EXISTS FOR (e:Event)      ON (e.title)",
+            "CREATE INDEX IF NOT EXISTS FOR (l:Location)   ON (l.name)",
+            "CREATE INDEX IF NOT EXISTS FOR (dc:Document)  ON (dc.path)",
+            "CREATE INDEX IF NOT EXISTS FOR (r:Reminder)   ON (r.title)",
+            "CREATE INDEX IF NOT EXISTS FOR (c:Commitment) ON (c.what)",
         ]
         async with self._driver.session() as s:
             for q in queries:
@@ -137,7 +139,8 @@ class GraphMemory:
         return extract_entities(user_msg, assistant_msg, tool_used, tool_data)
 
     async def _upsert_entities(self, entities: list[dict], now: str) -> None:
-        """MERGE entities into Neo4j — create if new, update if existing."""
+        """MERGE entities into Neo4j — create if new, update if existing.
+        Also create relationships between entities."""
         async with self._driver.session() as session:
             for ent in entities:
                 label = ent["label"]
@@ -158,6 +161,43 @@ class GraphMemory:
                     await session.run(query, **props)
                 except Exception as exc:
                     log.debug("Upsert %s failed: %s", label, exc)
+
+                # Create relationships
+                for rel in ent.get("rels", []):
+                    await self._upsert_relationship(
+                        session, label, key, key_val, rel
+                    )
+
+    async def _upsert_relationship(
+        self,
+        session,
+        src_label: str,
+        src_key: str,
+        src_val: str,
+        rel: dict,
+    ) -> None:
+        """MERGE a relationship between two nodes."""
+        rel_type = rel["type"]
+        tgt_label = rel["target_label"]
+        tgt_key = rel["target_key"]
+        tgt_val = rel["target_val"]
+
+        query = (
+            f"MATCH (a:{src_label} {{{src_key}: $src_val}})\n"
+            f"MATCH (b:{tgt_label} {{{tgt_key}: $tgt_val}})\n"
+            f"MERGE (a)-[r:{rel_type}]->(b)\n"
+            f"ON CREATE SET r.created_at = $now\n"
+            f"ON MATCH SET r.updated_at = $now"
+        )
+        try:
+            await session.run(
+                query,
+                src_val=src_val,
+                tgt_val=tgt_val,
+                now=datetime.now().isoformat(),
+            )
+        except Exception as exc:
+            log.debug("Rel %s failed: %s", rel_type, exc)
 
     # ── Reading — build context for LLM ────────────────────────────────────
 
@@ -213,6 +253,89 @@ class GraphMemory:
             f"Graph memory: {s['total_nodes']} nodes, "
             f"{s['total_relationships']} rels"
         )
+
+    # ── Delete operations ──────────────────────────────────────────────────
+
+    async def delete_node(
+        self,
+        label: str,
+        key: str,
+        value: str,
+    ) -> bool:
+        """Delete a specific node and its relationships.
+
+        Returns True if a node was deleted.
+        """
+        if not self._enabled:
+            return False
+
+        try:
+            result = await self._query(
+                f"MATCH (n:{label} {{{key}: $val}}) "
+                f"DETACH DELETE n RETURN count(n) AS deleted",
+                val=value,
+            )
+            return result[0]["deleted"] > 0 if result else False
+        except Exception as exc:
+            log.debug("Delete %s failed: %s", label, exc)
+            return False
+
+    async def delete_by_label(
+        self,
+        label: str,
+        limit: int = 0,
+    ) -> int:
+        """Delete all nodes of a given label (with optional limit).
+
+        Returns count of deleted nodes.
+        """
+        if not self._enabled:
+            return 0
+
+        try:
+            if limit > 0:
+                result = await self._query(
+                    f"MATCH (n:{label}) WITH n LIMIT $limit "
+                    f"DETACH DELETE n RETURN count(n) AS deleted",
+                    limit=limit,
+                )
+            else:
+                result = await self._query(
+                    f"MATCH (n:{label}) DETACH DELETE n "
+                    f"RETURN count(n) AS deleted"
+                )
+            return result[0]["deleted"] if result else 0
+        except Exception as exc:
+            log.debug("Delete all %s failed: %s", label, exc)
+            return 0
+
+    async def delete_relationship(
+        self,
+        src_label: str,
+        src_key: str,
+        src_val: str,
+        rel_type: str,
+        tgt_label: str,
+        tgt_key: str,
+        tgt_val: str,
+    ) -> bool:
+        """Delete a specific relationship between two nodes."""
+        if not self._enabled:
+            return False
+
+        try:
+            result = await self._query(
+                f"MATCH (a:{src_label} {{{src_key}: $src_val}})"
+                f"-[r:{rel_type}]->"
+                f"(b:{tgt_label} {{{tgt_key}: $tgt_val}}) "
+                f"DELETE r RETURN count(r) AS deleted",
+                src_val=src_val,
+                tgt_val=tgt_val,
+            )
+            return result[0]["deleted"] > 0 if result else False
+        except Exception as exc:
+            log.debug("Delete rel %s failed: %s", rel_type, exc)
+            return False
 
 
 # Singleton

--- a/src/bantz/memory/nodes.py
+++ b/src/bantz/memory/nodes.py
@@ -15,7 +15,8 @@ from datetime import datetime
 # ── Schema constants ───────────────────────────────────────────────────────
 
 NODE_LABELS = (
-    "Person", "Topic", "Decision", "Task", "Event", "Location", "Document",
+    "Person", "Topic", "Decision", "Task", "Event",
+    "Location", "Document", "Reminder", "Commitment",
 )
 
 REL_TYPES = {
@@ -94,6 +95,9 @@ def extract_entities(
             "props": {"name": name, "last_seen": datetime.now().isoformat()},
             "rels": [],
         })
+
+    # Track extracted names/labels for relationship building later
+    _people_names = list(found_people)
 
     # ── Topics from tool usage ──
     if tool_used and tool_used in _TOOL_TOPIC_MAP:
@@ -205,6 +209,7 @@ def extract_entities(
             })
 
     # ── Locations ──
+    _location_names: list[str] = []
     loc_patterns = [
         r"(?:in|at|from|going to|travel to)\s+"
         r"([A-Z][a-z]+(?:\s+[A-Z][a-z]+)?)"
@@ -214,12 +219,180 @@ def extract_entities(
         for m in re.finditer(pat, f"{user_msg} {assistant_msg}"):
             loc = m.group(1).strip()
             if loc not in _SKIP_LOCATIONS and len(loc) > 2:
+                _location_names.append(loc)
                 entities.append({
                     "label": "Location",
                     "key": "name",
                     "props": {"name": loc,
                               "last_mentioned": datetime.now().isoformat()},
                     "rels": [],
+                })
+
+    # ── Reminders (from tool data) ──
+    if tool_used == "reminder" and tool_data:
+        title = tool_data.get("title", "")
+        if title:
+            props = {
+                "title": title,
+                "status": "active",
+                "created_at": datetime.now().isoformat(),
+            }
+            if tool_data.get("fire_at"):
+                props["fire_at"] = tool_data["fire_at"]
+                props["trigger_type"] = "time"
+            if tool_data.get("trigger_place"):
+                props["trigger_place"] = tool_data["trigger_place"]
+                props["trigger_type"] = "location"
+            entities.append({
+                "label": "Reminder",
+                "key": "title",
+                "props": props,
+                "rels": [],
+            })
+
+    # ── Commitments — "I promised", "I committed", "I guarantee" ──
+    commitment_patterns = [
+        r"(?:i\s+promise[d]?\s+(?:to\s+)?|i\s+commit(?:ted)?\s+to\s+|"
+        r"i\s+guarantee\s+|i\s+swear\s+(?:to\s+)?|i'?ll\s+make\s+sure\s+(?:to\s+)?)"
+        r"(.+?)(?:\.|$|!)",
+        r"(?:promise[d]?\s+(?:you|him|her|them)\s+(?:to\s+)?)"
+        r"(.+?)(?:\.|$|!)",
+    ]
+    for pat in commitment_patterns:
+        m = re.search(pat, combined)
+        if m:
+            what = m.group(1).strip()[:150]
+            if len(what) > 3:
+                rels: list[dict] = []
+                # Link commitment to people mentioned
+                for pname in _people_names:
+                    rels.append({
+                        "type": "COMMITTED_TO",
+                        "target_label": "Person",
+                        "target_key": "name",
+                        "target_val": pname,
+                    })
+                entities.append({
+                    "label": "Commitment",
+                    "key": "what",
+                    "props": {
+                        "what": what,
+                        "status": "active",
+                        "date": datetime.now().isoformat(),
+                        "context": user_msg[:200],
+                    },
+                    "rels": rels,
+                })
+            break
+
+    # ── Build relationships between co-occurring entities ──
+    entities = _build_relationships(entities, _people_names, _location_names, tool_used)
+
+    return entities
+
+
+def _build_relationships(
+    entities: list[dict],
+    people: list[str],
+    locations: list[str],
+    tool_used: str | None,
+) -> list[dict]:
+    """Enrich entities with cross-references based on co-occurrence."""
+
+    # Collect labels of entities we extracted this turn
+    has_task = any(e["label"] == "Task" for e in entities)
+    has_event = any(e["label"] == "Event" for e in entities)
+    has_decision = any(e["label"] == "Decision" for e in entities)
+    has_document = any(e["label"] == "Document" for e in entities)
+    has_topic = any(e["label"] == "Topic" for e in entities)
+
+    for ent in entities:
+        label = ent["label"]
+
+        # Person → Task: ASSIGNED_TO
+        if label == "Task" and people:
+            for pname in people[:2]:
+                ent["rels"].append({
+                    "type": "ASSIGNED_TO",
+                    "target_label": "Person",
+                    "target_key": "name",
+                    "target_val": pname,
+                })
+
+        # Person → Topic: WORKS_ON
+        if label == "Person" and has_topic:
+            topic_ent = next((e for e in entities if e["label"] == "Topic"), None)
+            if topic_ent:
+                ent["rels"].append({
+                    "type": "WORKS_ON",
+                    "target_label": "Topic",
+                    "target_key": "name",
+                    "target_val": topic_ent["props"]["name"],
+                })
+
+        # Decision → Event: DECIDED_IN
+        if label == "Decision" and has_event:
+            event_ent = next((e for e in entities if e["label"] == "Event"), None)
+            if event_ent:
+                ent["rels"].append({
+                    "type": "DECIDED_IN",
+                    "target_label": "Event",
+                    "target_key": "title",
+                    "target_val": event_ent["props"]["title"],
+                })
+
+        # Event/Person → Location: LOCATED_AT
+        if label in ("Event", "Person") and locations:
+            ent["rels"].append({
+                "type": "LOCATED_AT",
+                "target_label": "Location",
+                "target_key": "name",
+                "target_val": locations[0],
+            })
+
+        # Task/Decision → Document: REFERENCES
+        if label in ("Task", "Decision") and has_document:
+            doc_ent = next((e for e in entities if e["label"] == "Document"), None)
+            if doc_ent:
+                ent["rels"].append({
+                    "type": "REFERENCES",
+                    "target_label": "Document",
+                    "target_key": "path",
+                    "target_val": doc_ent["props"]["path"],
+                })
+
+        # Topic ↔ Topic / Event / Person: RELATED_TO
+        if label == "Topic" and has_event:
+            event_ent = next((e for e in entities if e["label"] == "Event"), None)
+            if event_ent:
+                ent["rels"].append({
+                    "type": "RELATED_TO",
+                    "target_label": "Event",
+                    "target_key": "title",
+                    "target_val": event_ent["props"]["title"],
+                })
+
+        # Person → Person: KNOWS (if multiple people mentioned together)
+        if label == "Person" and len(people) > 1:
+            my_name = ent["props"]["name"]
+            for other in people:
+                if other != my_name:
+                    ent["rels"].append({
+                        "type": "KNOWS",
+                        "target_label": "Person",
+                        "target_key": "name",
+                        "target_val": other,
+                    })
+
+        # Task → Decision: FOLLOWS_UP
+        if label == "Task" and has_decision:
+            dec_ent = next((e for e in entities if e["label"] == "Decision"), None)
+            if dec_ent:
+                ent["rels"].append({
+                    "type": "FOLLOWS_UP",
+                    "target_label": "Decision",
+                    "target_key": "what",
+                    "target_val": dec_ent["props"]["what"],
                 })
 
     return entities


### PR DESCRIPTION
Closes #87

### What changed

**nodes.py — Schema + Extraction:**
- `NODE_LABELS`: added `Reminder` and `Commitment` → **9/9 node types**
- `REL_TYPES`: all 9 relation types already defined, now all **actually written to graph**
- New `Commitment` extraction: 'I promised', 'I committed to', 'I guarantee', 'I'll make sure to'
- New `Reminder` extraction from tool_data when reminder tool is used
- `_build_relationships()`: infers rels from entity co-occurrence:
  - `ASSIGNED_TO` — Task → Person
  - `WORKS_ON` — Person → Topic
  - `DECIDED_IN` — Decision → Event
  - `LOCATED_AT` — Event/Person → Location
  - `REFERENCES` — Task/Decision → Document
  - `RELATED_TO` — Topic ↔ Event
  - `KNOWS` — Person ↔ Person (multi-person mentions)
  - `COMMITTED_TO` — Commitment → Person
  - `FOLLOWS_UP` — Task → Decision

**graph.py — CRUD + Relationships:**
- Indexes for `Reminder` and `Commitment` nodes
- `_upsert_relationship()`: MERGE relationships into Neo4j
- `delete_node(label, key, value)`: delete a specific node + DETACH its rels
- `delete_by_label(label, limit)`: bulk delete by node type
- `delete_relationship()`: delete a specific edge

**context_builder.py — LLM context:**
- Queries active Commitments and Reminders for LLM context inject
- Shows trigger type (time/location) for reminder context

### Acceptance ✅
- [x] All 9 node types with properties
- [x] All 9 relation types
- [x] CRUD operations for each node type (create/update/read/delete)
- [x] Context builder generates relevant context for LLM
- [x] Auto-extraction from conversation works