### PR TITLE
refactor(data): Migrate JSON file stores into unified DB schema — closes #117

### DIFF
--- a/src/bantz/core/places.py
+++ b/src/bantz/core/places.py
@@ -5,7 +5,7 @@ Known locations with labels — "dorm", "campus", "home", etc.
 Compare current GPS to known places.  Travel hints for schedule.
 Geofence detection, stationary tracking, proactive place-learning.
 
-Data: ~/.local/share/bantz/places.json
+Data stored via DAL (SQLite), with JSON fallback for backward compat.
 Setup: bantz --setup places
 
 Usage:
@@ -24,9 +24,12 @@ import math
 import time as _time
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from bantz.core.location import Location, location_service
+
+if TYPE_CHECKING:
+    from bantz.data.store import PlaceStore
 
 log = logging.getLogger("bantz.places")
 
@@ -53,6 +56,7 @@ class PlaceService:
     def __init__(self) -> None:
         self._data: dict[str, dict] = {}
         self._loaded = False
+        self._store: PlaceStore | None = None
 
         # ── Geofence / stationary state ──────────────────────────────
         self._current_place_key: Optional[str] = None
@@ -68,10 +72,17 @@ class PlaceService:
         # Location-triggered reminders that fired
         self._place_fired: list[dict] = []
 
+    def bind_store(self, store: PlaceStore) -> None:
+        """Bind a DAL store for persistence (called by DataLayer)."""
+        self._store = store
+        self._loaded = False  # force reload on next access
+
     def _load(self) -> None:
         if self._loaded:
             return
-        if PLACES_PATH.exists():
+        if self._store:
+            self._data = self._store.load_all()
+        elif PLACES_PATH.exists():
             try:
                 self._data = json.loads(PLACES_PATH.read_text(encoding="utf-8"))
             except Exception:
@@ -79,7 +90,7 @@ class PlaceService:
         self._loaded = True
 
     def reload(self) -> None:
-        """Force reload from disk (after --setup places)."""
+        """Force reload from store (after --setup places)."""
         self._loaded = False
         self._data = {}
         self._load()
@@ -310,12 +321,15 @@ class PlaceService:
         return False
 
     def _persist(self) -> None:
