### PR TITLE
feat(core): daily & weekly digest automation (#88)

### DIFF
--- a/src/bantz/config.py
+++ b/src/bantz/config.py
@@ -54,6 +54,15 @@ class Config(BaseSettings):
     morning_briefing_hour: int = Field(8, alias="BANTZ_MORNING_HOUR")
     morning_briefing_minute: int = Field(0, alias="BANTZ_MORNING_MINUTE")
 
+    # ── Digests ───────────────────────────────────────────────────────────
+    daily_digest_enabled: bool = Field(True, alias="BANTZ_DAILY_DIGEST_ENABLED")
+    daily_digest_hour: int = Field(20, alias="BANTZ_DAILY_DIGEST_HOUR")
+    daily_digest_minute: int = Field(0, alias="BANTZ_DAILY_DIGEST_MINUTE")
+    weekly_digest_enabled: bool = Field(True, alias="BANTZ_WEEKLY_DIGEST_ENABLED")
+    weekly_digest_day: str = Field("sunday", alias="BANTZ_WEEKLY_DIGEST_DAY")
+    weekly_digest_hour: int = Field(20, alias="BANTZ_WEEKLY_DIGEST_HOUR")
+    weekly_digest_minute: int = Field(0, alias="BANTZ_WEEKLY_DIGEST_MINUTE")
+
     # ── Scheduler / Reminders ─────────────────────────────────────────────
     reminder_check_interval: int = Field(30, alias="BANTZ_REMINDER_CHECK_INTERVAL")
 

--- a/src/bantz/core/digest.py
+++ b/src/bantz/core/digest.py
@@ -1,0 +1,400 @@
+"""
+Bantz v3 — Daily & Weekly Digest (#88)
+
+Evening daily digest and Sunday weekly digest combining all data sources.
+Gemini Flash synthesises the raw data into a natural language summary.
+
+Usage:
+    from bantz.core.digest import digest_manager
+
+    text = await digest_manager.daily_digest()
+    text = await digest_manager.weekly_digest()
+
+Config (env / .env):
+    BANTZ_DAILY_DIGEST_ENABLED=true
+    BANTZ_DAILY_DIGEST_HOUR=20
+    BANTZ_DAILY_DIGEST_MINUTE=0
+    BANTZ_WEEKLY_DIGEST_ENABLED=true
+    BANTZ_WEEKLY_DIGEST_DAY=sunday
+    BANTZ_WEEKLY_DIGEST_HOUR=20
+    BANTZ_WEEKLY_DIGEST_MINUTE=0
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timedelta
+from typing import Optional
+
+log = logging.getLogger("bantz.digest")
+
+_DAY_MAP = {
+    "monday": 0, "tuesday": 1, "wednesday": 2, "thursday": 3,
+    "friday": 4, "saturday": 5, "sunday": 6,
+}
+
+DAILY_SYSTEM_PROMPT = """\
+You are Bantz, a personal AI assistant. Write a concise evening Daily Digest
+for the user (3rd person is fine). Use bullet points. Keep it under 300 words.
+Tone: friendly, informative, slightly witty — like a personal news anchor.
+Sections: Tasks & Reminders, Email, Calendar, Weather Tomorrow, Commitments.
+Skip any section with no data. Don't add data the user didn't provide.
+Write in English."""
+
+WEEKLY_SYSTEM_PROMPT = """\
+You are Bantz, a personal AI assistant. Write a Weekly Digest (Sunday review)
+for the user. Use bullet points. Keep it under 500 words.
+Tone: reflective, helpful — highlight wins, flag overdue items, preview the week.
+Sections: Week Review (tasks/reminders), Email Volume, Calendar Utilization,
+Knowledge Graph Growth, Open Commitments, Upcoming Week Preview.
+Skip any section with no data. Don't add data the user didn't provide.
+Write in English."""
+
+
+class DigestManager:
+    """Generates daily and weekly digests."""
+
+    def __init__(self) -> None:
+        self._last_daily: Optional[str] = None  # date string
+        self._last_weekly: Optional[str] = None  # week number string
+
+    # ── Public API ────────────────────────────────────────────────────────
+
+    async def daily_digest(self) -> str:
+        """Generate the evening daily digest."""
+        raw = await self._collect_daily_data()
+        summary = await self._synthesize(raw, DAILY_SYSTEM_PROMPT)
+        now = datetime.now()
+        header = f"📊 Daily Digest — {now.strftime('%A, %d %B %Y')}"
+        return f"{header}\n\n{summary}"
+
+    async def weekly_digest(self) -> str:
+        """Generate the Sunday weekly digest."""
+        raw = await self._collect_weekly_data()
+        summary = await self._synthesize(raw, WEEKLY_SYSTEM_PROMPT)
+        now = datetime.now()
+        week_num = now.isocalendar()[1]
+        header = f"📊 Weekly Digest — Week {week_num}, {now.year}"
+        return f"{header}\n\n{summary}"
+
+    async def daily_if_due(self) -> Optional[str]:
+        """Return digest text if it's time, else None. Call from polling loop."""
+        from bantz.config import config
+        if not config.daily_digest_enabled:
+            return None
+
+        now = datetime.now()
+        today = now.strftime("%Y-%m-%d")
+
+        if self._last_daily == today:
+            return None
+
+        if now.hour == config.daily_digest_hour and now.minute >= config.daily_digest_minute:
+            self._last_daily = today
+            try:
+                return await self.daily_digest()
+            except Exception as exc:
+                log.warning("Daily digest failed: %s", exc)
+                return None
+        return None
+
+    async def weekly_if_due(self) -> Optional[str]:
+        """Return weekly digest if it's the right day+time, else None."""
+        from bantz.config import config
+        if not config.weekly_digest_enabled:
+            return None
+
+        now = datetime.now()
+        target_day = _DAY_MAP.get(config.weekly_digest_day.lower(), 6)
+
+        if now.weekday() != target_day:
+            return None
+
+        week_key = f"{now.year}-W{now.isocalendar()[1]}"
+        if self._last_weekly == week_key:
+            return None
+
+        if now.hour == config.weekly_digest_hour and now.minute >= config.weekly_digest_minute:
+            self._last_weekly = week_key
+            try:
+                return await self.weekly_digest()
+            except Exception as exc:
+                log.warning("Weekly digest failed: %s", exc)
+                return None
+        return None
+
+    # ── Data collection — daily ───────────────────────────────────────────
+
+    async def _collect_daily_data(self) -> str:
+        """Gather raw data from all sources for daily digest."""
+        parts: list[str] = []
+
+        results = await asyncio.gather(
+            self._get_reminders_today(),
+            self._get_email_stats_today(),
+            self._get_calendar_today(),
+            self._get_tomorrow_weather(),
+            self._get_commitments(),
+            return_exceptions=True,
+        )
+
+        labels = [
+            "REMINDERS & TASKS TODAY",
+            "EMAIL TODAY",
+            "CALENDAR TODAY",
+            "WEATHER TOMORROW",
+            "COMMITMENTS DUE SOON",
+        ]
+
+        for label, result in zip(labels, results):
+            if isinstance(result, str) and result:
+                parts.append(f"[{label}]\n{result}")
+
+        if not parts:
+            return "No data available for today's digest."
+
+        return "\n\n".join(parts)
+
+    # ── Data collection — weekly ──────────────────────────────────────────
+
+    async def _collect_weekly_data(self) -> str:
+        """Gather raw data for weekly digest."""
+        parts: list[str] = []
+
+        results = await asyncio.gather(
+            self._get_reminders_week(),
+            self._get_email_stats_week(),
+            self._get_calendar_week(),
+            self._get_graph_growth(),
+            self._get_commitments(),
+            self._get_next_week_preview(),
+            return_exceptions=True,
+        )
+
+        labels = [
+            "TASKS & REMINDERS THIS WEEK",
+            "EMAIL THIS WEEK",
+            "CALENDAR THIS WEEK",
+            "KNOWLEDGE GRAPH GROWTH",
+            "OPEN COMMITMENTS",
+            "NEXT WEEK PREVIEW",
+        ]
+
+        for label, result in zip(labels, results):
+            if isinstance(result, str) and result:
+                parts.append(f"[{label}]\n{result}")
+
+        if not parts:
+            return "No data available for this week's digest."
+
+        return "\n\n".join(parts)
+
+    # ── Individual data fetchers ──────────────────────────────────────────
+
+    async def _get_reminders_today(self) -> Optional[str]:
+        try:
+            from bantz.core.scheduler import scheduler
+            upcoming = scheduler.list_upcoming(limit=20)
+            fired_today = scheduler.due_today()
+            total_active = scheduler.count_active()
+
+            lines = [f"Active reminders: {total_active}"]
+            if fired_today:
+                lines.append(f"Due today: {len(fired_today)}")
+                for r in fired_today[:5]:
+                    lines.append(f"  • {r['title']}")
+            if upcoming:
+                lines.append(f"Upcoming:")
+                for r in upcoming[:5]:
+                    fire = datetime.fromisoformat(r["fire_at"])
+                    place = r.get("trigger_place")
+                    if place:
+                        lines.append(f"  • {r['title']} (at {place})")
+                    else:
+                        lines.append(f"  • {r['title']} — {fire.strftime('%d %b %H:%M')}")
+            return "\n".join(lines)
+        except Exception:
+            return None
+
+    async def _get_reminders_week(self) -> Optional[str]:
+        try:
+            from bantz.core.scheduler import scheduler
+            upcoming = scheduler.list_upcoming(limit=20)
+            all_items = scheduler.list_all(limit=50)
+
+            # Count fired this week
+            week_ago = datetime.now() - timedelta(days=7)
+            fired_this_week = [
+                r for r in all_items
+                if r.get("fired") and r.get("created_at", "") >= week_ago.isoformat()
+            ]
+
+            lines = [
+                f"Completed this week: {len(fired_this_week)}",
+                f"Still active: {scheduler.count_active()}",
+            ]
+            if upcoming:
+                lines.append(f"Next up:")
+                for r in upcoming[:5]:
+                    lines.append(f"  • {r['title']}")
+            return "\n".join(lines)
+        except Exception:
+            return None
+
+    async def _get_email_stats_today(self) -> Optional[str]:
+        try:
+            from bantz.tools.gmail import email_stats_today
+            stats = await email_stats_today()
+            if all(v == 0 for v in stats.values()):
+                return None
+            return (
+                f"Received: {stats['received']}\n"
+                f"Sent: {stats['sent']}\n"
+                f"Currently unread: {stats['unread']}"
+            )
+        except Exception:
+            return None
+
+    async def _get_email_stats_week(self) -> Optional[str]:
+        try:
+            from bantz.tools.gmail import email_stats_week
+            stats = await email_stats_week()
+            if all(v == 0 for v in stats.values()):
+                return None
+            return (
+                f"Received this week: {stats['received']}\n"
+                f"Sent this week: {stats['sent']}\n"
+                f"Currently unread: {stats['unread']}"
+            )
+        except Exception:
+            return None
+
+    async def _get_calendar_today(self) -> Optional[str]:
+        try:
+            from bantz.tools.calendar import CalendarTool
+            c = CalendarTool()
+            result = await c.execute(action="today")
+            if result.success:
+                text = result.output.strip()
+                if "no events" in text.lower():
+                    return "No events today"
+                return text
+        except Exception:
+            pass
+        return None
+
+    async def _get_calendar_week(self) -> Optional[str]:
+        try:
+            from bantz.tools.calendar import CalendarTool
+            c = CalendarTool()
+            result = await c.execute(action="week")
+            if result.success:
+                text = result.output.strip()
+                # Count events
+                event_lines = [l for l in text.splitlines() if l.strip().startswith("•") or "—" in l]
+                return f"Events this week: {len(event_lines)}\n{text}"
+        except Exception:
+            pass
+        return None
+
+    async def _get_tomorrow_weather(self) -> Optional[str]:
+        try:
+            from bantz.tools.weather import tomorrow_forecast
+            forecast = await tomorrow_forecast()
+            if forecast:
+                return f"Tomorrow: {forecast}"
+        except Exception:
+            pass
+        return None
+
+    async def _get_graph_growth(self) -> Optional[str]:
+        try:
+            from bantz.memory.graph import graph_memory
+            if not graph_memory.enabled:
+                return None
+
+            stats = await graph_memory.stats()
+            week_ago = (datetime.now() - timedelta(days=7)).isoformat()
+            growth = await graph_memory.growth_since(week_ago)
+
+            lines = [
+                f"Total: {stats.get('total_nodes', 0)} nodes, "
+                f"{stats.get('total_relationships', 0)} relationships",
+            ]
+            if growth["new_nodes"] > 0:
+                lines.append(f"New this week: +{growth['new_nodes']} nodes, +{growth['new_rels']} relationships")
+                if growth["by_label"]:
+                    breakdown = ", ".join(f"{k}: +{v}" for k, v in growth["by_label"].items())
+                    lines.append(f"  ({breakdown})")
+            else:
+                lines.append("No new entries this week")
+            return "\n".join(lines)
+        except Exception:
+            return None
+
+    async def _get_commitments(self) -> Optional[str]:
+        try:
+            from bantz.memory.graph import graph_memory
+            if not graph_memory.enabled:
+                return None
+
+            result = await graph_memory._query(
+                "MATCH (c:Commitment {status: 'active'}) "
+                "RETURN c.what AS what, c.date AS date "
+                "ORDER BY c.date DESC LIMIT 10"
+            )
+            if not result:
+                return None
+
+            lines = [f"Active commitments: {len(result)}"]
+            for c in result:
+                lines.append(f"  • {c['what']}")
+            return "\n".join(lines)
+        except Exception:
+            return None
+
+    async def _get_next_week_preview(self) -> Optional[str]:
+        """Calendar events for the upcoming week."""
+        try:
+            from bantz.tools.calendar import CalendarTool
+            c = CalendarTool()
+            result = await c.execute(action="week")
+            if result.success:
+                return result.output.strip() or None
+        except Exception:
+            pass
+        return None
+
+    # ── LLM synthesis ─────────────────────────────────────────────────────
+
+    @staticmethod
+    async def _synthesize(raw_data: str, system_prompt: str) -> str:
+        """Pass raw data through Gemini Flash for natural language summary."""
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": raw_data},
+        ]
+
+        # Try Gemini first (preferred for digest — faster, cheaper)
+        try:
+            from bantz.llm.gemini import gemini
+            if gemini.is_enabled():
+                result = await gemini.chat(messages, temperature=0.3)
+                if result and len(result) > 20:
+                    return result
+        except Exception:
+            pass
+
+        # Fallback to Ollama
+        try:
+            from bantz.llm.ollama import ollama
+            return await ollama.chat(messages)
+        except Exception:
+            pass
+
+        # Final fallback: return raw data if no LLM available
+        return raw_data
+
+
+# Singleton
+digest_manager = DigestManager()

