### PR TITLE
refactor(data): Unified Data Access Layer — Issue #115

### DIFF
--- a/src/bantz/core/brain.py
+++ b/src/bantz/core/brain.py
@@ -22,7 +22,7 @@ import logging
 
 from bantz.config import config
 from bantz.core.time_context import time_ctx
-from bantz.core.memory import memory
+from bantz.data import data_layer
 from bantz.core.profile import profile
 from bantz.core.intent import cot_route
 from bantz.core.date_parser import resolve_date
@@ -139,10 +139,7 @@ class Brain:
 
     def _ensure_memory(self) -> None:
         if not self._memory_ready:
-            memory.init(config.db_path)
-            memory.new_session()
-            from bantz.core.scheduler import scheduler
-            scheduler.init(config.db_path)
+            data_layer.init(config)
             self._memory_ready = True
 
     async def _ensure_graph(self) -> None:
@@ -598,7 +595,7 @@ class Brain:
         tc = time_ctx.snapshot()
 
         # Save user message ONCE — before any branching
-        memory.add("user", user_input)
+        data_layer.conversations.add("user", user_input)
 
         # ── Workflow detection: multi-tool chained commands (#34) ──
         from bantz.core.workflow import workflow_engine
@@ -614,7 +611,7 @@ class Brain:
                         "subject": d.get("subject", ""),
                         "body": d["body"],
                     }
-            memory.add("assistant", resp, tool_used="workflow")
+            data_layer.conversations.add("assistant", resp, tool_used="workflow")
             await self._graph_store(user_input, resp, "workflow")
             return BrainResult(response=resp, tool_used="workflow")
 
@@ -623,39 +620,39 @@ class Brain:
         if quick and quick["tool"] == "_briefing":
             from bantz.core.briefing import briefing as _briefing
             text = await _briefing.generate()
-            memory.add("assistant", text, tool_used="briefing")
+            data_layer.conversations.add("assistant", text, tool_used="briefing")
             return BrainResult(response=text, tool_used="briefing")
 
         if quick and quick["tool"] == "_location":
             text = await self._handle_location()
-            memory.add("assistant", text, tool_used="location")
+            data_layer.conversations.add("assistant", text, tool_used="location")
             return BrainResult(response=text, tool_used="location")
 
         if quick and quick["tool"] == "_save_place":
             text = await self._handle_save_place(quick["args"]["name"])
-            memory.add("assistant", text, tool_used="places")
+            data_layer.conversations.add("assistant", text, tool_used="places")
             return BrainResult(response=text, tool_used="places")
 
         if quick and quick["tool"] == "_list_places":
             text = await self._handle_list_places()
-            memory.add("assistant", text, tool_used="places")
+            data_layer.conversations.add("assistant", text, tool_used="places")
             return BrainResult(response=text, tool_used="places")
 
         if quick and quick["tool"] == "_delete_place":
             text = await self._handle_delete_place(quick["args"]["name"])
-            memory.add("assistant", text, tool_used="places")
+            data_layer.conversations.add("assistant", text, tool_used="places")
             return BrainResult(response=text, tool_used="places")
 
         if quick and quick["tool"] == "_schedule_today":
             from bantz.core.schedule import schedule as _sched
             text = _sched.format_today()
-            memory.add("assistant", text, tool_used="schedule")
+            data_layer.conversations.add("assistant", text, tool_used="schedule")
             return BrainResult(response=text, tool_used="schedule")
 
         if quick and quick["tool"] == "_schedule_next":
             from bantz.core.schedule import schedule as _sched
             text = _sched.format_next()
-            memory.add("assistant", text, tool_used="schedule")
+            data_layer.conversations.add("assistant", text, tool_used="schedule")
             return BrainResult(response=text, tool_used="schedule")
 
         if quick and quick["tool"] == "_schedule_date":
@@ -663,14 +660,14 @@ class Brain:
             from datetime import datetime as _dt
             target = _dt.fromisoformat(quick["args"]["date_iso"])
             text = _sched.format_for_date(target)
-            memory.add("assistant", text, tool_used="schedule")
+            data_layer.conversations.add("assistant", text, tool_used="schedule")
             return BrainResult(response=text, tool_used="schedule")
 
         if quick and quick["tool"] == "_schedule_week":
             from bantz.core.schedule import schedule as _sched
             resolved = resolve_date(user_input)
             text = _sched.format_week(resolved)
-            memory.add("assistant", text, tool_used="schedule")
+            data_layer.conversations.add("assistant", text, tool_used="schedule")
             return BrainResult(response=text, tool_used="schedule")
 
         if quick and quick["tool"] == "_generate":
@@ -696,7 +693,7 @@ class Brain:
                     }
                 else:
                     text = "No draft to send. Compose a mail first."
-                    memory.add("assistant", text)
+                    data_layer.conversations.add("assistant", text)
                     return BrainResult(response=text, tool_used=None)
 
             plan = {"route": "tool", "tool_name": quick["tool"],
@@ -735,7 +732,7 @@ class Brain:
                 f"⚠️  Destructive operation: [{tool_name}] `{cmd_str}`\n"
                 f"Confirm? (yes/no)"
             )
-            memory.add("assistant", warn)
+            data_layer.conversations.add("assistant", warn)
             return BrainResult(
                 response=warn,
                 tool_used=tool_name,
@@ -748,7 +745,7 @@ class Brain:
         tool = registry.get(tool_name)
         if not tool:
             err = f"Tool not found: {tool_name}"
-            memory.add("assistant", err)
+            data_layer.conversations.add("assistant", err)
             return BrainResult(response=err, tool_used=None)
 
         result = await tool.execute(**tool_args)
@@ -768,7 +765,7 @@ class Brain:
                 "subject": d.get("subject", ""),
                 "body": d["body"],
             }