-        """Write current data to disk."""
-        PLACES_PATH.parent.mkdir(parents=True, exist_ok=True)
-        PLACES_PATH.write_text(
-            json.dumps(self._data, ensure_ascii=False, indent=2),
-            encoding="utf-8",
-        )
+        """Write current data to store or disk."""
+        if self._store:
+            self._store.save_all(self._data)
+        else:
+            PLACES_PATH.parent.mkdir(parents=True, exist_ok=True)
+            PLACES_PATH.write_text(
+                json.dumps(self._data, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
         self._loaded = True
 
     async def travel_hint(
@@ -375,11 +389,13 @@ class PlaceService:
         return dict(self._data)
 
     def save(self, data: dict[str, dict]) -> None:
-        """Write places to disk (used by --setup places)."""
+        """Write places to store (used by --setup places)."""
         self._data = data
         self._persist()
 
     def is_configured(self) -> bool:
+        if self._store:
+            return self._store.exists()
         return PLACES_PATH.exists()
 
     def status_line(self) -> str:

--- a/src/bantz/core/profile.py
+++ b/src/bantz/core/profile.py
@@ -1,7 +1,7 @@
 """
 Bantz v2 — User Profile
 
-Stores user identity and preferences in ~/.local/share/bantz/profile.json.
+Stores user identity and preferences via DAL (SQLite), with JSON fallback.
 Used by brain.py for personalized prompts, briefing.py for section filtering,
 time_context.py / butler.py for named greetings.
 
@@ -24,7 +24,10 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from bantz.data.store import ProfileStore as _ProfileStore
 
 
 _PROFILE_PATH = Path.home() / ".local" / "share" / "bantz" / "profile.json"
@@ -52,11 +55,21 @@ ALL_NEWS_SOURCES = ["hn", "google"]
 class Profile:
     def __init__(self) -> None:
         self._data: dict[str, Any] = {}
+        self._store: _ProfileStore | None = None
         self._load()
+
+    def bind_store(self, store: _ProfileStore) -> None:
+        """Bind a DAL store for persistence (called by DataLayer)."""
+        self._store = store
+        self._load()  # reload from new store
 
     # ── Persistence ───────────────────────────────────────────────────────
 
     def _load(self) -> None:
+        if self._store:
+            self._data = self._store.load()
+            return
+        # JSON fallback
         if _PROFILE_PATH.exists():
             try:
                 self._data = json.loads(_PROFILE_PATH.read_text("utf-8"))
@@ -66,7 +79,6 @@ class Profile:
             self._data = {}
 
     def save(self, data: dict[str, Any]) -> None:
-        _PROFILE_PATH.parent.mkdir(parents=True, exist_ok=True)
         merged = {**_DEFAULTS, **data}
         # Merge preferences sub-dict properly
         merged["preferences"] = {
@@ -74,6 +86,11 @@ class Profile:
             **data.get("preferences", {}),
         }
         self._data = merged
+        if self._store:
+            self._store.save(self._data)
+            return
+        # JSON fallback
+        _PROFILE_PATH.parent.mkdir(parents=True, exist_ok=True)
         _PROFILE_PATH.write_text(
             json.dumps(self._data, ensure_ascii=False, indent=2),
             encoding="utf-8",
@@ -112,6 +129,8 @@ class Profile:
 
     @property
     def path(self) -> Path:
+        if self._store:
+            return self._store.path
         return _PROFILE_PATH
 
     # ── Prompt helpers ────────────────────────────────────────────────────

--- a/src/bantz/core/schedule.py
+++ b/src/bantz/core/schedule.py
@@ -1,7 +1,6 @@
 """
 Bantz v2 — University Schedule
-Reads weekly timetable from ~/.local/share/bantz/schedule.json.
-No DB needed — static JSON, fast read.
+Reads weekly timetable via DAL (SQLite), with JSON fallback for backward compat.
 
 Schedule format:
 {
@@ -23,7 +22,10 @@ from __future__ import annotations
 import json
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from bantz.data.store import ScheduleStore
 
 
 SCHEDULE_PATH = Path.home() / ".local" / "share" / "bantz" / "schedule.json"
@@ -55,11 +57,19 @@ class Schedule:
     def __init__(self) -> None:
         self._data: dict = {}
         self._loaded = False
+        self._store: ScheduleStore | None = None
+
+    def bind_store(self, store: ScheduleStore) -> None:
+        """Bind a DAL store for persistence (called by DataLayer)."""
+        self._store = store
+        self._loaded = False  # force reload on next access
 
     def _load(self) -> None:
         if self._loaded:
             return
-        if SCHEDULE_PATH.exists():
+        if self._store:
+            self._data = self._store.load()
+        elif SCHEDULE_PATH.exists():
             try:
                 self._data = json.loads(SCHEDULE_PATH.read_text(encoding="utf-8"))
             except Exception:
@@ -203,6 +213,8 @@ class Schedule:
         return f"Next class: {emoji} {name}  {time}{loc_str}\n  ⏰ {when}"
 
     def is_configured(self) -> bool:
+        if self._store:
+            return self._store.exists()
         return SCHEDULE_PATH.exists()
 
     @staticmethod

--- a/src/bantz/core/session.py
+++ b/src/bantz/core/session.py
@@ -2,7 +2,7 @@
 Bantz v2 — Session Tracker
 
 Tracks launch timestamps for absence-aware greetings.
-Stores data in ~/.local/share/bantz/session.json.
+Stores data via DAL (SQLite), with JSON fallback for backward compat.
 
 Schema:
     {
@@ -15,13 +15,23 @@ from __future__ import annotations
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from bantz.data.store import SessionStore
 
 
 _SESSION_PATH = Path.home() / ".local" / "share" / "bantz" / "session.json"
 
 
 class SessionTracker:
+
+    def __init__(self) -> None:
+        self._store: SessionStore | None = None
+
+    def bind_store(self, store: SessionStore) -> None:
+        """Bind a DAL store for persistence (called by DataLayer)."""
+        self._store = store
 
     def on_launch(self) -> dict[str, Any]:
         """
@@ -78,6 +88,9 @@ class SessionTracker:
     # ── Persistence ───────────────────────────────────────────────────────
 
     def _load(self) -> dict:
+        if self._store:
+            return self._store.load()
+        # JSON fallback (pre-migration or standalone usage)
         if _SESSION_PATH.exists():
             try:
                 return json.loads(_SESSION_PATH.read_text("utf-8"))
@@ -86,6 +99,10 @@ class SessionTracker:
         return {}
 
     def _save(self, data: dict) -> None:
+        if self._store:
+            self._store.save(data)
+            return
+        # JSON fallback
         _SESSION_PATH.parent.mkdir(parents=True, exist_ok=True)
         _SESSION_PATH.write_text(
             json.dumps(data, ensure_ascii=False, indent=2),
@@ -94,6 +111,8 @@ class SessionTracker:
 
     @property
     def path(self) -> Path:
+        if self._store:
+            return self._store.path
         return _SESSION_PATH
 
 

--- a/src/bantz/data/layer.py
+++ b/src/bantz/data/layer.py
@@ -12,9 +12,13 @@ Initialized once during app startup — replaces scattered init() calls.
 At runtime the DataLayer wires the existing ``Memory`` and ``Scheduler``
 singletons (which now inherit from the ABCs) so that every module in the
 codebase — old or new — shares the same connections and session.
+
+Profile, places, schedule, and session now go through SQLite stores
+(migrated from JSON on first launch).
 """
 from __future__ import annotations
 
+import json
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
@@ -34,6 +38,12 @@ from bantz.data.json_store import (
     JSONScheduleStore,
     JSONSessionStore,
 )
+from bantz.data.sqlite_store import (
+    SQLitePlaceStore,
+    SQLiteProfileStore,
+    SQLiteScheduleStore,
+    SQLiteSessionStore,
+)
 
 if TYPE_CHECKING:
     from bantz.config import Config
@@ -47,10 +57,10 @@ class DataLayer:
     Attributes:
         conversations — messages & sessions      (SQLite via Memory)
         reminders     — scheduled reminders      (SQLite via Scheduler)
-        profile       — user identity/prefs      (JSON file)
-        places        — named GPS locations      (JSON file)
-        schedule      — weekly timetable         (JSON file)
-        session       — launch tracking          (JSON file)
+        profile       — user identity/prefs      (SQLite, auto-migrated from JSON)
+        places        — named GPS locations      (SQLite, auto-migrated from JSON)
+        schedule      — weekly timetable         (SQLite, auto-migrated from JSON)
+        session       — launch tracking          (SQLite, auto-migrated from JSON)
         graph         — knowledge graph          (Neo4j, optional)
     """
 
@@ -71,7 +81,8 @@ class DataLayer:
 
         Wires the existing ``Memory`` and ``Scheduler`` singletons so that
         they serve double duty as the DAL conversation/reminder stores.
-        JSON stores are created fresh for profile, places, schedule, session.
+        SQLite stores are created for profile, places, schedule, session,
+        with automatic migration from JSON on first run.
         """
         if self._initialized:
             return
@@ -90,19 +101,92 @@ class DataLayer:
         self.conversations = memory  # Memory IS-A ConversationStore
         self.reminders = scheduler  # Scheduler IS-A ReminderStore
 
-        # ── JSON stores ──────────────────────────────────────────────────
+        # ── SQLite stores for profile / places / schedule / session ──────
+        self.profile = SQLiteProfileStore(cfg.db_path)
+        self.places = SQLitePlaceStore(cfg.db_path)
+        self.schedule = SQLiteScheduleStore(cfg.db_path)
+        self.session = SQLiteSessionStore(cfg.db_path)
+
+        # ── Auto-migrate JSON → SQLite if tables are empty ───────────────
         base_dir = (
             Path(cfg.data_dir)
             if cfg.data_dir
             else Path.home() / ".local" / "share" / "bantz"
         )
-        self.profile = JSONProfileStore(base_dir)
-        self.places = JSONPlaceStore(base_dir)
-        self.schedule = JSONScheduleStore(base_dir)
-        self.session = JSONSessionStore(base_dir)
+        self._auto_migrate_json(base_dir)
+
+        # ── Bind stores to core singletons ───────────────────────────────
+        from bantz.core.session import session_tracker
+        from bantz.core.profile import profile
+        from bantz.core.places import places
+        from bantz.core.schedule import schedule
+
+        session_tracker.bind_store(self.session)
+        profile.bind_store(self.profile)
+        places.bind_store(self.places)
+        schedule.bind_store(self.schedule)
 
         self._initialized = True
         log.info("DataLayer initialized  db=%s  data=%s", cfg.db_path, base_dir)
+
+    def _auto_migrate_json(self, base_dir: Path) -> None:
+        """Silently import JSON data into SQLite if tables are empty.
+
+        Ensures seamless upgrade for existing v2 users.
+        """
+        migrated = []
+
+        # ── profile.json → user_profile table ────────────────────────────
+        if not self.profile.exists():
+            pf = base_dir / "profile.json"
+            if pf.exists():
+                try:
+                    data = json.loads(pf.read_text("utf-8"))
+                    if data:
+                        self.profile.save(data)
+                        migrated.append("profile")
+                except Exception as exc:
+                    log.warning("Auto-migrate profile.json failed: %s", exc)
+
+        # ── places.json → places table ───────────────────────────────────
+        if not self.places.exists():
+            pf = base_dir / "places.json"
+            if pf.exists():
+                try:
+                    data = json.loads(pf.read_text("utf-8"))
+                    if data:
+                        self.places.save_all(data)
+                        migrated.append("places")
+                except Exception as exc:
+                    log.warning("Auto-migrate places.json failed: %s", exc)
+
+        # ── schedule.json → schedule_entries table ───────────────────────
+        if not self.schedule.exists():
+            pf = base_dir / "schedule.json"
+            if pf.exists():
+                try:
+                    data = json.loads(pf.read_text("utf-8"))
+                    if data:
+                        self.schedule.save(data)
+                        migrated.append("schedule")
+                except Exception as exc:
+                    log.warning("Auto-migrate schedule.json failed: %s", exc)
+
+        # ── session.json → session_state table ───────────────────────────
+        sess_data = self.session.load()
+        if not sess_data:
+            pf = base_dir / "session.json"
+            if pf.exists():
+                try:
+                    data = json.loads(pf.read_text("utf-8"))
+                    if data:
+                        self.session.save(data)
+                        migrated.append("session")
+                except Exception as exc:
+                    log.warning("Auto-migrate session.json failed: %s", exc)
+
+        if migrated:
+            log.info("Auto-migrated JSON → SQLite: %s", ", ".join(migrated))
 
     async def init_graph(self) -> None:
         """Initialize the optional graph store (Neo4j).

--- a/src/bantz/data/migration.py
+++ b/src/bantz/data/migration.py
@@ -1,10 +1,10 @@
 """
 Bantz v3 — Data Migration Utility
 
-Validates existing v2 JSON data files and optionally imports them into
-a unified SQLite schema.  Use this when moving to an all-SQLite backend.
+Validates existing v2 JSON data files and imports them into the unified
+SQLite schema.  Runs automatically on first launch (via DataLayer) or
+manually via CLI:
 
-CLI usage (future):
     python -m bantz.data.migration --validate
     python -m bantz.data.migration --migrate
     python -m bantz.data.migration --migrate --dry-run
@@ -62,12 +62,10 @@ def validate_json_files(data_dir: Path = DEFAULT_DATA_DIR) -> dict[str, Any]:
 
 
 _UNIFIED_SCHEMA = """\
-CREATE TABLE IF NOT EXISTS kv_store (
-    namespace  TEXT NOT NULL,
-    key        TEXT NOT NULL,
+CREATE TABLE IF NOT EXISTS user_profile (
+    key        TEXT PRIMARY KEY,
     value      TEXT NOT NULL,
-    updated_at TEXT NOT NULL,
-    PRIMARY KEY (namespace, key)
+    updated_at TEXT NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS places (
@@ -78,7 +76,7 @@ CREATE TABLE IF NOT EXISTS places (
     radius REAL NOT NULL DEFAULT 100.0
 );
 
-CREATE TABLE IF NOT EXISTS schedule (
+CREATE TABLE IF NOT EXISTS schedule_entries (
     day      TEXT NOT NULL,
     idx      INTEGER NOT NULL,
     name     TEXT NOT NULL,
@@ -87,6 +85,12 @@ CREATE TABLE IF NOT EXISTS schedule (
     location TEXT DEFAULT '',
     type     TEXT DEFAULT '',
     PRIMARY KEY (day, idx)
+);
+
+CREATE TABLE IF NOT EXISTS session_state (
+    key        TEXT PRIMARY KEY,
+    value      TEXT NOT NULL,
+    updated_at TEXT NOT NULL
 );
 """
 
@@ -114,11 +118,11 @@ def migrate_to_sqlite(
     # Create unified tables
     conn.executescript(_UNIFIED_SCHEMA)
 
-    # ── profile → kv_store ────────────────────────────────────────────
-    _migrate_kv(conn, data_dir / "profile.json", "profile", results, dry_run)
+    # ── profile → user_profile ────────────────────────────────────────
+    _migrate_kv(conn, data_dir / "profile.json", "user_profile", results, dry_run)
 
-    # ── session → kv_store ────────────────────────────────────────────
-    _migrate_kv(conn, data_dir / "session.json", "session", results, dry_run)
+    # ── session → session_state ───────────────────────────────────────
+    _migrate_kv(conn, data_dir / "session.json", "session_state", results, dry_run)
 
     # ── places → places table ─────────────────────────────────────────
     places_path = data_dir / "places.json"
@@ -148,7 +152,7 @@ def migrate_to_sqlite(
     else:
         results["places"] = {"status": "skipped", "reason": "file not found"}
 
-    # ── schedule → schedule table ─────────────────────────────────────
+    # ── schedule → schedule_entries table ─────────────────────────────
     schedule_path = data_dir / "schedule.json"
     if schedule_path.exists():
         try:
@@ -158,7 +162,7 @@ def migrate_to_sqlite(
                 for day, entries in data.items():
                     for idx, entry in enumerate(entries):
                         conn.execute(
-                            """INSERT OR REPLACE INTO schedule
+                            """INSERT OR REPLACE INTO schedule_entries
                                    (day, idx, name, time, duration, location, type)
                                VALUES (?, ?, ?, ?, ?, ?, ?)""",
                             (
@@ -191,13 +195,15 @@ def migrate_to_sqlite(
 def _migrate_kv(
     conn: sqlite3.Connection,
     json_path: Path,
-    namespace: str,
+    table_name: str,
     results: dict,
     dry_run: bool,
 ) -> None:
-    """Migrate a flat JSON file into the kv_store table."""
+    """Migrate a flat JSON file into a key/value table."""
+    # Derive a friendly name from the table name
+    name = table_name.replace("user_", "").replace("_state", "")
     if not json_path.exists():
-        results[namespace] = {"status": "skipped", "reason": "file not found"}
+        results[name] = {"status": "skipped", "reason": "file not found"}
         return
     try:
         data = json.loads(json_path.read_text("utf-8"))
@@ -205,13 +211,13 @@ def _migrate_kv(
         if not dry_run:
             for k, v in data.items():
                 conn.execute(
-                    """INSERT OR REPLACE INTO kv_store(namespace, key, value, updated_at)
-                       VALUES (?, ?, ?, ?)""",
-                    (namespace, k, json.dumps(v, ensure_ascii=False), now),
+                    f"""INSERT OR REPLACE INTO {table_name}(key, value, updated_at)
+                       VALUES (?, ?, ?)""",
+                    (k, json.dumps(v, ensure_ascii=False), now),
                 )
-        results[namespace] = {"migrated": len(data), "status": "ok"}
+        results[name] = {"migrated": len(data), "status": "ok"}
     except Exception as exc:
-        results[namespace] = {"status": "error", "error": str(exc)}
+        results[name] = {"status": "error", "error": str(exc)}
 
 
 # ━━ CLI entry point ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/src/bantz/data/sqlite_store.py
+++ b/src/bantz/data/sqlite_store.py
@@ -11,14 +11,22 @@ DataLayer wires the existing ``Memory`` and ``Scheduler`` singletons
 """
 from __future__ import annotations
 
+import json
 import logging
 import sqlite3
 import threading
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
-from bantz.data.store import ConversationStore, ReminderStore
+from bantz.data.store import (
+    ConversationStore,
+    PlaceStore,
+    ProfileStore,
+    ReminderStore,
+    ScheduleStore,
+    SessionStore,
+)
 
 log = logging.getLogger("bantz.data.sqlite")
 
@@ -443,3 +451,262 @@ class SQLiteReminderStore(ReminderStore):
         elif repeat == "custom" and interval > 0:
             return current + timedelta(seconds=interval)
         return current + timedelta(days=1)
+
+
+# ━━ Profile Store (SQLite) ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class SQLiteProfileStore(ProfileStore):
+    """SQLite-backed profile store — key/value table for user identity."""
+
+    def __init__(self, db_path: Path) -> None:
+        self._db_path = db_path
+        self._conn = _connect(db_path)
+        self._lock = threading.Lock()
+        self._create_tables()
+
+    def _create_tables(self) -> None:
+        self._conn.execute("""
+            CREATE TABLE IF NOT EXISTS user_profile (
+                key        TEXT PRIMARY KEY,
+                value      TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )
+        """)
+
+    def load(self) -> dict[str, Any]:
+        rows = self._conn.execute(
+            "SELECT key, value FROM user_profile"
+        ).fetchall()
+        result: dict[str, Any] = {}
+        for row in rows:
+            try:
+                result[row["key"]] = json.loads(row["value"])
+            except (json.JSONDecodeError, TypeError):
+                result[row["key"]] = row["value"]
+        return result
+
+    def save(self, data: dict[str, Any]) -> None:
+        now = _now()
+        with self._lock:
+            self._conn.execute("DELETE FROM user_profile")
+            for k, v in data.items():
+                self._conn.execute(
+                    "INSERT INTO user_profile(key, value, updated_at) VALUES (?,?,?)",
+                    (k, json.dumps(v, ensure_ascii=False), now),
+                )
+
+    def exists(self) -> bool:
+        row = self._conn.execute(
+            "SELECT COUNT(*) FROM user_profile"
+        ).fetchone()
+        return row[0] > 0
+
+    @property
+    def path(self) -> Path:
+        return self._db_path
+
+
+# ━━ Place Store (SQLite) ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class SQLitePlaceStore(PlaceStore):
+    """SQLite-backed place store — named GPS locations."""
+
+    def __init__(self, db_path: Path) -> None:
+        self._db_path = db_path
+        self._conn = _connect(db_path)
+        self._lock = threading.Lock()
+        self._create_tables()
+
+    def _create_tables(self) -> None:
+        self._conn.execute("""
+            CREATE TABLE IF NOT EXISTS places (
+                key    TEXT PRIMARY KEY,
+                label  TEXT NOT NULL,
+                lat    REAL NOT NULL DEFAULT 0.0,
+                lon    REAL NOT NULL DEFAULT 0.0,
+                radius REAL NOT NULL DEFAULT 100.0
+            )
+        """)
+
+    def load_all(self) -> dict[str, dict]:
+        rows = self._conn.execute(
+            "SELECT key, label, lat, lon, radius FROM places"
+        ).fetchall()
+        return {
+            row["key"]: {
+                "label": row["label"],
+                "lat": row["lat"],
+                "lon": row["lon"],
+                "radius": row["radius"],
+            }
+            for row in rows
+        }
+
+    def save_all(self, data: dict[str, dict]) -> None:
+        with self._lock:
+            self._conn.execute("DELETE FROM places")
+            for key, place in data.items():
+                self._conn.execute(
+                    "INSERT INTO places(key, label, lat, lon, radius) VALUES (?,?,?,?,?)",
+                    (
+                        key,
+                        place.get("label", key),
+                        place.get("lat", 0.0),
+                        place.get("lon", 0.0),
+                        place.get("radius", 100.0),
+                    ),
+                )
+
+    def upsert(self, key: str, place: dict) -> None:
+        """Insert or update a single place."""
+        with self._lock:
+            self._conn.execute(
+                """INSERT OR REPLACE INTO places(key, label, lat, lon, radius)
+                   VALUES (?,?,?,?,?)""",
+                (
+                    key,
+                    place.get("label", key),
+                    place.get("lat", 0.0),
+                    place.get("lon", 0.0),
+                    place.get("radius", 100.0),
+                ),
+            )
+
+    def delete(self, key: str) -> bool:
+        """Delete a single place. Returns True if it existed."""
+        with self._lock:
+            cur = self._conn.execute("DELETE FROM places WHERE key = ?", (key,))
+            return cur.rowcount > 0
+
+    def exists(self) -> bool:
+        row = self._conn.execute(
+            "SELECT COUNT(*) FROM places"
+        ).fetchone()
+        return row[0] > 0
+
+    @property
+    def path(self) -> Path:
+        return self._db_path
+
+
+# ━━ Schedule Store (SQLite) ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class SQLiteScheduleStore(ScheduleStore):
+    """SQLite-backed schedule store — weekly timetable."""
+
+    def __init__(self, db_path: Path) -> None:
+        self._db_path = db_path
+        self._conn = _connect(db_path)
+        self._lock = threading.Lock()
+        self._create_tables()
+
+    def _create_tables(self) -> None:
+        self._conn.execute("""
+            CREATE TABLE IF NOT EXISTS schedule_entries (
+                day      TEXT NOT NULL,
+                idx      INTEGER NOT NULL,
+                name     TEXT NOT NULL,
+                time     TEXT NOT NULL,
+                duration INTEGER NOT NULL DEFAULT 60,
+                location TEXT DEFAULT '',
+                type     TEXT DEFAULT '',
+                PRIMARY KEY (day, idx)
+            )
+        """)
+
+    def load(self) -> dict[str, list[dict]]:
+        rows = self._conn.execute(
+            "SELECT day, idx, name, time, duration, location, type "
+            "FROM schedule_entries ORDER BY day, idx"
+        ).fetchall()
+        result: dict[str, list[dict]] = {}
+        for row in rows:
+            entry = {
+                "name": row["name"],
+                "time": row["time"],
+                "duration": row["duration"],
+                "location": row["location"],
+                "type": row["type"],
+            }
+            result.setdefault(row["day"], []).append(entry)
+        return result
+
+    def save(self, data: dict[str, list[dict]]) -> None:
+        with self._lock:
+            self._conn.execute("DELETE FROM schedule_entries")
+            for day, entries in data.items():
+                for idx, entry in enumerate(entries):
+                    self._conn.execute(
+                        """INSERT INTO schedule_entries
+                           (day, idx, name, time, duration, location, type)
+                           VALUES (?,?,?,?,?,?,?)""",
+                        (
+                            day, idx,
+                            entry.get("name", ""),
+                            entry.get("time", ""),
+                            entry.get("duration", 60),
+                            entry.get("location", ""),
+                            entry.get("type", ""),
+                        ),
+                    )
+
+    def exists(self) -> bool:
+        row = self._conn.execute(
+            "SELECT COUNT(*) FROM schedule_entries"
+        ).fetchone()
+        return row[0] > 0
+
+    @property
+    def path(self) -> Path:
+        return self._db_path
+
+
+# ━━ Session Store (SQLite) ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class SQLiteSessionStore(SessionStore):
+    """SQLite-backed session state — launch tracking key/value."""
+
+    def __init__(self, db_path: Path) -> None:
+        self._db_path = db_path
+        self._conn = _connect(db_path)
+        self._lock = threading.Lock()
+        self._create_tables()
+
+    def _create_tables(self) -> None:
+        self._conn.execute("""
+            CREATE TABLE IF NOT EXISTS session_state (
+                key        TEXT PRIMARY KEY,
+                value      TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )
+        """)
+
+    def load(self) -> dict:
+        rows = self._conn.execute(
+            "SELECT key, value FROM session_state"
+        ).fetchall()
+        result: dict = {}
+        for row in rows:
+            try:
+                result[row["key"]] = json.loads(row["value"])
+            except (json.JSONDecodeError, TypeError):
+                result[row["key"]] = row["value"]
+        return result
+
+    def save(self, data: dict) -> None:
+        now = _now()
+        with self._lock:
+            self._conn.execute("DELETE FROM session_state")
+            for k, v in data.items():
+                self._conn.execute(
+                    "INSERT INTO session_state(key, value, updated_at) VALUES (?,?,?)",
+                    (k, json.dumps(v, ensure_ascii=False), now),
+                )
+
+    @property
+    def path(self) -> Path:
+        return self._db_path

--- a/tests/test_json_migration.py
+++ b/tests/test_json_migration.py
@@ -1,0 +1,626 @@
+"""
+Tests for Issue #117 — Migrate JSON file stores into unified DB schema.
+
+Covers:
+    - SQLiteProfileStore CRUD ops
+    - SQLitePlaceStore CRUD ops (incl. upsert/delete)
+    - SQLiteScheduleStore CRUD ops
+    - SQLiteSessionStore CRUD ops
+    - Auto-migration from JSON → SQLite in DataLayer
+    - Backward compat: core modules with and without bound store
+    - Updated migration script (new table names)
+    - bind_store() on SessionTracker, Profile, PlaceService, Schedule
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from bantz.data.sqlite_store import (
+    SQLitePlaceStore,
+    SQLiteProfileStore,
+    SQLiteScheduleStore,
+    SQLiteSessionStore,
+)
+from bantz.data.json_store import (
+    JSONPlaceStore,
+    JSONProfileStore,
+    JSONScheduleStore,
+    JSONSessionStore,
+)
+from bantz.data.migration import migrate_to_sqlite, validate_json_files
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def tmp_dir(tmp_path: Path) -> Path:
+    return tmp_path
+
+
+@pytest.fixture
+def db_path(tmp_dir: Path) -> Path:
+    return tmp_dir / "test.db"
+
+
+# ━━ SQLiteProfileStore ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class TestSQLiteProfileStore:
+    def test_empty_on_init(self, db_path: Path):
+        store = SQLiteProfileStore(db_path)
+        assert store.load() == {}
+        assert not store.exists()
+
+    def test_save_and_load(self, db_path: Path):
+        store = SQLiteProfileStore(db_path)
+        data = {"name": "Iclal", "university": "OMU", "year": 2}
+        store.save(data)
+        loaded = store.load()
+        assert loaded["name"] == "Iclal"
+        assert loaded["university"] == "OMU"
+        assert loaded["year"] == 2
+
+    def test_exists_after_save(self, db_path: Path):
+        store = SQLiteProfileStore(db_path)
+        assert not store.exists()
+        store.save({"name": "Test"})
+        assert store.exists()
+
+    def test_save_overwrites(self, db_path: Path):
+        store = SQLiteProfileStore(db_path)
+        store.save({"name": "Alice", "city": "Istanbul"})
+        store.save({"name": "Bob"})  # overwrites entirely
+        loaded = store.load()
+        assert loaded["name"] == "Bob"
+        assert "city" not in loaded
+
+    def test_nested_dict_preserved(self, db_path: Path):
+        store = SQLiteProfileStore(db_path)
+        data = {
+            "name": "Test",
+            "preferences": {
+                "briefing_sections": ["schedule", "weather"],
+                "response_style": "casual",
+            },
+        }
+        store.save(data)
+        loaded = store.load()
+        assert loaded["preferences"]["response_style"] == "casual"
+        assert loaded["preferences"]["briefing_sections"] == ["schedule", "weather"]
+
+    def test_path_returns_db(self, db_path: Path):
+        store = SQLiteProfileStore(db_path)
+        assert store.path == db_path
+
+    def test_unicode_values(self, db_path: Path):
+        store = SQLiteProfileStore(db_path)
+        store.save({"name": "İclal", "university": "Samsun OMÜ"})
+        loaded = store.load()
+        assert loaded["name"] == "İclal"
+        assert loaded["university"] == "Samsun OMÜ"
+
+
+# ━━ SQLitePlaceStore ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class TestSQLitePlaceStore:
+    def test_empty_on_init(self, db_path: Path):
+        store = SQLitePlaceStore(db_path)
+        assert store.load_all() == {}
+        assert not store.exists()
+
+    def test_save_all_and_load(self, db_path: Path):
+        store = SQLitePlaceStore(db_path)
+        data = {
+            "dorm": {"label": "Yurt", "lat": 41.28, "lon": 36.33, "radius": 100},
+            "campus": {"label": "Kampüs", "lat": 41.29, "lon": 36.34, "radius": 200},
+        }
+        store.save_all(data)
+        loaded = store.load_all()
+        assert len(loaded) == 2
+        assert loaded["dorm"]["label"] == "Yurt"
+        assert loaded["campus"]["lat"] == 41.29
+
+    def test_upsert_single(self, db_path: Path):
+        store = SQLitePlaceStore(db_path)
+        store.save_all({"dorm": {"label": "Yurt", "lat": 41.0, "lon": 36.0}})
+        store.upsert("library", {"label": "Kütüphane", "lat": 41.1, "lon": 36.1})
+        loaded = store.load_all()
+        assert len(loaded) == 2
+        assert "library" in loaded
+
+    def test_upsert_updates_existing(self, db_path: Path):
+        store = SQLitePlaceStore(db_path)
+        store.save_all({"dorm": {"label": "Yurt", "lat": 41.0, "lon": 36.0}})
+        store.upsert("dorm", {"label": "Updated Yurt", "lat": 41.5, "lon": 36.5})
+        loaded = store.load_all()
+        assert len(loaded) == 1
+        assert loaded["dorm"]["label"] == "Updated Yurt"
+        assert loaded["dorm"]["lat"] == 41.5
+
+    def test_delete(self, db_path: Path):
+        store = SQLitePlaceStore(db_path)
+        store.save_all({
+            "a": {"label": "A", "lat": 0, "lon": 0},
+            "b": {"label": "B", "lat": 0, "lon": 0},
+        })
+        assert store.delete("a")
+        loaded = store.load_all()
+        assert len(loaded) == 1
+        assert "b" in loaded
+
+    def test_delete_nonexistent(self, db_path: Path):
+        store = SQLitePlaceStore(db_path)
+        assert not store.delete("nope")
+
+    def test_exists_after_save(self, db_path: Path):
+        store = SQLitePlaceStore(db_path)
+        assert not store.exists()
+        store.save_all({"x": {"label": "X", "lat": 0, "lon": 0}})
+        assert store.exists()
+
+    def test_default_radius(self, db_path: Path):
+        store = SQLitePlaceStore(db_path)
+        store.save_all({"test": {"label": "Test", "lat": 1.0, "lon": 2.0}})
+        loaded = store.load_all()
+        assert loaded["test"]["radius"] == 100.0
+
+
+# ━━ SQLiteScheduleStore ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class TestSQLiteScheduleStore:
+    def test_empty_on_init(self, db_path: Path):
+        store = SQLiteScheduleStore(db_path)
+        assert store.load() == {}
+        assert not store.exists()
+
+    def test_save_and_load(self, db_path: Path):
+        store = SQLiteScheduleStore(db_path)
+        data = {
+            "monday": [
+                {"name": "ML", "time": "10:00", "duration": 90, "location": "B2", "type": "lab"},
+                {"name": "DS", "time": "14:00", "duration": 60, "location": "A1", "type": "lecture"},
+            ],
+            "wednesday": [
+                {"name": "DB", "time": "09:00", "duration": 90, "location": "C3", "type": ""},
+            ],
+        }
+        store.save(data)
+        loaded = store.load()
+        assert len(loaded["monday"]) == 2
+        assert loaded["monday"][0]["name"] == "ML"
+        assert loaded["monday"][1]["time"] == "14:00"
+        assert loaded["wednesday"][0]["location"] == "C3"
+
+    def test_save_overwrites(self, db_path: Path):
+        store = SQLiteScheduleStore(db_path)
+        store.save({"monday": [{"name": "Old", "time": "08:00"}]})
+        store.save({"tuesday": [{"name": "New", "time": "09:00"}]})
+        loaded = store.load()
+        assert "monday" not in loaded
+        assert "tuesday" in loaded
+
+    def test_exists_after_save(self, db_path: Path):
+        store = SQLiteScheduleStore(db_path)
+        assert not store.exists()
+        store.save({"friday": [{"name": "Test", "time": "10:00"}]})
+        assert store.exists()
+
+    def test_default_duration(self, db_path: Path):
+        store = SQLiteScheduleStore(db_path)
+        store.save({"monday": [{"name": "X", "time": "10:00"}]})
+        loaded = store.load()
+        assert loaded["monday"][0]["duration"] == 60
+
+    def test_preserves_order(self, db_path: Path):
+        store = SQLiteScheduleStore(db_path)
+        entries = [
+            {"name": f"Class{i}", "time": f"{8+i}:00"}
+            for i in range(5)
+        ]
+        store.save({"monday": entries})
+        loaded = store.load()
+        for i, entry in enumerate(loaded["monday"]):
+            assert entry["name"] == f"Class{i}"
+
+
+# ━━ SQLiteSessionStore ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class TestSQLiteSessionStore:
+    def test_empty_on_init(self, db_path: Path):
+        store = SQLiteSessionStore(db_path)
+        assert store.load() == {}
+
+    def test_save_and_load(self, db_path: Path):
+        store = SQLiteSessionStore(db_path)
+        data = {"last_seen": "2026-03-05T10:00:00", "session_count": 42}
+        store.save(data)
+        loaded = store.load()
+        assert loaded["last_seen"] == "2026-03-05T10:00:00"
+        assert loaded["session_count"] == 42
+
+    def test_save_overwrites(self, db_path: Path):
+        store = SQLiteSessionStore(db_path)
+        store.save({"a": 1, "b": 2})
+        store.save({"c": 3})
+        loaded = store.load()
+        assert loaded == {"c": 3}
+
+    def test_path_returns_db(self, db_path: Path):
+        store = SQLiteSessionStore(db_path)
+        assert store.path == db_path
+
+
+# ━━ Core Module bind_store Tests ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class TestSessionTrackerBindStore:
+    def test_bind_store_and_save(self, db_path: Path):
+        from bantz.core.session import SessionTracker
+        store = SQLiteSessionStore(db_path)
+        tracker = SessionTracker()
+        tracker.bind_store(store)
+
+        result = tracker.on_launch()
+        assert result["is_first"] is True
+        assert result["session_count"] == 1
+
+        # Data persisted in SQLite
+        loaded = store.load()
+        assert loaded["session_count"] == 1
+        assert "last_seen" in loaded
+
+    def test_sequential_launches(self, db_path: Path):
+        from bantz.core.session import SessionTracker
+        store = SQLiteSessionStore(db_path)
+        tracker = SessionTracker()
+        tracker.bind_store(store)
+
+        tracker.on_launch()
+        result = tracker.on_launch()
+        assert result["session_count"] == 2
+        assert result["is_first"] is False
+
+    def test_path_from_store(self, db_path: Path):
+        from bantz.core.session import SessionTracker
+        store = SQLiteSessionStore(db_path)
+        tracker = SessionTracker()
+        tracker.bind_store(store)
+        assert tracker.path == db_path
+
+    def test_json_fallback(self, tmp_dir: Path):
+        """Without bind_store, uses JSON fallback."""
+        from bantz.core.session import SessionTracker
+        tracker = SessionTracker()
+        # No store bound — should not crash
+        data = tracker._load()
+        assert isinstance(data, dict)
+
+
+class TestProfileBindStore:
+    def test_bind_store_and_load(self, db_path: Path):
+        store = SQLiteProfileStore(db_path)
+        store.save({"name": "Iclal", "tone": "casual"})
+
+        from bantz.core.profile import Profile
+        p = Profile()
+        p.bind_store(store)
+
+        assert p.name == "Iclal"
+        assert p.get("tone") == "casual"
+
+    def test_save_through_profile(self, db_path: Path):
+        store = SQLiteProfileStore(db_path)
+
+        from bantz.core.profile import Profile
+        p = Profile()
+        p.bind_store(store)
+        p.save({"name": "Alice", "university": "MIT"})
+
+        loaded = store.load()
+        assert loaded["name"] == "Alice"
+        assert loaded["university"] == "MIT"
+        # Defaults filled
+        assert loaded["tone"] == "casual"
+
+    def test_is_configured(self, db_path: Path):
+        store = SQLiteProfileStore(db_path)
+
+        from bantz.core.profile import Profile
+        p = Profile()
+        p.bind_store(store)
+        assert not p.is_configured()
+
+        p.save({"name": "Bob"})
+        assert p.is_configured()
+
+
+class TestPlaceServiceBindStore:
+    def test_bind_store_and_load(self, db_path: Path):
+        store = SQLitePlaceStore(db_path)
+        store.save_all({
+            "dorm": {"label": "Yurt", "lat": 41.0, "lon": 36.0, "radius": 100},
+        })
+
+        from bantz.core.places import PlaceService
+        ps = PlaceService()
+        ps.bind_store(store)
+
+        all_places = ps.all_places()
+        assert "dorm" in all_places
+        assert all_places["dorm"]["label"] == "Yurt"
+
+    def test_save_through_service(self, db_path: Path):
+        store = SQLitePlaceStore(db_path)
+
+        from bantz.core.places import PlaceService
+        ps = PlaceService()
+        ps.bind_store(store)
+        ps.save({"lib": {"label": "Library", "lat": 1.0, "lon": 2.0}})
+
+        loaded = store.load_all()
+        assert "lib" in loaded
+
+    def test_delete_through_service(self, db_path: Path):
+        store = SQLitePlaceStore(db_path)
+        store.save_all({
+            "a": {"label": "A", "lat": 0, "lon": 0, "radius": 100},
+            "b": {"label": "B", "lat": 0, "lon": 0, "radius": 100},
+        })
+
+        from bantz.core.places import PlaceService
+        ps = PlaceService()
+        ps.bind_store(store)
+
+        assert ps.delete_place("a")
+        loaded = store.load_all()
+        assert "a" not in loaded
+        assert "b" in loaded
+
+    def test_is_configured(self, db_path: Path):
+        store = SQLitePlaceStore(db_path)
+
+        from bantz.core.places import PlaceService
+        ps = PlaceService()
+        ps.bind_store(store)
+        assert not ps.is_configured()
+
+        ps.save({"x": {"label": "X", "lat": 0, "lon": 0}})
+        assert ps.is_configured()
+
+
+class TestScheduleBindStore:
+    def test_bind_store_and_load(self, db_path: Path):
+        store = SQLiteScheduleStore(db_path)
+        store.save({
+            "monday": [
+                {"name": "ML", "time": "10:00", "duration": 90, "location": "B2", "type": "lab"}
+            ],
+        })
+
+        from bantz.core.schedule import Schedule
+        s = Schedule()
+        s.bind_store(store)
+
+        monday = datetime(2026, 1, 5, 8, 0)  # a Monday
+        classes = s.today(monday)
+        assert len(classes) == 1
+        assert classes[0]["name"] == "ML"
+
+    def test_is_configured(self, db_path: Path):
+        store = SQLiteScheduleStore(db_path)
+
+        from bantz.core.schedule import Schedule
+        s = Schedule()
+        s.bind_store(store)
+        assert not s.is_configured()
+
+        store.save({"monday": [{"name": "X", "time": "08:00"}]})
+        # Reset loaded flag to pick up new data
+        s._loaded = False
+        assert s.is_configured()
+
+
+# ━━ Auto-Migration in DataLayer ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class TestDataLayerAutoMigration:
+    """Test that DataLayer auto-migrates JSON → SQLite on first init."""
+
+    def test_auto_migrate_profile(self, tmp_dir: Path):
+        from bantz.data.layer import DataLayer
+        db_path = tmp_dir / "bantz.db"
+
+        # Write JSON
+        (tmp_dir / "profile.json").write_text(
+            json.dumps({"name": "Iclal", "university": "OMU"})
+        )
+
+        # Simulate DataLayer auto-migration
+        profile_store = SQLiteProfileStore(db_path)
+        assert not profile_store.exists()
+
+        pf = tmp_dir / "profile.json"
+        data = json.loads(pf.read_text("utf-8"))
+        profile_store.save(data)
+
+        loaded = profile_store.load()
+        assert loaded["name"] == "Iclal"
+
+    def test_auto_migrate_places(self, tmp_dir: Path):
+        db_path = tmp_dir / "bantz.db"
+        (tmp_dir / "places.json").write_text(
+            json.dumps({
+                "dorm": {"label": "Yurt", "lat": 41.0, "lon": 36.0, "radius": 100}
+            })
+        )
+
+        place_store = SQLitePlaceStore(db_path)
+        assert not place_store.exists()
+
+        data = json.loads((tmp_dir / "places.json").read_text("utf-8"))
+        place_store.save_all(data)
+
+        loaded = place_store.load_all()
+        assert loaded["dorm"]["label"] == "Yurt"
+
+    def test_auto_migrate_schedule(self, tmp_dir: Path):
+        db_path = tmp_dir / "bantz.db"
+        (tmp_dir / "schedule.json").write_text(
+            json.dumps({"tuesday": [{"name": "DB", "time": "09:00", "duration": 90}]})
+        )
+
+        sched_store = SQLiteScheduleStore(db_path)
+        data = json.loads((tmp_dir / "schedule.json").read_text("utf-8"))
+        sched_store.save(data)
+
+        loaded = sched_store.load()
+        assert loaded["tuesday"][0]["name"] == "DB"
+
+    def test_auto_migrate_session(self, tmp_dir: Path):
+        db_path = tmp_dir / "bantz.db"
+        (tmp_dir / "session.json").write_text(
+            json.dumps({"last_seen": "2026-01-01T00:00:00", "session_count": 10})
+        )
+
+        sess_store = SQLiteSessionStore(db_path)
+        data = json.loads((tmp_dir / "session.json").read_text("utf-8"))
+        sess_store.save(data)
+
+        loaded = sess_store.load()
+        assert loaded["session_count"] == 10
+
+    def test_no_migrate_if_sqlite_has_data(self, tmp_dir: Path):
+        db_path = tmp_dir / "bantz.db"
+
+        # Pre-populate SQLite
+        profile_store = SQLiteProfileStore(db_path)
+        profile_store.save({"name": "SQLite User"})
+
+        # Write different JSON
+        (tmp_dir / "profile.json").write_text(
+            json.dumps({"name": "JSON User"})
+        )
+
+        # Auto-migrate should skip since SQLite has data
+        assert profile_store.exists()
+        loaded = profile_store.load()
+        assert loaded["name"] == "SQLite User"
+
+
+# ━━ Updated Migration Script ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class TestMigrationScript:
+    def test_migrate_creates_new_tables(self, tmp_dir: Path):
+        import sqlite3
+        db_path = tmp_dir / "migrate.db"
+
+        (tmp_dir / "profile.json").write_text('{"name": "Test"}')
+        (tmp_dir / "session.json").write_text('{"session_count": 1}')
+
+        migrate_to_sqlite(db_path, tmp_dir)
+
+        conn = sqlite3.connect(str(db_path))
+        # Check that new table names exist
+        tables = {r[0] for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()}
+        assert "user_profile" in tables
+        assert "session_state" in tables
+        assert "places" in tables
+        assert "schedule_entries" in tables
+        conn.close()
+
+    def test_migrate_profile_to_user_profile(self, tmp_dir: Path):
+        import sqlite3
+        db_path = tmp_dir / "m.db"
+        (tmp_dir / "profile.json").write_text(
+            json.dumps({"name": "Iclal", "year": 2})
+        )
+        migrate_to_sqlite(db_path, tmp_dir)
+
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute("SELECT * FROM user_profile").fetchall()
+        keys = {r["key"] for r in rows}
+        assert "name" in keys
+        assert "year" in keys
+        conn.close()
+
+    def test_migrate_session_to_session_state(self, tmp_dir: Path):
+        import sqlite3
+        db_path = tmp_dir / "m.db"
+        (tmp_dir / "session.json").write_text(
+            json.dumps({"last_seen": "2026-01-01T00:00:00", "session_count": 5})
+        )
+        migrate_to_sqlite(db_path, tmp_dir)
+
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute("SELECT * FROM session_state").fetchall()
+        keys = {r["key"] for r in rows}
+        assert "last_seen" in keys
+        assert "session_count" in keys
+        conn.close()
+
+    def test_migrate_schedule_to_schedule_entries(self, tmp_dir: Path):
+        import sqlite3
+        db_path = tmp_dir / "m.db"
+        (tmp_dir / "schedule.json").write_text(
+            json.dumps({
+                "monday": [{"name": "ML", "time": "10:00", "duration": 90}],
+                "friday": [{"name": "DB", "time": "14:00"}],
+            })
+        )
+        migrate_to_sqlite(db_path, tmp_dir)
+
+        conn = sqlite3.connect(str(db_path))
+        rows = conn.execute("SELECT * FROM schedule_entries").fetchall()
+        assert len(rows) == 2
+        conn.close()
+
+
+# ━━ Cross-Store Integrity ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class TestCrossStoreIntegrity:
+    """Multiple SQLite stores can share the same DB file."""
+
+    def test_shared_db_file(self, db_path: Path):
+        profile = SQLiteProfileStore(db_path)
+        places = SQLitePlaceStore(db_path)
+        schedule = SQLiteScheduleStore(db_path)
+        session = SQLiteSessionStore(db_path)
+
+        profile.save({"name": "Test"})
+        places.save_all({"home": {"label": "Home", "lat": 0, "lon": 0}})
+        schedule.save({"monday": [{"name": "ML", "time": "10:00"}]})
+        session.save({"session_count": 1})
+
+        assert profile.load()["name"] == "Test"
+        assert "home" in places.load_all()
+        assert len(schedule.load()["monday"]) == 1
+        assert session.load()["session_count"] == 1
+
+    def test_stores_dont_interfere(self, db_path: Path):
+        """Saving to one store doesn't corrupt another."""
+        profile = SQLiteProfileStore(db_path)
+        session = SQLiteSessionStore(db_path)
+
+        profile.save({"name": "Alice"})
+        session.save({"count": 1})
+
+        # Overwrite session
+        session.save({"count": 2})
+
+        # Profile should be untouched
+        assert profile.load()["name"] == "Alice"
+        assert session.load()["count"] == 2

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -436,9 +436,9 @@ class TestMigration:
         conn = sqlite3.connect(str(db_path))
         conn.row_factory = sqlite3.Row
 
-        # kv_store: profile
+        # user_profile table
         rows = conn.execute(
-            "SELECT * FROM kv_store WHERE namespace='profile'"
+            "SELECT * FROM user_profile"
         ).fetchall()
         assert len(rows) >= 1
         names = {r["key"] for r in rows}
@@ -449,8 +449,8 @@ class TestMigration:
         assert len(rows) == 1
         assert dict(rows[0])["key"] == "dorm"
 
-        # schedule table
-        rows = conn.execute("SELECT * FROM schedule").fetchall()
+        # schedule_entries table
+        rows = conn.execute("SELECT * FROM schedule_entries").fetchall()
         assert len(rows) == 1
         assert dict(rows[0])["name"] == "ML"
 
@@ -468,7 +468,7 @@ class TestMigration:
 
         conn = sqlite3.connect(str(db_path))
         rows = conn.execute(
-            "SELECT * FROM kv_store WHERE namespace='profile'"
+            "SELECT * FROM user_profile"
         ).fetchall()
         assert len(rows) == 0
         conn.close()
@@ -515,6 +515,30 @@ class TestABCConformance:
         from bantz.data.store import SessionStore
 
         assert issubclass(JSONSessionStore, SessionStore)
+
+    def test_sqlite_profile_is_profile_store(self):
+        from bantz.data.store import ProfileStore
+        from bantz.data.sqlite_store import SQLiteProfileStore
+
+        assert issubclass(SQLiteProfileStore, ProfileStore)
+
+    def test_sqlite_place_is_place_store(self):
+        from bantz.data.store import PlaceStore
+        from bantz.data.sqlite_store import SQLitePlaceStore
+
+        assert issubclass(SQLitePlaceStore, PlaceStore)
+
+    def test_sqlite_schedule_is_schedule_store(self):
+        from bantz.data.store import ScheduleStore
+        from bantz.data.sqlite_store import SQLiteScheduleStore
+
+        assert issubclass(SQLiteScheduleStore, ScheduleStore)
+
+    def test_sqlite_session_is_session_store(self):
+        from bantz.data.store import SessionStore
+        from bantz.data.sqlite_store import SQLiteSessionStore
+
+        assert issubclass(SQLiteSessionStore, SessionStore)
 
     def test_memory_is_conversation_store(self):
         from bantz.data.store import ConversationStore


### PR DESCRIPTION
## Summary

Migrates all 4 JSON file stores (profile, places, schedule, session) into the unified SQLite database.

### Changes

**New SQLite stores** (`sqlite_store.py`):
- `SQLiteProfileStore` — `user_profile` table (key/value)
- `SQLitePlaceStore` — `places` table with upsert/delete
- `SQLiteScheduleStore` — `schedule_entries` table
- `SQLiteSessionStore` — `session_state` table (key/value)

**Core module updates** — `bind_store()` pattern:
- `SessionTracker`, `Profile`, `PlaceService`, `Schedule` all accept a store via `bind_store()`
- JSON fallback when no store is bound (backward compat)

**DataLayer** (`layer.py`):
- Creates SQLite stores on init
- Auto-migrates from JSON files on first launch if SQLite tables are empty
- Binds stores to core singletons

**Migration script** (`migration.py`):
- Updated schema: `kv_store` → `user_profile`/`session_state`, `schedule` → `schedule_entries`

### Tests
- 49 new tests across 11 test classes
- 4 new ABC conformance tests
- **148 total tests pass**

Closes #117