--- a/src/bantz/interface/telegram_bot.py
+++ b/src/bantz/interface/telegram_bot.py
@@ -102,7 +102,9 @@ async def cmd_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         "/ders — today's schedule\n"
         "/siradaki — next class\n"
         "/haber — latest news\n"
-        "/hatirlatici — list reminders"
+        "/hatirlatici — list reminders\n"
+        "/digest — evening daily digest\n"
+        "/weekly — weekly summary"
     )
 
 
@@ -214,6 +216,82 @@ async def cmd_hatirlatici(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         await update.message.reply_text(f"Reminder error: {exc}")
 
 
+@_authorized
+async def cmd_digest(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """On-demand daily digest."""
+    _active_chats.add(update.effective_chat.id)
+    await update.message.reply_text("⏳ Generating digest…")
+    try:
+        from bantz.core.digest import digest_manager
+        text = await digest_manager.daily_digest()
+        await _safe_reply(update, text)
+    except Exception as exc:
+        await update.message.reply_text(f"Digest error: {exc}")
+
+
+@_authorized
+async def cmd_weekly(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """On-demand weekly digest."""
+    _active_chats.add(update.effective_chat.id)
+    await update.message.reply_text("⏳ Generating weekly digest…")
+    try:
+        from bantz.core.digest import digest_manager
+        text = await digest_manager.weekly_digest()
+        await _safe_reply(update, text)
+    except Exception as exc:
+        await update.message.reply_text(f"Weekly digest error: {exc}")
+
+
+# ── Proactive digest notifications ───────────────────────────────────────────
+
+async def _daily_digest_job(context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Scheduled job: send evening daily digest to all active chats."""
+    if not _active_chats or not config.daily_digest_enabled:
+        return
+
+    try:
+        from bantz.core.digest import digest_manager
+        text = await digest_manager.daily_digest()
+    except Exception as exc:
+        log.warning("Daily digest job failed: %s", exc)
+        return
+
+    for chat_id in _active_chats:
+        try:
+            await context.bot.send_message(chat_id=chat_id, text=text)
+        except Exception as exc:
+            log.debug("Failed to send daily digest to %d: %s", chat_id, exc)
+
+
+async def _weekly_digest_job(context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Scheduled job: send weekly digest on configured day."""
+    if not _active_chats or not config.weekly_digest_enabled:
+        return
+
+    from datetime import datetime
+    now = datetime.now()
+    _DAY_MAP = {
+        "monday": 0, "tuesday": 1, "wednesday": 2, "thursday": 3,
+        "friday": 4, "saturday": 5, "sunday": 6,
+    }
+    target_day = _DAY_MAP.get(config.weekly_digest_day.lower(), 6)
+    if now.weekday() != target_day:
+        return
+
+    try:
+        from bantz.core.digest import digest_manager
+        text = await digest_manager.weekly_digest()
+    except Exception as exc:
+        log.warning("Weekly digest job failed: %s", exc)
+        return
+
+    for chat_id in _active_chats:
+        try:
+            await context.bot.send_message(chat_id=chat_id, text=text)
+        except Exception as exc:
+            log.debug("Failed to send weekly digest to %d: %s", chat_id, exc)
+
+
 # ── Proactive reminder notifications ─────────────────────────────────────────
 
 async def _check_reminders_job(context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -274,6 +352,8 @@ def run_bot() -> None:
     app.add_handler(CommandHandler("siradaki", cmd_siradaki))
     app.add_handler(CommandHandler("haber", cmd_haber))
     app.add_handler(CommandHandler("hatirlatici", cmd_hatirlatici))
+    app.add_handler(CommandHandler("digest", cmd_digest))
+    app.add_handler(CommandHandler("weekly", cmd_weekly))
 
     # Proactive reminder check — runs every 30 seconds
     app.job_queue.run_repeating(
@@ -281,6 +361,29 @@ def run_bot() -> None:
         interval=config.reminder_check_interval,
         first=10,
         name="reminder_check",
+    )
+
+    # Daily digest — runs every 60s, job itself checks if it's the right time
+    import datetime as _dt
+    _digest_time = _dt.time(
+        hour=config.daily_digest_hour,
+        minute=config.daily_digest_minute,
+    )
+    app.job_queue.run_daily(
+        _daily_digest_job,
+        time=_digest_time,
+        name="daily_digest",
+    )
+
+    # Weekly digest — runs daily at configured time, job checks day-of-week
+    _weekly_time = _dt.time(
+        hour=config.weekly_digest_hour,
+        minute=config.weekly_digest_minute,
+    )
+    app.job_queue.run_daily(
+        _weekly_digest_job,
+        time=_weekly_time,
+        name="weekly_digest",
     )
 
     log.info("🦌 Bantz Telegram bot starting...")

--- a/src/bantz/interface/tui/app.py
+++ b/src/bantz/interface/tui/app.py
@@ -72,6 +72,7 @@ class BantzApp(App):
         self._start_stationary_checker()
         self._start_morning_briefing_timer()
         self._start_reminder_checker()
+        self._start_digest_checker()
         self.query_one("#chat-input", Input).focus()
 
     async def action_quit(self) -> None:
@@ -186,6 +187,39 @@ class BantzApp(App):
                 chat.scroll_end()
                 try:
                     memory.add("assistant", text, tool_used="briefing")
+                except Exception:
+                    pass
+        except Exception:
+            pass
+
+    def _start_digest_checker(self) -> None:
+        self.set_interval(60, self._check_digest)
+
+    @work(exclusive=False)
+    async def _check_digest(self) -> None:
+        try:
+            from bantz.core.digest import digest_manager
+            from bantz.core.memory import memory
+
+            # Check daily digest
+            text = await digest_manager.daily_if_due()
+            if text:
+                chat = self.query_one("#chat-log", ChatLog)
+                chat.add_bantz(text)
+                chat.scroll_end()
+                try:
+                    memory.add("assistant", text, tool_used="digest")
+                except Exception:
+                    pass
+
+            # Check weekly digest
+            text = await digest_manager.weekly_if_due()
+            if text:
+                chat = self.query_one("#chat-log", ChatLog)
+                chat.add_bantz(text)
+                chat.scroll_end()
+                try:
+                    memory.add("assistant", text, tool_used="digest")
                 except Exception:
                     pass
         except Exception:

--- a/src/bantz/memory/graph.py
+++ b/src/bantz/memory/graph.py
@@ -254,6 +254,38 @@ class GraphMemory:
             f"{s['total_relationships']} rels"
         )
 
+    # ── Growth tracking ────────────────────────────────────────────────────
+
+    async def growth_since(self, since_iso: str) -> dict:
+        """Count nodes and relationships created since a given ISO timestamp.
+
+        Returns {"new_nodes": N, "new_rels": N, "by_label": {...}}.
+        """
+        if not self._enabled:
+            return {"new_nodes": 0, "new_rels": 0, "by_label": {}}
+
+        try:
+            nodes = await self._query(
+                "MATCH (n) WHERE n.created_at >= $since OR n.updated_at >= $since "
+                "OR n.last_seen >= $since OR n.accessed_at >= $since "
+                "RETURN labels(n)[0] AS label, count(n) AS cnt",
+                since=since_iso,
+            )
+            rels = await self._query(
+                "MATCH ()-[r]->() WHERE r.created_at >= $since "
+                "RETURN count(r) AS cnt",
+                since=since_iso,
+            )
+            by_label = {r["label"]: r["cnt"] for r in nodes}
+            return {
+                "new_nodes": sum(r["cnt"] for r in nodes),
+                "new_rels": rels[0]["cnt"] if rels else 0,
+                "by_label": by_label,
+            }
+        except Exception as exc:
+            log.debug("Growth query failed: %s", exc)
+            return {"new_nodes": 0, "new_rels": 0, "by_label": {}}
+
     # ── Delete operations ──────────────────────────────────────────────────
 
     async def delete_node(

--- a/src/bantz/tools/gmail.py
+++ b/src/bantz/tools/gmail.py
@@ -1003,3 +1003,53 @@ class GmailTool(BaseTool):
 
 
 registry.register(GmailTool())
+
+
+# ── Digest helpers ────────────────────────────────────────────────────────────
+
+def _count_query_sync(creds, query: str) -> int:
+    """Count messages matching a Gmail query."""
+    from googleapiclient.discovery import build
+    svc = build("gmail", "v1", credentials=creds)
+    result = svc.users().messages().list(
+        userId="me", q=query, maxResults=1,
+    ).execute()
+    return result.get("resultSizeEstimate", 0)
+
+
+async def email_stats_today() -> dict:
+    """Return email stats for today: received, sent, unread counts."""
+    try:
+        tool = GmailTool()
+        creds = token_store.get("gmail")
+        loop = asyncio.get_event_loop()
+
+        unread = await loop.run_in_executor(None, tool._count_sync, creds)
+        received = await loop.run_in_executor(
+            None, _count_query_sync, creds, "newer_than:1d in:inbox",
+        )
+        sent = await loop.run_in_executor(
+            None, _count_query_sync, creds, "newer_than:1d in:sent",
+        )
+        return {"received": received, "sent": sent, "unread": unread}
+    except Exception:
+        return {"received": 0, "sent": 0, "unread": 0}
+
+
+async def email_stats_week() -> dict:
+    """Return email stats for this week."""
+    try:
+        tool = GmailTool()
+        creds = token_store.get("gmail")
+        loop = asyncio.get_event_loop()
+
+        unread = await loop.run_in_executor(None, tool._count_sync, creds)
+        received = await loop.run_in_executor(
+            None, _count_query_sync, creds, "newer_than:7d in:inbox",
+        )
+        sent = await loop.run_in_executor(
+            None, _count_query_sync, creds, "newer_than:7d in:sent",
+        )
+        return {"received": received, "sent": sent, "unread": unread}
+    except Exception:
+        return {"received": 0, "sent": 0, "unread": 0}

--- a/src/bantz/tools/weather.py
+++ b/src/bantz/tools/weather.py
@@ -84,3 +84,23 @@ class WeatherTool(BaseTool):
 
 
 registry.register(WeatherTool())
+
+
+# ── Digest helper ─────────────────────────────────────────────────────────────
+
+async def tomorrow_forecast() -> str | None:
+    """Return a short forecast string for tomorrow, or None on failure."""
+    try:
+        tool = WeatherTool()
+        loc = await location_service.get()
+        data = await tool._fetch(loc.city)
+        days = data.get("weather", [])
+        if len(days) < 2:
+            return None
+        day = days[1]  # tomorrow
+        max_c = day["maxtempC"]
+        min_c = day["mintempC"]
+        desc = day["hourly"][4]["weatherDesc"][0]["value"]  # noon
+        return f"{min_c}°C–{max_c}°C, {desc}"
+    except Exception:
+        return None


### PR DESCRIPTION
## Issue #88 — Daily & Weekly Digest Automation

### New Files
- **`core/digest.py`**: `DigestManager` with `daily_digest()` / `weekly_digest()` — collects data from all sources and synthesises via Gemini Flash

### Modified Files
- **`config.py`**: 7 new config fields (`BANTZ_DAILY_DIGEST_ENABLED/HOUR/MINUTE`, `BANTZ_WEEKLY_DIGEST_ENABLED/DAY/HOUR/MINUTE`)
- **`gmail.py`**: `email_stats_today()`, `email_stats_week()` helpers
- **`weather.py`**: `tomorrow_forecast()` helper
- **`graph.py`**: `growth_since(since_iso)` for weekly graph stats
- **`telegram_bot.py`**: `/digest` + `/weekly` commands, `run_daily` scheduled jobs
- **`tui/app.py`**: 60s polling digest checker

### Architecture
- Evening daily digest: calendar, email stats, reminders, tomorrow weather, commitments
- Sunday weekly digest: week review, email volume, graph growth, open commitments, next week preview
- LLM synthesis: Gemini Flash (primary) → Ollama (fallback) → raw data
- Delivery: Telegram scheduled jobs + TUI polling + on-demand commands
- Config-driven: enable/disable, custom times, custom day for weekly

Closes #88