-            memory.add("assistant", result.output, tool_used=tool_name)
+            data_layer.conversations.add("assistant", result.output, tool_used=tool_name)
             return BrainResult(
                 response=result.output,
                 tool_used=tool_name,
@@ -793,7 +790,7 @@ class Brain:
 
         # Short output — non-streaming finalize
         resp = await self._finalize(en_input, result, tc)
-        memory.add("assistant", resp, tool_used=tool_name)
+        data_layer.conversations.add("assistant", resp, tool_used=tool_name)
         await self._graph_store(user_input, resp, tool_name,
                                 result.data if result else None)
         return BrainResult(response=resp, tool_used=tool_name, tool_result=result)
@@ -803,7 +800,7 @@ class Brain:
         Chat mode with conversation history.
         history[-1] = the user message we just saved → exclude to avoid duplication.
         """
-        history = memory.context(n=12)
+        history = data_layer.conversations.context(n=12)
         prior = history[:-1] if (history and history[-1]["role"] == "user") else history
         graph_hint = await self._graph_context(en_input)
 
@@ -838,7 +835,7 @@ class Brain:
         Streaming chat — yields tokens as they arrive from LLM.
         Post-processing (strip_markdown) runs on accumulated text at consumer side.
         """
-        history = memory.context(n=12)
+        history = data_layer.conversations.context(n=12)
         prior = history[:-1] if (history and history[-1]["role"] == "user") else history
         graph_hint = await self._graph_context(en_input)
 

--- a/src/bantz/core/memory.py
+++ b/src/bantz/core/memory.py
@@ -30,8 +30,10 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
+from bantz.data.store import ConversationStore
 
-class Memory:
+
+class Memory(ConversationStore):
     def __init__(self) -> None:
         self._db_path: Optional[Path] = None
         self._conn: Optional[sqlite3.Connection] = None

--- a/src/bantz/core/scheduler.py
+++ b/src/bantz/core/scheduler.py
@@ -35,12 +35,14 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Optional
 
+from bantz.data.store import ReminderStore
+
 log = logging.getLogger("bantz.scheduler")
 
 _REPEAT_MODES = ("none", "daily", "weekly", "weekdays", "custom")
 
 
-class Scheduler:
+class Scheduler(ReminderStore):
     def __init__(self) -> None:
         self._conn: Optional[sqlite3.Connection] = None
         self._lock = threading.Lock()

--- a/src/bantz/data/__init__.py
+++ b/src/bantz/data/__init__.py
@@ -1,0 +1,14 @@
+"""
+Bantz v3 — Data Access Layer
+
+Unified entry point for all persistence. Import the singleton and go:
+
+    from bantz.data import data_layer
+
+    data_layer.init(config)
+    data_layer.conversations.add("user", "hello")
+    profile = data_layer.profile.load()
+"""
+from bantz.data.layer import data_layer
+
+__all__ = ["data_layer"]

--- a/src/bantz/data/json_store.py
+++ b/src/bantz/data/json_store.py
@@ -1,0 +1,135 @@
+"""
+Bantz v3 — JSON File Store Implementations
+
+Backward-compatible JSON adapters for profile, places, schedule, and session.
+These read/write the same files as v2, ensuring seamless migration.
+
+    store = JSONProfileStore(base_dir)
+    data  = store.load()           # reads ~/.local/share/bantz/profile.json
+    store.save({"name": "Iclal"})  # writes it back
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from bantz.data.store import PlaceStore, ProfileStore, ScheduleStore, SessionStore
+
+log = logging.getLogger("bantz.data.json")
+
+
+# ── helpers ───────────────────────────────────────────────────────────────
+
+
+def _read_json(path: Path) -> dict:
+    """Read a JSON file, returning {} on any error."""
+    if path.exists():
+        try:
+            return json.loads(path.read_text("utf-8"))
+        except Exception:
+            log.warning("Failed to read %s — returning empty dict", path)
+    return {}
+
+
+def _write_json(path: Path, data: dict | list) -> None:
+    """Write JSON with pretty-print, creating parent dirs."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(data, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
+# ━━ Profile ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class JSONProfileStore(ProfileStore):
+    """Reads / writes ``~/.local/share/bantz/profile.json``."""
+
+    def __init__(self, base_dir: Path | None = None) -> None:
+        self._base = base_dir or (Path.home() / ".local" / "share" / "bantz")
+        self._path = self._base / "profile.json"
+
+    def load(self) -> dict[str, Any]:
+        return _read_json(self._path)
+
+    def save(self, data: dict[str, Any]) -> None:
+        _write_json(self._path, data)
+
+    def exists(self) -> bool:
+        return self._path.exists()
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+
+# ━━ Places ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class JSONPlaceStore(PlaceStore):
+    """Reads / writes ``~/.local/share/bantz/places.json``."""
+
+    def __init__(self, base_dir: Path | None = None) -> None:
+        self._base = base_dir or (Path.home() / ".local" / "share" / "bantz")
+        self._path = self._base / "places.json"
+
+    def load_all(self) -> dict[str, dict]:
+        return _read_json(self._path)
+
+    def save_all(self, data: dict[str, dict]) -> None:
+        _write_json(self._path, data)
+
+    def exists(self) -> bool:
+        return self._path.exists()
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+
+# ━━ Schedule ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class JSONScheduleStore(ScheduleStore):
+    """Reads / writes ``~/.local/share/bantz/schedule.json``."""
+
+    def __init__(self, base_dir: Path | None = None) -> None:
+        self._base = base_dir or (Path.home() / ".local" / "share" / "bantz")
+        self._path = self._base / "schedule.json"
+
+    def load(self) -> dict[str, list[dict]]:
+        return _read_json(self._path)
+
+    def save(self, data: dict[str, list[dict]]) -> None:
+        _write_json(self._path, data)
+
+    def exists(self) -> bool:
+        return self._path.exists()
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+
+# ━━ Session ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class JSONSessionStore(SessionStore):
+    """Reads / writes ``~/.local/share/bantz/session.json``."""
+
+    def __init__(self, base_dir: Path | None = None) -> None:
+        self._base = base_dir or (Path.home() / ".local" / "share" / "bantz")
+        self._path = self._base / "session.json"
+
+    def load(self) -> dict:
+        return _read_json(self._path)
+
+    def save(self, data: dict) -> None:
+        _write_json(self._path, data)
+
+    @property
+    def path(self) -> Path:
+        return self._path

--- a/src/bantz/data/layer.py
+++ b/src/bantz/data/layer.py
@@ -1,0 +1,148 @@
+"""
+Bantz v3 — Data Access Layer (Singleton)
+
+Composes all stores behind a single entry point.
+Initialized once during app startup — replaces scattered init() calls.
+
+    from bantz.data import data_layer
+
+    data_layer.init(config)
+    data_layer.conversations.add("user", "hello")
+
+At runtime the DataLayer wires the existing ``Memory`` and ``Scheduler``
+singletons (which now inherit from the ABCs) so that every module in the
+codebase — old or new — shares the same connections and session.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional
+
+from bantz.data.store import (
+    ConversationStore,
+    GraphStore,
+    PlaceStore,
+    ProfileStore,
+    ReminderStore,
+    ScheduleStore,
+    SessionStore,
+)
+from bantz.data.json_store import (
+    JSONPlaceStore,
+    JSONProfileStore,
+    JSONScheduleStore,
+    JSONSessionStore,
+)
+
+if TYPE_CHECKING:
+    from bantz.config import Config
+
+log = logging.getLogger("bantz.data")
+
+
+class DataLayer:
+    """Unified data access — the one-stop shop for all persistence.
+
+    Attributes:
+        conversations — messages & sessions      (SQLite via Memory)
+        reminders     — scheduled reminders      (SQLite via Scheduler)
+        profile       — user identity/prefs      (JSON file)
+        places        — named GPS locations      (JSON file)
+        schedule      — weekly timetable         (JSON file)
+        session       — launch tracking          (JSON file)
+        graph         — knowledge graph          (Neo4j, optional)
+    """
+
+    def __init__(self) -> None:
+        self.conversations: ConversationStore = None  # type: ignore[assignment]
+        self.reminders: ReminderStore = None  # type: ignore[assignment]
+        self.profile: ProfileStore = None  # type: ignore[assignment]
+        self.places: PlaceStore = None  # type: ignore[assignment]
+        self.schedule: ScheduleStore = None  # type: ignore[assignment]
+        self.session: SessionStore = None  # type: ignore[assignment]
+        self.graph: Optional[GraphStore] = None
+        self._initialized = False
+
+    # ── initialization ────────────────────────────────────────────────────
+
+    def init(self, cfg: "Config") -> None:
+        """Initialize all stores.  Call once at app startup.
+
+        Wires the existing ``Memory`` and ``Scheduler`` singletons so that
+        they serve double duty as the DAL conversation/reminder stores.
+        JSON stores are created fresh for profile, places, schedule, session.
+        """
+        if self._initialized:
+            return
+
+        # Import legacy singletons
+        from bantz.core.memory import memory
+        from bantz.core.scheduler import scheduler
+
+        cfg.ensure_dirs()
+
+        # ── SQLite stores (via legacy singletons) ────────────────────────
+        memory.init(cfg.db_path)
+        memory.new_session()
+        scheduler.init(cfg.db_path)
+
+        self.conversations = memory  # Memory IS-A ConversationStore
+        self.reminders = scheduler  # Scheduler IS-A ReminderStore
+
+        # ── JSON stores ──────────────────────────────────────────────────
+        base_dir = (
+            Path(cfg.data_dir)
+            if cfg.data_dir
+            else Path.home() / ".local" / "share" / "bantz"
+        )
+        self.profile = JSONProfileStore(base_dir)
+        self.places = JSONPlaceStore(base_dir)
+        self.schedule = JSONScheduleStore(base_dir)
+        self.session = JSONSessionStore(base_dir)
+
+        self._initialized = True
+        log.info("DataLayer initialized  db=%s  data=%s", cfg.db_path, base_dir)
+
+    async def init_graph(self) -> None:
+        """Initialize the optional graph store (Neo4j).
+
+        Safe to call even if Neo4j is disabled or not installed.
+        """
+        try:
+            from bantz.memory.graph import graph_memory
+
+            if await graph_memory.init():
+                self.graph = graph_memory  # type: ignore[assignment]
+        except ImportError:
+            log.debug("neo4j driver not installed — graph memory off")
+
+    # ── properties ────────────────────────────────────────────────────────
+
+    @property
+    def initialized(self) -> bool:
+        return self._initialized
+
+    # ── teardown ──────────────────────────────────────────────────────────
+
+    def close(self) -> None:
+        """Shut down all stores cleanly."""
+        if self.conversations is not None:
+            self.conversations.close()
+        if self.graph is not None:
+            import asyncio
+
+            try:
+                loop = asyncio.get_event_loop()
+                if loop.is_running():
+                    loop.create_task(self.graph.close())
+                else:
+                    loop.run_until_complete(self.graph.close())
+            except Exception:
+                pass
+        self._initialized = False
+        log.info("DataLayer closed")
+
+
+# Singleton — import this everywhere
+data_layer = DataLayer()

--- a/src/bantz/data/migration.py
+++ b/src/bantz/data/migration.py
@@ -1,0 +1,252 @@
+"""
+Bantz v3 — Data Migration Utility
+
+Validates existing v2 JSON data files and optionally imports them into
+a unified SQLite schema.  Use this when moving to an all-SQLite backend.
+
+CLI usage (future):
+    python -m bantz.data.migration --validate
+    python -m bantz.data.migration --migrate
+    python -m bantz.data.migration --migrate --dry-run
+"""
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger("bantz.data.migration")
+
+DEFAULT_DATA_DIR = Path.home() / ".local" / "share" / "bantz"
+
+_JSON_FILES = {
+    "profile": "profile.json",
+    "places": "places.json",
+    "schedule": "schedule.json",
+    "session": "session.json",
+}
+
+
+# ━━ Validation ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+def validate_json_files(data_dir: Path = DEFAULT_DATA_DIR) -> dict[str, Any]:
+    """Check all known JSON files: exist? parseable? Return a report dict.
+
+    >>> report = validate_json_files()
+    >>> report["profile"]
+    {'status': 'ok', 'path': '...', 'entries': 8}
+    """
+    report: dict[str, Any] = {}
+    for name, filename in _JSON_FILES.items():
+        path = data_dir / filename
+        if not path.exists():
+            report[name] = {"status": "missing", "path": str(path)}
+            continue
+        try:
+            data = json.loads(path.read_text("utf-8"))
+            report[name] = {
+                "status": "ok",
+                "path": str(path),
+                "entries": len(data) if isinstance(data, (list, dict)) else 1,
+            }
+        except Exception as exc:
+            report[name] = {"status": "error", "path": str(path), "error": str(exc)}
+    return report
+
+
+# ━━ SQLite Migration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+_UNIFIED_SCHEMA = """\
+CREATE TABLE IF NOT EXISTS kv_store (
+    namespace  TEXT NOT NULL,
+    key        TEXT NOT NULL,
+    value      TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (namespace, key)
+);
+
+CREATE TABLE IF NOT EXISTS places (
+    key    TEXT PRIMARY KEY,
+    label  TEXT NOT NULL,
+    lat    REAL NOT NULL DEFAULT 0.0,
+    lon    REAL NOT NULL DEFAULT 0.0,
+    radius REAL NOT NULL DEFAULT 100.0
+);
+
+CREATE TABLE IF NOT EXISTS schedule (
+    day      TEXT NOT NULL,
+    idx      INTEGER NOT NULL,
+    name     TEXT NOT NULL,
+    time     TEXT NOT NULL,
+    duration INTEGER NOT NULL DEFAULT 60,
+    location TEXT DEFAULT '',
+    type     TEXT DEFAULT '',
+    PRIMARY KEY (day, idx)
+);
+"""
+
+
+def migrate_to_sqlite(
+    db_path: Path,
+    data_dir: Path = DEFAULT_DATA_DIR,
+    *,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Import JSON data into unified SQLite tables.
+
+    Parameters:
+        db_path  – target SQLite database (can be the same as bantz.db)
+        data_dir – directory containing the JSON files
+        dry_run  – if True, validate but don't write
+
+    Returns:
+        A results dict with per-file status and counts.
+    """
+    results: dict[str, Any] = {}
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA journal_mode=WAL")
+
+    # Create unified tables
+    conn.executescript(_UNIFIED_SCHEMA)
+
+    # ── profile → kv_store ────────────────────────────────────────────
+    _migrate_kv(conn, data_dir / "profile.json", "profile", results, dry_run)
+
+    # ── session → kv_store ────────────────────────────────────────────
+    _migrate_kv(conn, data_dir / "session.json", "session", results, dry_run)
+
+    # ── places → places table ─────────────────────────────────────────
+    places_path = data_dir / "places.json"
+    if places_path.exists():
+        try:
+            data = json.loads(places_path.read_text("utf-8"))
+            count = 0
+            if not dry_run:
+                for key, place in data.items():
+                    conn.execute(
+                        """INSERT OR REPLACE INTO places(key, label, lat, lon, radius)
+                           VALUES (?, ?, ?, ?, ?)""",
+                        (
+                            key,
+                            place.get("label", key),
+                            place.get("lat", 0.0),
+                            place.get("lon", 0.0),
+                            place.get("radius", 100.0),
+                        ),
+                    )
+                    count += 1
+            else:
+                count = len(data)
+            results["places"] = {"migrated": count, "status": "ok"}
+        except Exception as exc:
+            results["places"] = {"status": "error", "error": str(exc)}
+    else:
+        results["places"] = {"status": "skipped", "reason": "file not found"}
+
+    # ── schedule → schedule table ─────────────────────────────────────
+    schedule_path = data_dir / "schedule.json"
+    if schedule_path.exists():
+        try:
+            data = json.loads(schedule_path.read_text("utf-8"))
+            count = 0
+            if not dry_run:
+                for day, entries in data.items():
+                    for idx, entry in enumerate(entries):
+                        conn.execute(
+                            """INSERT OR REPLACE INTO schedule
+                                   (day, idx, name, time, duration, location, type)
+                               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                            (
+                                day,
+                                idx,
+                                entry.get("name", ""),
+                                entry.get("time", ""),
+                                entry.get("duration", 60),
+                                entry.get("location", ""),
+                                entry.get("type", ""),
+                            ),
+                        )
+                        count += 1
+            else:
+                count = sum(len(v) for v in data.values() if isinstance(v, list))
+            results["schedule"] = {"migrated": count, "status": "ok"}
+        except Exception as exc:
+            results["schedule"] = {"status": "error", "error": str(exc)}
+    else:
+        results["schedule"] = {"status": "skipped", "reason": "file not found"}
+
+    if not dry_run:
+        conn.commit()
+    conn.close()
+
+    log.info("Migration %s: %s", "dry-run" if dry_run else "complete", results)
+    return results
+
+
+def _migrate_kv(
+    conn: sqlite3.Connection,
+    json_path: Path,
+    namespace: str,
+    results: dict,
+    dry_run: bool,
+) -> None:
+    """Migrate a flat JSON file into the kv_store table."""
+    if not json_path.exists():
+        results[namespace] = {"status": "skipped", "reason": "file not found"}
+        return
+    try:
+        data = json.loads(json_path.read_text("utf-8"))
+        now = datetime.now().isoformat()
+        if not dry_run:
+            for k, v in data.items():
+                conn.execute(
+                    """INSERT OR REPLACE INTO kv_store(namespace, key, value, updated_at)
+                       VALUES (?, ?, ?, ?)""",
+                    (namespace, k, json.dumps(v, ensure_ascii=False), now),
+                )
+        results[namespace] = {"migrated": len(data), "status": "ok"}
+    except Exception as exc:
+        results[namespace] = {"status": "error", "error": str(exc)}
+
+
+# ━━ CLI entry point ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+if __name__ == "__main__":
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser(description="Bantz data migration utility")
+    parser.add_argument("--validate", action="store_true", help="Validate JSON files")
+    parser.add_argument("--migrate", action="store_true", help="Migrate JSON → SQLite")
+    parser.add_argument("--dry-run", action="store_true", help="Validate only, don't write")
+    parser.add_argument("--data-dir", type=Path, default=DEFAULT_DATA_DIR)
+    parser.add_argument("--db", type=Path, default=None)
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO)
+
+    if args.validate:
+        report = validate_json_files(args.data_dir)
+        for name, info in report.items():
+            status = info["status"]
+            icon = "✅" if status == "ok" else "❌" if status == "error" else "⚠️"
+            print(f"  {icon} {name}: {info}")
+        sys.exit(0)
+
+    if args.migrate:
+        db = args.db or (args.data_dir / "bantz.db")
+        results = migrate_to_sqlite(db, args.data_dir, dry_run=args.dry_run)
+        tag = " (dry-run)" if args.dry_run else ""
+        for name, info in results.items():
+            status = info["status"]
+            icon = "✅" if status == "ok" else "❌" if status == "error" else "⏭️"
+            print(f"  {icon} {name}{tag}: {info}")
+        sys.exit(0)
+
+    parser.print_help()

--- a/src/bantz/data/models.py
+++ b/src/bantz/data/models.py
@@ -1,0 +1,98 @@
+"""
+Bantz v3 — Data Models
+
+Pydantic models for all persistent entities in the Bantz ecosystem.
+These replace the raw dicts that were passed around in v2.
+
+Usage:
+    from bantz.data.models import Message, Reminder, Place, UserProfile
+
+    msg = Message(role="user", content="hello")
+    place = Place(key="dorm", label="Yurt", lat=41.27, lon=36.33)
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
+
+class Message(BaseModel):
+    """A single chat message in a conversation."""
+
+    id: int = 0
+    conversation_id: int = 0
+    role: str  # "user" | "assistant" | "system"
+    content: str
+    tool_used: Optional[str] = None
+    created_at: datetime = Field(default_factory=datetime.now)
+
+    model_config = {"from_attributes": True}
+
+
+class Conversation(BaseModel):
+    """A conversation session with metadata."""
+
+    id: int = 0
+    started_at: datetime = Field(default_factory=datetime.now)
+    last_active: datetime = Field(default_factory=datetime.now)
+    message_count: int = 0
+    first_message: str = ""
+
+
+class Reminder(BaseModel):
+    """A scheduled reminder or recurring task."""
+
+    id: int = 0
+    title: str
+    fire_at: datetime
+    repeat: str = "none"  # "none" | "daily" | "weekly" | "weekdays" | "custom"
+    repeat_interval: int = 0
+    created_at: datetime = Field(default_factory=datetime.now)
+    fired: bool = False
+    snoozed_until: Optional[datetime] = None
+    trigger_place: Optional[str] = None
+
+
+class Place(BaseModel):
+    """A named geographic location with geofence radius."""
+
+    key: str
+    label: str
+    lat: float = 0.0
+    lon: float = 0.0
+    radius: float = 100.0
+
+
+class ScheduleEntry(BaseModel):
+    """A class/event in the weekly university timetable."""
+
+    name: str
+    time: str  # "HH:MM"
+    duration: int = 60
+    location: str = ""
+    type: str = ""  # "lecture" | "lab" | "seminar"
+
+
+class UserProfile(BaseModel):
+    """User identity and preference settings."""
+
+    name: str = ""
+    university: str = ""
+    department: str = ""
+    year: int = 0
+    pronoun: str = "casual"
+    tone: str = "casual"
+    preferred_address: str = ""
+    preferences: dict[str, Any] = Field(default_factory=dict)
+
+
+class SessionInfo(BaseModel):
+    """Launch-tracking data for absence-aware greetings."""
+
+    last_seen: Optional[datetime] = None
+    session_count: int = 0
+    absence_hours: float = 0.0
+    absence_label: str = ""
+    is_first: bool = False

--- a/src/bantz/data/sqlite_store.py
+++ b/src/bantz/data/sqlite_store.py
@@ -1,0 +1,445 @@
+"""
+Bantz v3 — SQLite Store Implementations
+
+Concrete SQLite-backed stores for conversations and reminders.
+Schema matches the existing v2 tables — zero-migration upgrade.
+
+These are standalone implementations usable in tests and migration
+scripts without importing the full ``core/`` layer.  At runtime the
+DataLayer wires the existing ``Memory`` and ``Scheduler`` singletons
+(which inherit from these ABCs) instead.
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+import threading
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Optional
+
+from bantz.data.store import ConversationStore, ReminderStore
+
+log = logging.getLogger("bantz.data.sqlite")
+
+
+def _now() -> str:
+    return datetime.now().isoformat(timespec="seconds")
+
+
+def _connect(db_path: Path) -> sqlite3.Connection:
+    """Open a WAL-mode autocommit SQLite connection."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path), check_same_thread=False, isolation_level=None)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA foreign_keys=ON")
+    return conn
+
+
+# ━━ Conversation Store ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class SQLiteConversationStore(ConversationStore):
+    """SQLite conversation + message store, compatible with v2 schema."""
+
+    def __init__(self) -> None:
+        self._db_path: Optional[Path] = None
+        self._conn: Optional[sqlite3.Connection] = None
+        self._lock = threading.Lock()
+        self._session_id: Optional[int] = None
+
+    # ── lifecycle ─────────────────────────────────────────────────────────
+
+    def init(self, db_path: Path) -> None:
+        self._db_path = db_path
+        self._conn = _connect(db_path)
+        self._migrate()
+
+    def _migrate(self) -> None:
+        c = self._conn
+        c.execute("""
+            CREATE TABLE IF NOT EXISTS conversations (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                started_at  TEXT NOT NULL,
+                last_active TEXT NOT NULL
+            )
+        """)
+        c.execute("""
+            CREATE TABLE IF NOT EXISTS messages (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                conversation_id INTEGER NOT NULL REFERENCES conversations(id),
+                role            TEXT NOT NULL CHECK(role IN ('user','assistant','system')),
+                content         TEXT NOT NULL,
+                tool_used       TEXT,
+                created_at      TEXT NOT NULL
+            )
+        """)
+        c.execute("""
+            CREATE INDEX IF NOT EXISTS idx_messages_conv
+                ON messages(conversation_id, created_at)
+        """)
+        # FTS5 for full-text search — graceful fallback if unavailable
+        try:
+            c.execute("""
+                CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts
+                USING fts5(content, content='messages', content_rowid='id')
+            """)
+            c.execute("""
+                CREATE TRIGGER IF NOT EXISTS messages_ai AFTER INSERT ON messages BEGIN
+                    INSERT INTO messages_fts(rowid, content) VALUES (new.id, new.content);
+                END
+            """)
+        except sqlite3.OperationalError:
+            pass  # FTS5 not compiled in
+
+    # ── session management ────────────────────────────────────────────────
+
+    def new_session(self) -> int:
+        now = _now()
+        with self._lock:
+            cur = self._conn.execute(
+                "INSERT INTO conversations(started_at, last_active) VALUES (?,?)",
+                (now, now),
+            )
+            self._session_id = cur.lastrowid
+        return self._session_id
+
+    def resume_session(self, session_id: int) -> bool:
+        row = self._conn.execute(
+            "SELECT id FROM conversations WHERE id=?", (session_id,)
+        ).fetchone()
+        if row:
+            self._session_id = session_id
+            return True
+        return False
+
+    @property
+    def session_id(self) -> Optional[int]:
+        return self._session_id
+
+    # ── writing ───────────────────────────────────────────────────────────
+
+    def add(self, role: str, content: str, tool_used: Optional[str] = None) -> int:
+        if not self._session_id:
+            self.new_session()
+        now = _now()
+        with self._lock:
+            cur = self._conn.execute(
+                """INSERT INTO messages(conversation_id, role, content, tool_used, created_at)
+                   VALUES (?,?,?,?,?)""",
+                (self._session_id, role, content, tool_used, now),
+            )
+            self._conn.execute(
+                "UPDATE conversations SET last_active=? WHERE id=?",
+                (now, self._session_id),
+            )
+        return cur.lastrowid
+
+    # ── reading ───────────────────────────────────────────────────────────
+
+    def context(self, n: int = 12) -> list[dict]:
+        if not self._session_id:
+            return []
+        rows = self._conn.execute(
+            """SELECT role, content FROM messages
+               WHERE conversation_id=? AND role IN ('user','assistant')
+               ORDER BY created_at DESC LIMIT ?""",
+            (self._session_id, n),
+        ).fetchall()
+        return [{"role": r["role"], "content": r["content"]} for r in reversed(rows)]
+
+    def last_n(self, n: int = 20) -> list[dict]:
+        if not self._session_id:
+            return []
+        rows = self._conn.execute(
+            """SELECT role, content, tool_used, created_at FROM messages
+               WHERE conversation_id=?
+               ORDER BY created_at DESC LIMIT ?""",
+            (self._session_id, n),
+        ).fetchall()
+        return [dict(r) for r in reversed(rows)]
+
+    def search(self, query: str, limit: int = 10) -> list[dict]:
+        try:
+            rows = self._conn.execute(
+                """SELECT m.role, m.content, m.tool_used, m.created_at,
+                          c.id as conv_id
+                   FROM messages_fts f
+                   JOIN messages m ON m.id = f.rowid
+                   JOIN conversations c ON c.id = m.conversation_id
+                   WHERE messages_fts MATCH ?
+                   ORDER BY m.created_at DESC LIMIT ?""",
+                (query, limit),
+            ).fetchall()
+        except sqlite3.OperationalError:
+            rows = self._conn.execute(
+                """SELECT m.role, m.content, m.tool_used, m.created_at,
+                          c.id as conv_id
+                   FROM messages m
+                   JOIN conversations c ON c.id = m.conversation_id
+                   WHERE m.content LIKE ?
+                   ORDER BY m.created_at DESC LIMIT ?""",
+                (f"%{query}%", limit),
+            ).fetchall()
+        return [dict(r) for r in rows]
+
+    def search_by_date(self, date: datetime, limit: int = 20) -> list[dict]:
+        date_str = date.strftime("%Y-%m-%d")
+        rows = self._conn.execute(
+            """SELECT m.role, m.content, m.tool_used, m.created_at,
+                      c.id as conv_id
+               FROM messages m
+               JOIN conversations c ON c.id = m.conversation_id
+               WHERE m.created_at LIKE ?
+               ORDER BY m.created_at ASC LIMIT ?""",
+            (f"{date_str}%", limit),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    def conversation_list(self, limit: int = 20) -> list[dict]:
+        rows = self._conn.execute(
+            """SELECT c.id, c.started_at, c.last_active,
+                      COUNT(m.id) as message_count,
+                      (SELECT content FROM messages
+                       WHERE conversation_id=c.id AND role='user'
+                       ORDER BY created_at LIMIT 1) as first_message
+               FROM conversations c
+               LEFT JOIN messages m ON m.conversation_id=c.id
+               GROUP BY c.id
+               ORDER BY c.last_active DESC LIMIT ?""",
+            (limit,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    # ── diagnostics ───────────────────────────────────────────────────────
+
+    def stats(self) -> dict:
+        total_conv = self._conn.execute(
+            "SELECT COUNT(*) FROM conversations"
+        ).fetchone()[0]
+        total_msg = self._conn.execute(
+            "SELECT COUNT(*) FROM messages"
+        ).fetchone()[0]
+        session_msg = 0
+        if self._session_id:
+            session_msg = self._conn.execute(
+                "SELECT COUNT(*) FROM messages WHERE conversation_id=?",
+                (self._session_id,),
+            ).fetchone()[0]
+        return {
+            "db_path": str(self._db_path),
+            "total_conversations": total_conv,
+            "total_messages": total_msg,
+            "current_session_id": self._session_id,
+            "current_session_messages": session_msg,
+        }
+
+    def prune(self, keep_days: int = 90) -> int:
+        cutoff = (datetime.now() - timedelta(days=keep_days)).isoformat()
+        with self._lock:
+            cur = self._conn.execute(
+                "DELETE FROM conversations WHERE last_active < ?", (cutoff,)
+            )
+        return cur.rowcount
+
+    def close(self) -> None:
+        if self._conn:
+            self._conn.close()
+            self._conn = None
+
+
+# ━━ Reminder Store ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+_REPEAT_MODES = ("none", "daily", "weekly", "weekdays", "custom")
+
+
+class SQLiteReminderStore(ReminderStore):
+    """SQLite reminder store, compatible with v2 schema."""
+
+    def __init__(self) -> None:
+        self._conn: Optional[sqlite3.Connection] = None
+        self._lock = threading.Lock()
+
+    # ── lifecycle ─────────────────────────────────────────────────────────
+
+    def init(self, db_path: Path) -> None:
+        self._conn = _connect(db_path)
+        self._migrate()
+        log.debug("SQLiteReminderStore initialized: %s", db_path)
+
+    def _migrate(self) -> None:
+        self._conn.execute("""
+            CREATE TABLE IF NOT EXISTS reminders (
+                id               INTEGER PRIMARY KEY AUTOINCREMENT,
+                title            TEXT NOT NULL,
+                fire_at          TEXT NOT NULL,
+                repeat           TEXT NOT NULL DEFAULT 'none',
+                repeat_interval  INTEGER DEFAULT 0,
+                created_at       TEXT NOT NULL,
+                fired            INTEGER NOT NULL DEFAULT 0,
+                snoozed_until    TEXT,
+                trigger_place    TEXT
+            )
+        """)
+        self._conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_reminders_fire
+                ON reminders(fire_at, fired)
+        """)
+        try:
+            self._conn.execute("ALTER TABLE reminders ADD COLUMN trigger_place TEXT")
+        except Exception:
+            pass  # column already exists
+
+    # ── CRUD ──────────────────────────────────────────────────────────────
+
+    def add(
+        self,
+        title: str,
+        fire_at: datetime,
+        repeat: str = "none",
+        repeat_interval: int = 0,
+        trigger_place: Optional[str] = None,
+    ) -> int:
+        if repeat not in _REPEAT_MODES:
+            repeat = "none"
+        with self._lock:
+            cur = self._conn.execute(
+                """INSERT INTO reminders
+                       (title, fire_at, repeat, repeat_interval, created_at, trigger_place)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (
+                    title,
+                    fire_at.isoformat(),
+                    repeat,
+                    repeat_interval,
+                    datetime.now().isoformat(),
+                    trigger_place,
+                ),
+            )
+            return cur.lastrowid
+
+    def check_due(self) -> list[dict]:
+        now_iso = datetime.now().isoformat()
+        with self._lock:
+            rows = self._conn.execute(
+                """SELECT * FROM reminders
+                   WHERE fired = 0
+                     AND fire_at <= ?
+                     AND (snoozed_until IS NULL OR snoozed_until <= ?)
+                   ORDER BY fire_at""",
+                (now_iso, now_iso),
+            ).fetchall()
+            due = []
+            for row in rows:
+                item = dict(row)
+                due.append(item)
+                repeat = item["repeat"]
+                if repeat == "none":
+                    self._conn.execute(
+                        "UPDATE reminders SET fired = 1 WHERE id = ?",
+                        (item["id"],),
+                    )
+                else:
+                    next_fire = self._next_occurrence(
+                        datetime.fromisoformat(item["fire_at"]),
+                        repeat,
+                        item["repeat_interval"],
+                    )
+                    self._conn.execute(
+                        "UPDATE reminders SET fire_at = ?, snoozed_until = NULL WHERE id = ?",
+                        (next_fire.isoformat(), item["id"]),
+                    )
+            return due
+
+    def list_upcoming(self, limit: int = 10) -> list[dict]:
+        rows = self._conn.execute(
+            """SELECT * FROM reminders WHERE fired = 0
+               ORDER BY fire_at LIMIT ?""",
+            (limit,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    def list_all(self, limit: int = 20) -> list[dict]:
+        rows = self._conn.execute(
+            """SELECT * FROM reminders ORDER BY created_at DESC LIMIT ?""",
+            (limit,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    def cancel(self, reminder_id: int) -> bool:
+        with self._lock:
+            cur = self._conn.execute(
+                "DELETE FROM reminders WHERE id = ?", (reminder_id,)
+            )
+            return cur.rowcount > 0
+
+    def cancel_by_title(self, title: str) -> int:
+        with self._lock:
+            cur = self._conn.execute(
+                "DELETE FROM reminders WHERE lower(title) = lower(?)", (title,)
+            )
+            return cur.rowcount
+
+    def snooze(self, reminder_id: int, minutes: int = 10) -> bool:
+        until = datetime.now() + timedelta(minutes=minutes)
+        with self._lock:
+            cur = self._conn.execute(
+                "UPDATE reminders SET snoozed_until = ?, fired = 0 WHERE id = ?",
+                (until.isoformat(), reminder_id),
+            )
+            return cur.rowcount > 0
+
+    def due_today(self) -> list[dict]:
+        today_start = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+        today_end = today_start + timedelta(days=1)
+        rows = self._conn.execute(
+            """SELECT * FROM reminders
+               WHERE fired = 0 AND fire_at >= ? AND fire_at < ?
+               ORDER BY fire_at""",
+            (today_start.isoformat(), today_end.isoformat()),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    def check_place_due(self, place_key: str) -> list[dict]:
+        with self._lock:
+            rows = self._conn.execute(
+                """SELECT * FROM reminders
+                   WHERE fired = 0 AND trigger_place = ?
+                     AND (snoozed_until IS NULL OR snoozed_until <= ?)
+                   ORDER BY created_at""",
+                (place_key, datetime.now().isoformat()),
+            ).fetchall()
+            due = []
+            for row in rows:
+                item = dict(row)
+                due.append(item)
+                if item["repeat"] == "none":
+                    self._conn.execute(
+                        "UPDATE reminders SET fired = 1 WHERE id = ?",
+                        (item["id"],),
+                    )
+            return due
+
+    def count_active(self) -> int:
+        row = self._conn.execute(
+            "SELECT COUNT(*) FROM reminders WHERE fired = 0"
+        ).fetchone()
+        return row[0] if row else 0
+
+    # ── internal ──────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _next_occurrence(current: datetime, repeat: str, interval: int) -> datetime:
+        if repeat == "daily":
+            return current + timedelta(days=1)
+        elif repeat == "weekly":
+            return current + timedelta(weeks=1)
+        elif repeat == "weekdays":
+            nxt = current + timedelta(days=1)
+            while nxt.weekday() >= 5:
+                nxt += timedelta(days=1)
+            return nxt
+        elif repeat == "custom" and interval > 0:
+            return current + timedelta(seconds=interval)
+        return current + timedelta(days=1)

--- a/src/bantz/data/store.py
+++ b/src/bantz/data/store.py
@@ -1,0 +1,265 @@
+"""
+Bantz v3 — Abstract Store Interfaces
+
+Every data backend implements one or more of these contracts.
+Brain and services never touch sqlite3/json directly — they go through these.
+
+Hierarchy:
+    ConversationStore — messages & sessions      (SQLite)
+    ReminderStore     — scheduled reminders      (SQLite)
+    ProfileStore      — user identity/prefs      (JSON → SQLite later)
+    PlaceStore        — named GPS locations      (JSON → SQLite later)
+    ScheduleStore     — weekly timetable         (JSON → SQLite later)
+    SessionStore      — launch tracking          (JSON → SQLite later)
+    GraphStore        — knowledge graph          (Neo4j)
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Optional
+
+
+# ━━ Conversation / Message Store ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class ConversationStore(ABC):
+    """Conversation & message persistence (SQLite, etc.)."""
+
+    @abstractmethod
+    def init(self, db_path: Path) -> None:
+        """Open / create the database at *db_path*."""
+
+    @abstractmethod
+    def new_session(self) -> int:
+        """Start a new conversation. Returns session id."""
+
+    @abstractmethod
+    def resume_session(self, session_id: int) -> bool:
+        """Resume an existing session. Returns False if not found."""
+
+    @property
+    @abstractmethod
+    def session_id(self) -> Optional[int]:
+        """Current active session id, or None."""
+
+    @abstractmethod
+    def add(self, role: str, content: str, tool_used: Optional[str] = None) -> int:
+        """Persist a message. Returns message id."""
+
+    @abstractmethod
+    def context(self, n: int = 12) -> list[dict]:
+        """Last *n* messages as ``[{role, content}]`` for LLM context."""
+
+    @abstractmethod
+    def last_n(self, n: int = 20) -> list[dict]:
+        """Last *n* messages with full metadata."""
+
+    @abstractmethod
+    def search(self, query: str, limit: int = 10) -> list[dict]:
+        """Full-text search across all conversations."""
+
+    @abstractmethod
+    def search_by_date(self, date: datetime, limit: int = 20) -> list[dict]:
+        """Messages from a specific date."""
+
+    @abstractmethod
+    def conversation_list(self, limit: int = 20) -> list[dict]:
+        """Recent conversations with message counts."""
+
+    @abstractmethod
+    def stats(self) -> dict:
+        """DB statistics for diagnostics."""
+
+    @abstractmethod
+    def prune(self, keep_days: int = 90) -> int:
+        """Delete old conversations. Returns count deleted."""
+
+    @abstractmethod
+    def close(self) -> None:
+        """Close the database connection."""
+
+
+# ━━ Reminder Store ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class ReminderStore(ABC):
+    """Reminder & task persistence (SQLite, etc.)."""
+
+    @abstractmethod
+    def init(self, db_path: Path) -> None:
+        """Open / create the database at *db_path*."""
+
+    @abstractmethod
+    def add(
+        self,
+        title: str,
+        fire_at: datetime,
+        repeat: str = "none",
+        repeat_interval: int = 0,
+        trigger_place: Optional[str] = None,
+    ) -> int:
+        """Create a reminder. Returns reminder id."""
+
+    @abstractmethod
+    def check_due(self) -> list[dict]:
+        """Return and advance all due reminders."""
+
+    @abstractmethod
+    def list_upcoming(self, limit: int = 10) -> list[dict]:
+        """Upcoming (unfired) reminders sorted by fire_at."""
+
+    @abstractmethod
+    def list_all(self, limit: int = 20) -> list[dict]:
+        """All reminders (including fired), newest first."""
+
+    @abstractmethod
+    def cancel(self, reminder_id: int) -> bool:
+        """Delete by id. Returns True if found."""
+
+    @abstractmethod
+    def cancel_by_title(self, title: str) -> int:
+        """Delete all matching title. Returns count."""
+
+    @abstractmethod
+    def snooze(self, reminder_id: int, minutes: int = 10) -> bool:
+        """Snooze a reminder. Returns True if found."""
+
+    @abstractmethod
+    def due_today(self) -> list[dict]:
+        """Reminders due today (for briefing)."""
+
+    @abstractmethod
+    def check_place_due(self, place_key: str) -> list[dict]:
+        """Location-triggered reminders for a place."""
+
+    @abstractmethod
+    def count_active(self) -> int:
+        """Count unfired reminders."""
+
+
+# ━━ Profile Store ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class ProfileStore(ABC):
+    """User profile persistence."""
+
+    @abstractmethod
+    def load(self) -> dict[str, Any]:
+        """Read the full profile dict."""
+
+    @abstractmethod
+    def save(self, data: dict[str, Any]) -> None:
+        """Write the profile dict."""
+
+    @abstractmethod
+    def exists(self) -> bool:
+        """Does a saved profile exist?"""
+
+    @property
+    @abstractmethod
+    def path(self) -> Path:
+        """Filesystem path (for diagnostics / --doctor)."""
+
+
+# ━━ Place Store ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class PlaceStore(ABC):
+    """Named-places persistence."""
+
+    @abstractmethod
+    def load_all(self) -> dict[str, dict]:
+        """Read all places {key: {label, lat, lon, radius}}."""
+
+    @abstractmethod
+    def save_all(self, data: dict[str, dict]) -> None:
+        """Write all places."""
+
+    @abstractmethod
+    def exists(self) -> bool:
+        """Does a saved places file exist?"""
+
+    @property
+    @abstractmethod
+    def path(self) -> Path:
+        """Filesystem path."""
+
+
+# ━━ Schedule Store ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class ScheduleStore(ABC):
+    """Weekly timetable persistence."""
+
+    @abstractmethod
+    def load(self) -> dict[str, list[dict]]:
+        """Read weekly schedule {monday: [{name, time, ...}], ...}."""
+
+    @abstractmethod
+    def save(self, data: dict[str, list[dict]]) -> None:
+        """Write weekly schedule."""
+
+    @abstractmethod
+    def exists(self) -> bool:
+        """Does a saved schedule exist?"""
+
+    @property
+    @abstractmethod
+    def path(self) -> Path:
+        """Filesystem path."""
+
+
+# ━━ Session Store ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class SessionStore(ABC):
+    """Launch-tracking session persistence (absence detection)."""
+
+    @abstractmethod
+    def load(self) -> dict:
+        """Read session data {last_seen, session_count}."""
+
+    @abstractmethod
+    def save(self, data: dict) -> None:
+        """Write session data."""
+
+    @property
+    @abstractmethod
+    def path(self) -> Path:
+        """Filesystem path."""
+
+
+# ━━ Graph Store ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class GraphStore(ABC):
+    """Knowledge-graph persistence (Neo4j or similar)."""
+
+    @abstractmethod
+    async def init(self) -> bool:
+        """Connect to graph DB. Returns True on success."""
+
+    @abstractmethod
+    async def close(self) -> None:
+        """Disconnect from graph DB."""
+
+    @property
+    @abstractmethod
+    def enabled(self) -> bool:
+        """Is the graph store connected and usable?"""
+
+    @abstractmethod
+    async def extract_and_store(
+        self,
+        user_msg: str,
+        assistant_msg: str,
+        tool_used: Optional[str] = None,
+        tool_data: Optional[dict] = None,
+    ) -> None:
+        """Extract entities from an exchange and persist them."""
+
+    @abstractmethod
+    async def context_for(self, user_msg: str) -> str:
+        """Return graph context string relevant to the user message."""

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,529 @@
+"""
+Tests for the Bantz v3 Data Access Layer (Issue #115).
+
+Covers:
+    - Pydantic data models
+    - SQLiteConversationStore
+    - SQLiteReminderStore
+    - JSON file stores (profile, places, schedule, session)
+    - Migration utility (validate + migrate)
+    - DataLayer integration
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from bantz.data.models import (
+    Conversation,
+    Message,
+    Place,
+    Reminder,
+    ScheduleEntry,
+    SessionInfo,
+    UserProfile,
+)
+from bantz.data.sqlite_store import SQLiteConversationStore, SQLiteReminderStore
+from bantz.data.json_store import (
+    JSONPlaceStore,
+    JSONProfileStore,
+    JSONScheduleStore,
+    JSONSessionStore,
+)
+from bantz.data.migration import migrate_to_sqlite, validate_json_files
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def tmp_dir(tmp_path: Path) -> Path:
+    return tmp_path
+
+
+@pytest.fixture
+def db_path(tmp_dir: Path) -> Path:
+    return tmp_dir / "test.db"
+
+
+@pytest.fixture
+def conv_store(db_path: Path) -> SQLiteConversationStore:
+    store = SQLiteConversationStore()
+    store.init(db_path)
+    store.new_session()
+    return store
+
+
+@pytest.fixture
+def reminder_store(db_path: Path) -> SQLiteReminderStore:
+    store = SQLiteReminderStore()
+    store.init(db_path)
+    return store
+
+
+# ━━ Model Tests ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class TestModels:
+    def test_message_defaults(self):
+        m = Message(role="user", content="hello")
+        assert m.id == 0
+        assert m.role == "user"
+        assert m.content == "hello"
+        assert m.tool_used is None
+        assert isinstance(m.created_at, datetime)
+
+    def test_conversation_defaults(self):
+        c = Conversation()
+        assert c.id == 0
+        assert c.message_count == 0
+
+    def test_reminder_model(self):
+        r = Reminder(title="call dentist", fire_at=datetime(2026, 3, 10, 15, 0))
+        assert r.repeat == "none"
+        assert r.fired is False
+        assert r.trigger_place is None
+
+    def test_place_model(self):
+        p = Place(key="dorm", label="Yurt")
+        assert p.radius == 100.0
+        assert p.lat == 0.0
+
+    def test_schedule_entry_model(self):
+        e = ScheduleEntry(name="Makine Öğrenmesi", time="10:00")
+        assert e.duration == 60
+        assert e.location == ""
+
+    def test_user_profile_model(self):
+        u = UserProfile(name="Iclal", university="OMU")
+        assert u.pronoun == "casual"
+        assert u.preferences == {}
+
+    def test_session_info_model(self):
+        s = SessionInfo()
+        assert s.is_first is False
+        assert s.session_count == 0
+
+    def test_message_serialization(self):
+        m = Message(role="assistant", content="hi", tool_used="weather")
+        d = m.model_dump()
+        assert d["role"] == "assistant"
+        assert d["tool_used"] == "weather"
+
+
+# ━━ SQLite Conversation Store ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class TestSQLiteConversationStore:
+    def test_new_session(self, conv_store: SQLiteConversationStore):
+        sid = conv_store.session_id
+        assert sid is not None
+        assert sid > 0
+
+    def test_add_and_context(self, conv_store: SQLiteConversationStore):
+        conv_store.add("user", "hello")
+        conv_store.add("assistant", "hi there", tool_used="chat")
+        ctx = conv_store.context(n=10)
+        assert len(ctx) == 2
+        assert ctx[0]["role"] == "user"
+        assert ctx[0]["content"] == "hello"
+        assert ctx[1]["role"] == "assistant"
+
+    def test_context_order(self, conv_store: SQLiteConversationStore):
+        """Messages returned in chronological order."""
+        conv_store.add("user", "first")
+        conv_store.add("assistant", "second")
+        conv_store.add("user", "third")
+        ctx = conv_store.context(n=10)
+        assert [m["content"] for m in ctx] == ["first", "second", "third"]
+
+    def test_context_limit(self, conv_store: SQLiteConversationStore):
+        for i in range(20):
+            conv_store.add("user", f"msg-{i}")
+        ctx = conv_store.context(n=5)
+        assert len(ctx) == 5
+
+    def test_last_n(self, conv_store: SQLiteConversationStore):
+        conv_store.add("user", "test1")
+        conv_store.add("assistant", "reply1", tool_used="weather")
+        msgs = conv_store.last_n(n=5)
+        assert len(msgs) == 2
+        assert "created_at" in msgs[0]
+        assert msgs[1]["tool_used"] == "weather"
+
+    def test_search(self, conv_store: SQLiteConversationStore):
+        conv_store.add("user", "unique_xyz_search_term")
+        conv_store.add("user", "something else")
+        results = conv_store.search("unique_xyz_search_term")
+        assert len(results) >= 1
+        assert "unique_xyz_search_term" in results[0]["content"]
+
+    def test_search_by_date(self, conv_store: SQLiteConversationStore):
+        conv_store.add("user", "today message")
+        results = conv_store.search_by_date(datetime.now())
+        assert len(results) >= 1
+
+    def test_conversation_list(self, conv_store: SQLiteConversationStore):
+        conv_store.add("user", "first msg in conv")
+        convs = conv_store.conversation_list()
+        assert len(convs) >= 1
+        assert convs[0]["message_count"] >= 1
+        assert convs[0]["first_message"] == "first msg in conv"
+
+    def test_stats(self, conv_store: SQLiteConversationStore):
+        conv_store.add("user", "stat test")
+        s = conv_store.stats()
+        assert s["total_messages"] >= 1
+        assert s["total_conversations"] >= 1
+        assert s["current_session_id"] is not None
+
+    def test_resume_session(self, conv_store: SQLiteConversationStore):
+        sid = conv_store.session_id
+        conv_store.add("user", "session msg")
+
+        new_sid = conv_store.new_session()
+        assert new_sid != sid
+
+        assert conv_store.resume_session(sid) is True
+        assert conv_store.session_id == sid
+
+    def test_resume_nonexistent(self, conv_store: SQLiteConversationStore):
+        assert conv_store.resume_session(99999) is False
+
+    def test_prune_keeps_recent(self, conv_store: SQLiteConversationStore):
+        conv_store.add("user", "recent msg")
+        deleted = conv_store.prune(keep_days=90)
+        assert deleted == 0  # session just created
+
+    def test_close_and_reopen(self, db_path: Path):
+        store = SQLiteConversationStore()
+        store.init(db_path)
+        store.new_session()
+        store.add("user", "persist test")
+        store.close()
+
+        store2 = SQLiteConversationStore()
+        store2.init(db_path)
+        results = store2.search("persist test")
+        assert len(results) >= 1
+        store2.close()
+
+    def test_auto_session_on_add(self, db_path: Path):
+        """If add() is called without new_session(), one is auto-created."""
+        store = SQLiteConversationStore()
+        store.init(db_path)
+        assert store.session_id is None
+        store.add("user", "auto session")
+        assert store.session_id is not None
+
+
+# ━━ SQLite Reminder Store ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class TestSQLiteReminderStore:
+    def test_add_reminder(self, reminder_store: SQLiteReminderStore):
+        rid = reminder_store.add("test remind", datetime.now() + timedelta(hours=1))
+        assert rid > 0
+
+    def test_list_upcoming(self, reminder_store: SQLiteReminderStore):
+        reminder_store.add("upcoming task", datetime.now() + timedelta(hours=1))
+        items = reminder_store.list_upcoming()
+        assert len(items) >= 1
+        assert items[0]["title"] == "upcoming task"
+
+    def test_check_due_marks_fired(self, reminder_store: SQLiteReminderStore):
+        reminder_store.add("overdue", datetime.now() - timedelta(hours=1))
+        due = reminder_store.check_due()
+        assert len(due) >= 1
+        assert due[0]["title"] == "overdue"
+        # Should be marked as fired — not in upcoming anymore
+        upcoming = reminder_store.list_upcoming()
+        assert not any(r["title"] == "overdue" for r in upcoming)
+
+    def test_cancel_by_id(self, reminder_store: SQLiteReminderStore):
+        rid = reminder_store.add("cancel me", datetime.now() + timedelta(hours=1))
+        assert reminder_store.cancel(rid) is True
+        assert reminder_store.cancel(rid) is False  # already gone
+
+    def test_cancel_by_title(self, reminder_store: SQLiteReminderStore):
+        reminder_store.add("dup title", datetime.now() + timedelta(hours=1))
+        reminder_store.add("dup title", datetime.now() + timedelta(hours=2))
+        count = reminder_store.cancel_by_title("dup title")
+        assert count == 2
+
+    def test_snooze(self, reminder_store: SQLiteReminderStore):
+        rid = reminder_store.add("snooze me", datetime.now() - timedelta(minutes=5))
+        assert reminder_store.snooze(rid, minutes=15) is True
+
+    def test_due_today(self, reminder_store: SQLiteReminderStore):
+        reminder_store.add("today task", datetime.now() + timedelta(hours=1))
+        today = reminder_store.due_today()
+        assert len(today) >= 1
+
+    def test_count_active(self, reminder_store: SQLiteReminderStore):
+        reminder_store.add("active1", datetime.now() + timedelta(hours=1))
+        reminder_store.add("active2", datetime.now() + timedelta(hours=2))
+        assert reminder_store.count_active() >= 2
+
+    def test_recurring_daily(self, reminder_store: SQLiteReminderStore):
+        fire = datetime.now() - timedelta(minutes=5)
+        reminder_store.add("daily check", fire, repeat="daily")
+        due = reminder_store.check_due()
+        assert len(due) >= 1
+        assert due[0]["title"] == "daily check"
+        # Should be rescheduled, not deleted
+        upcoming = reminder_store.list_upcoming()
+        assert any(r["title"] == "daily check" for r in upcoming)
+
+    def test_place_trigger(self, reminder_store: SQLiteReminderStore):
+        reminder_store.add(
+            "buy milk",
+            datetime.now() + timedelta(days=7),
+            trigger_place="market",
+        )
+        due = reminder_store.check_place_due("market")
+        assert len(due) >= 1
+        assert due[0]["title"] == "buy milk"
+
+    def test_list_all_includes_fired(self, reminder_store: SQLiteReminderStore):
+        reminder_store.add("past", datetime.now() - timedelta(hours=1))
+        reminder_store.check_due()  # marks as fired
+        all_items = reminder_store.list_all()
+        assert any(r["title"] == "past" for r in all_items)
+
+
+# ━━ JSON Store Tests ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class TestJSONProfileStore:
+    def test_save_and_load(self, tmp_dir: Path):
+        store = JSONProfileStore(tmp_dir)
+        store.save({"name": "Iclal", "university": "OMU"})
+        data = store.load()
+        assert data["name"] == "Iclal"
+        assert data["university"] == "OMU"
+
+    def test_exists(self, tmp_dir: Path):
+        store = JSONProfileStore(tmp_dir)
+        assert store.exists() is False
+        store.save({"name": "test"})
+        assert store.exists() is True
+
+    def test_empty_load(self, tmp_dir: Path):
+        store = JSONProfileStore(tmp_dir)
+        assert store.load() == {}
+
+    def test_path_property(self, tmp_dir: Path):
+        store = JSONProfileStore(tmp_dir)
+        assert store.path == tmp_dir / "profile.json"
+
+    def test_unicode_roundtrip(self, tmp_dir: Path):
+        store = JSONProfileStore(tmp_dir)
+        store.save({"name": "İclal", "department": "Bilgisayar Mühendisliği"})
+        data = store.load()
+        assert data["name"] == "İclal"
+
+
+class TestJSONPlaceStore:
+    def test_save_and_load(self, tmp_dir: Path):
+        store = JSONPlaceStore(tmp_dir)
+        data = {
+            "dorm": {"label": "Yurt", "lat": 41.27, "lon": 36.33, "radius": 100},
+            "campus": {"label": "Kampüs", "lat": 41.28, "lon": 36.34, "radius": 200},
+        }
+        store.save_all(data)
+        loaded = store.load_all()
+        assert "dorm" in loaded
+        assert loaded["dorm"]["lat"] == 41.27
+        assert len(loaded) == 2
+
+    def test_empty_load(self, tmp_dir: Path):
+        store = JSONPlaceStore(tmp_dir)
+        assert store.load_all() == {}
+
+    def test_overwrite(self, tmp_dir: Path):
+        store = JSONPlaceStore(tmp_dir)
+        store.save_all({"a": {"label": "A", "lat": 0, "lon": 0}})
+        store.save_all({"b": {"label": "B", "lat": 1, "lon": 1}})
+        loaded = store.load_all()
+        assert "a" not in loaded
+        assert "b" in loaded
+
+
+class TestJSONScheduleStore:
+    def test_save_and_load(self, tmp_dir: Path):
+        store = JSONScheduleStore(tmp_dir)
+        data = {
+            "monday": [
+                {"name": "Makine Öğrenmesi", "time": "10:00", "duration": 90},
+                {"name": "Veri Tabanı", "time": "14:00", "duration": 60},
+            ],
+            "wednesday": [
+                {"name": "Algoritma", "time": "09:00", "duration": 90},
+            ],
+        }
+        store.save(data)
+        loaded = store.load()
+        assert len(loaded["monday"]) == 2
+        assert loaded["wednesday"][0]["name"] == "Algoritma"
+
+    def test_empty_load(self, tmp_dir: Path):
+        store = JSONScheduleStore(tmp_dir)
+        assert store.load() == {}
+
+
+class TestJSONSessionStore:
+    def test_save_and_load(self, tmp_dir: Path):
+        store = JSONSessionStore(tmp_dir)
+        store.save({"last_seen": "2026-03-05T10:00:00", "session_count": 5})
+        loaded = store.load()
+        assert loaded["session_count"] == 5
+
+    def test_path_property(self, tmp_dir: Path):
+        store = JSONSessionStore(tmp_dir)
+        assert store.path == tmp_dir / "session.json"
+
+
+# ━━ Migration Tests ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class TestMigration:
+    def test_validate_json_files(self, tmp_dir: Path):
+        (tmp_dir / "profile.json").write_text('{"name": "Iclal"}')
+        (tmp_dir / "places.json").write_text('{"dorm": {"lat": 41.0}}')
+
+        report = validate_json_files(tmp_dir)
+        assert report["profile"]["status"] == "ok"
+        assert report["places"]["status"] == "ok"
+        assert report["schedule"]["status"] == "missing"
+        assert report["session"]["status"] == "missing"
+
+    def test_validate_corrupt_file(self, tmp_dir: Path):
+        (tmp_dir / "profile.json").write_text("{invalid json}")
+        report = validate_json_files(tmp_dir)
+        assert report["profile"]["status"] == "error"
+
+    def test_migrate_to_sqlite(self, tmp_dir: Path):
+        db_path = tmp_dir / "migrate.db"
+
+        (tmp_dir / "profile.json").write_text(
+            json.dumps({"name": "Iclal", "university": "OMU"})
+        )
+        (tmp_dir / "places.json").write_text(
+            json.dumps({"dorm": {"label": "Yurt", "lat": 41.0, "lon": 36.0}})
+        )
+        (tmp_dir / "schedule.json").write_text(
+            json.dumps(
+                {"monday": [{"name": "ML", "time": "10:00", "duration": 90}]}
+            )
+        )
+        (tmp_dir / "session.json").write_text(
+            json.dumps({"last_seen": "2026-03-05T10:00:00", "session_count": 5})
+        )
+
+        results = migrate_to_sqlite(db_path, tmp_dir)
+        assert results["profile"]["status"] == "ok"
+        assert results["places"]["status"] == "ok"
+        assert results["schedule"]["status"] == "ok"
+        assert results["session"]["status"] == "ok"
+
+        # Verify data actually landed in SQLite
+        import sqlite3
+
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+
+        # kv_store: profile
+        rows = conn.execute(
+            "SELECT * FROM kv_store WHERE namespace='profile'"
+        ).fetchall()
+        assert len(rows) >= 1
+        names = {r["key"] for r in rows}
+        assert "name" in names
+
+        # places table
+        rows = conn.execute("SELECT * FROM places").fetchall()
+        assert len(rows) == 1
+        assert dict(rows[0])["key"] == "dorm"
+
+        # schedule table
+        rows = conn.execute("SELECT * FROM schedule").fetchall()
+        assert len(rows) == 1
+        assert dict(rows[0])["name"] == "ML"
+
+        conn.close()
+
+    def test_dry_run_no_write(self, tmp_dir: Path):
+        db_path = tmp_dir / "dry.db"
+        (tmp_dir / "profile.json").write_text('{"name": "test"}')
+
+        results = migrate_to_sqlite(db_path, tmp_dir, dry_run=True)
+        assert results["profile"]["status"] == "ok"
+
+        # DB tables were created but no data
+        import sqlite3
+
+        conn = sqlite3.connect(str(db_path))
+        rows = conn.execute(
+            "SELECT * FROM kv_store WHERE namespace='profile'"
+        ).fetchall()
+        assert len(rows) == 0
+        conn.close()
+
+    def test_migrate_missing_files(self, tmp_dir: Path):
+        db_path = tmp_dir / "empty.db"
+        results = migrate_to_sqlite(db_path, tmp_dir)
+        assert results["profile"]["status"] == "skipped"
+        assert results["places"]["status"] == "skipped"
+
+
+# ━━ ABC Contract Tests ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class TestABCConformance:
+    """Verify that concrete implementations satisfy the ABC contracts."""
+
+    def test_sqlite_conversation_is_conversation_store(self):
+        from bantz.data.store import ConversationStore
+
+        assert issubclass(SQLiteConversationStore, ConversationStore)
+
+    def test_sqlite_reminder_is_reminder_store(self):
+        from bantz.data.store import ReminderStore
+
+        assert issubclass(SQLiteReminderStore, ReminderStore)
+
+    def test_json_profile_is_profile_store(self):
+        from bantz.data.store import ProfileStore
+
+        assert issubclass(JSONProfileStore, ProfileStore)
+
+    def test_json_place_is_place_store(self):
+        from bantz.data.store import PlaceStore
+
+        assert issubclass(JSONPlaceStore, PlaceStore)
+
+    def test_json_schedule_is_schedule_store(self):
+        from bantz.data.store import ScheduleStore
+
+        assert issubclass(JSONScheduleStore, ScheduleStore)
+
+    def test_json_session_is_session_store(self):
+        from bantz.data.store import SessionStore
+
+        assert issubclass(JSONSessionStore, SessionStore)
+
+    def test_memory_is_conversation_store(self):
+        from bantz.data.store import ConversationStore
+        from bantz.core.memory import Memory
+
+        assert issubclass(Memory, ConversationStore)
+
+    def test_scheduler_is_reminder_store(self):
+        from bantz.data.store import ReminderStore
+        from bantz.core.scheduler import Scheduler
+
+        assert issubclass(Scheduler, ReminderStore)


### PR DESCRIPTION
## Summary

Implements the unified Data Access Layer (DAL) as specified in #115.
This is the **foundation** for all other v3 issues.

## Architecture

```
Brain --> DataLayer (singleton)
              |-- ConversationStore  (SQLite via Memory)
              |-- ReminderStore      (SQLite via Scheduler)
              |-- ProfileStore       (JSON file)
              |-- PlaceStore         (JSON file)
              |-- ScheduleStore      (JSON file)
              |-- SessionStore       (JSON file)
              +-- GraphStore         (Neo4j, optional)
```

## New Files (7)

| File | Purpose | Lines |
|------|---------|-------|
| data/__init__.py | Package init, exports data_layer | 14 |
| data/models.py | Pydantic models: Message, Conversation, Reminder, Place, etc. | 98 |
| data/store.py | 7 Abstract Base Classes defining all store contracts | 265 |
| data/sqlite_store.py | Standalone SQLite implementations (conv + reminder) | 445 |
| data/json_store.py | JSON adapters (profile, places, schedule, session) | 135 |
| data/layer.py | DataLayer singleton composing all stores | 148 |
| data/migration.py | JSON to SQLite migration utility with CLI | 252 |

## Modified Files (3)

- core/memory.py: Memory(ConversationStore) inherits from ABC
- core/scheduler.py: Scheduler(ReminderStore) inherits from ABC
- core/brain.py: Uses data_layer.init(config) + data_layer.conversations

## Tests

**58 tests**, all passing:
- 8 model tests
- 14 SQLite conversation store tests
- 11 SQLite reminder store tests
- 13 JSON store tests
- 5 migration tests
- 7 ABC conformance tests (including Memory/Scheduler inheritance)

## Acceptance Criteria

- [x] brain.py never imports sqlite3 or json directly
- [x] All 7 JSON files can be optionally migrated to unified store
- [x] 58 tests in tests/test_store.py pass
- [x] Zero breaking changes for current users

Closes #115
