### PR TITLE
feat(automation): PyAutoGUI/pynput input simulation (#122)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,10 @@ docs = [
 graph = [
     "neo4j>=5.0.0",
 ]
+automation = [
+    "pyautogui>=0.9.54",
+    "pynput>=1.7.0",
+]
 
 [project.scripts]
 bantz = "bantz.__main__:main"

--- a/src/bantz/__main__.py
+++ b/src/bantz/__main__.py
@@ -554,6 +554,7 @@ async def _doctor() -> None:
     import bantz.tools.classroom
     import bantz.tools.reminder
     import bantz.tools.contacts
+    import bantz.tools.input_control
 
     print("Bantz v2 — System Check")
     print("─" * 44)
@@ -619,6 +620,30 @@ async def _doctor() -> None:
     from bantz.core.profile import profile as _prof
     icon = "✓" if _prof.is_configured() else "○"
     print(f"{icon} Profile: {_prof.status_line()}")
+
+    # Input Control (#122)
+    ic_ok = config.input_control_enabled
+    ic_backend = "disabled"
+    if ic_ok:
+        try:
+            from bantz.tools.input_control import _detect_backend
+            ic_backend = _detect_backend()
+        except Exception:
+            ic_backend = "error"
+    ic_icon = "✓" if ic_ok and ic_backend != "none" else "○"
+    if ic_ok:
+        print(f"{ic_icon} Input control: {ic_backend}  (confirm_destructive={config.input_confirm_destructive})")
+    else:
+        print(f"○ Input control: disabled  → set BANTZ_INPUT_CONTROL_ENABLED=true")
+
+    # Spatial Cache (#121)
+    try:
+        from bantz.vision.spatial_cache import spatial_db as _sc
+        _sc.init(config.db_path)
+        sc_stats = _sc.stats()
+        print(f"✓ Spatial cache: {sc_stats['total_entries']} entries, {sc_stats['total_hits']} hits")
+    except Exception:
+        print("○ Spatial cache: not initialized")
 
     # Telegram
     tg_ok = bool(config.telegram_bot_token)

--- a/src/bantz/config.py
+++ b/src/bantz/config.py
@@ -30,6 +30,11 @@ class Config(BaseSettings):
     vlm_timeout: int = Field(5, alias="BANTZ_VLM_TIMEOUT")
     screenshot_quality: int = Field(70, alias="BANTZ_SCREENSHOT_QUALITY")
 
+    # ── Input Control (#122) ──────────────────────────────────────────────
+    input_control_enabled: bool = Field(False, alias="BANTZ_INPUT_CONTROL_ENABLED")
+    input_confirm_destructive: bool = Field(True, alias="BANTZ_INPUT_CONFIRM_DESTRUCTIVE")
+    input_type_interval_ms: int = Field(50, alias="BANTZ_INPUT_TYPE_INTERVAL_MS")
+
     # ── Gemini (optional) ─────────────────────────────────────────────────
     gemini_enabled: bool = Field(False, alias="BANTZ_GEMINI_ENABLED")
     gemini_api_key: str = Field("", alias="BANTZ_GEMINI_API_KEY")

--- a/src/bantz/core/brain.py
+++ b/src/bantz/core/brain.py
@@ -533,6 +533,74 @@ class Brain:
             if not any(k in both for k in ("mail", "calendar", "assignment")):
                 return {"tool": "_generate", "args": {}}
 
+        # Input Control (#122) — mouse/keyboard simulation
+        _is_input = any(k in both for k in (
+            "type ", "type text", "type into", "type in",
+            "scroll down", "scroll up", "scroll left", "scroll right",
+            "drag from", "drag to",
+            "press ctrl", "press alt", "hotkey",
+            "press enter", "press escape", "press tab",
+            "double click", "right click", "right-click", "double-click",
+            "mouse position", "where is the mouse", "where's the mouse",
+            "move mouse", "move cursor",
+        ))
+        if _is_input:
+            # Type text
+            type_m = re.search(
+                r'(?:type|write|enter|input)\s+(?:text\s+)?["\'](.+?)["\']',
+                both, re.IGNORECASE,
+            )
+            if type_m:
+                return {"tool": "input_control", "args": {"action": "type_text", "text": type_m.group(1)}}
+            if re.search(r'type\s+(?:text\s+)?(?:into|in)', both):
+                return {"tool": "input_control", "args": {"action": "type_text", "text": ""}}
+            # Scroll
+            if any(k in both for k in ("scroll down", "scroll up", "scroll left", "scroll right")):
+                direction = "down"
+                for d in ("up", "down", "left", "right"):
+                    if f"scroll {d}" in both:
+                        direction = d
+                        break
+                amt_m = re.search(r'scroll\s+\w+\s+(\d+)', both)
+                amount = int(amt_m.group(1)) if amt_m else 3
+                return {"tool": "input_control", "args": {"action": "scroll", "direction": direction, "amount": amount}}
+            # Hotkey
+            hotkey_m = re.search(
+                r'(?:press|hotkey|shortcut)\s+((?:ctrl|alt|shift|super|meta|win)\s*\+\s*\w+(?:\s*\+\s*\w+)*)',
+                both, re.IGNORECASE,
+            )
+            if hotkey_m:
+                return {"tool": "input_control", "args": {"action": "hotkey", "keys": hotkey_m.group(1).strip()}}
+            if any(k in both for k in ("press enter",)):
+                return {"tool": "input_control", "args": {"action": "hotkey", "keys": "enter"}}
+            if any(k in both for k in ("press escape", "press esc")):
+                return {"tool": "input_control", "args": {"action": "hotkey", "keys": "escape"}}
+            if any(k in both for k in ("press tab",)):
+                return {"tool": "input_control", "args": {"action": "hotkey", "keys": "tab"}}
+            # Double click / right click
+            dbl_m = re.search(r'double[- ]?click\s+(?:at\s+)?(?:\(?(\d+)\s*,\s*(\d+)\)?)', both)
+            if dbl_m:
+                return {"tool": "input_control", "args": {"action": "double_click", "x": int(dbl_m.group(1)), "y": int(dbl_m.group(2))}}
+            rc_m = re.search(r'right[- ]?click\s+(?:at\s+)?(?:\(?(\d+)\s*,\s*(\d+)\)?)', both)
+            if rc_m:
+                return {"tool": "input_control", "args": {"action": "right_click", "x": int(rc_m.group(1)), "y": int(rc_m.group(2))}}
+            # Drag
+            drag_m = re.search(r'drag\s+(?:from\s+)?\(?(\d+)\s*,\s*(\d+)\)?\s+(?:to\s+)?\(?(\d+)\s*,\s*(\d+)\)?', both)
+            if drag_m:
+                return {"tool": "input_control", "args": {"action": "drag", "from_x": int(drag_m.group(1)), "from_y": int(drag_m.group(2)), "to_x": int(drag_m.group(3)), "to_y": int(drag_m.group(4))}}
+            # Mouse position
+            if any(k in both for k in ("mouse position", "where is the mouse", "where's the mouse")):
+                return {"tool": "input_control", "args": {"action": "get_position"}}
+            # Move mouse
+            mv_m = re.search(r'move\s+(?:mouse|cursor)\s+(?:to\s+)?\(?(\d+)\s*,\s*(\d+)\)?', both)
+            if mv_m:
+                return {"tool": "input_control", "args": {"action": "move_to", "x": int(mv_m.group(1)), "y": int(mv_m.group(2))}}
+            # Fallback: double_click / right_click without coordinates
+            if "double" in both and "click" in both:
+                return {"tool": "input_control", "args": {"action": "double_click", "x": 0, "y": 0}}
+            if "right" in both and "click" in both:
+                return {"tool": "input_control", "args": {"action": "right_click", "x": 0, "y": 0}}
+
         # Accessibility / AT-SPI (#119)
         _is_a11y = any(k in both for k in (
             "click the", "click on", "press the button",

--- a/src/bantz/tools/input_control.py
+++ b/src/bantz/tools/input_control.py
@@ -1,0 +1,735 @@
+"""
+Bantz v3 — Input Control Tool (#122)
+
+PyAutoGUI / pynput input simulation — mouse, keyboard, scroll.
+Wraps input actions with a safety model matching shell.py's patterns.
+
+Safety Model:
+  - safe:        click(x,y), move_to(x,y), scroll
+  - moderate:    type_text, double_click, drag
+  - destructive: hotkey combos (ctrl+w, alt+f4, ctrl+q, etc.)
+
+Backend Selection:
+  - X11:     pyautogui (full mouse/keyboard/screenshot support)
+  - Wayland: pynput (mouse via evdev, keyboard via uinput)
+  - Fallback: xdotool via subprocess
+
+Architecture:
+    Brain: "click Send button in Firefox"
+        → accessibility.py → find_element("firefox", "Send") → (1340, 680)
+        → input_control.py → click(1340, 680)
+
+Usage:
+    from bantz.tools.input_control import InputControlTool
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+import subprocess
+import time
+from datetime import datetime
+from typing import Any, Optional
+
+from bantz.config import config
+from bantz.tools import BaseTool, ToolResult, registry
+
+log = logging.getLogger("bantz.input_control")
+
+# ── Backend detection ─────────────────────────────────────────────────────
+
+_backend: Optional[str] = None
+_pyautogui = None
+_pynput_mouse = None
+_pynput_keyboard = None
+_pynput_mouse_controller = None
+_pynput_keyboard_controller = None
+
+
+def _detect_backend() -> str:
+    """Detect best input backend: pyautogui (X11) or pynput (Wayland)."""
+    global _backend
+    if _backend is not None:
+        return _backend
+
+    session = os.environ.get("XDG_SESSION_TYPE", "").lower()
+    wayland = session == "wayland" or bool(os.environ.get("WAYLAND_DISPLAY"))
+
+    if wayland:
+        try:
+            from pynput import mouse, keyboard  # noqa: F401
+            _backend = "pynput"
+            log.debug("Input backend: pynput (Wayland)")
+            return _backend
+        except ImportError:
+            pass
+
+    # X11 or fallback
+    try:
+        import pyautogui  # noqa: F401
+        _backend = "pyautogui"
+        log.debug("Input backend: pyautogui (X11)")
+        return _backend
+    except ImportError:
+        pass
+
+    # pynput as second fallback
+    try:
+        from pynput import mouse, keyboard  # noqa: F401
+        _backend = "pynput"
+        log.debug("Input backend: pynput (fallback)")
+        return _backend
+    except ImportError:
+        pass
+
+    # xdotool as last resort
+    try:
+        result = subprocess.run(["which", "xdotool"], capture_output=True)
+        if result.returncode == 0:
+            _backend = "xdotool"
+            log.debug("Input backend: xdotool (fallback)")
+            return _backend
+    except Exception:
+        pass
+
+    _backend = "none"
+    log.warning("No input backend available")
+    return _backend
+
+
+def _get_pyautogui():
+    """Lazy-load pyautogui with FAILSAFE enabled."""
+    global _pyautogui
+    if _pyautogui is None:
+        import pyautogui
+        pyautogui.FAILSAFE = True
+        pyautogui.PAUSE = 0.05  # slight pause between actions
+        _pyautogui = pyautogui
+    return _pyautogui
+
+
+def _get_pynput():
+    """Lazy-load pynput controllers."""
+    global _pynput_mouse, _pynput_keyboard
+    global _pynput_mouse_controller, _pynput_keyboard_controller
+    if _pynput_mouse_controller is None:
+        from pynput.mouse import Controller as MouseCtrl
+        from pynput.keyboard import Controller as KeyCtrl, Key
+        _pynput_mouse = MouseCtrl
+        _pynput_keyboard = KeyCtrl
+        _pynput_mouse_controller = MouseCtrl()
+        _pynput_keyboard_controller = KeyCtrl()
+    return _pynput_mouse_controller, _pynput_keyboard_controller
+
+
+# ── Safety classification ─────────────────────────────────────────────────
+
+# Destructive hotkeys that could close apps, delete data, etc.
+DESTRUCTIVE_HOTKEYS: frozenset[tuple[str, ...]] = frozenset({
+    ("ctrl", "w"),      # close tab
+    ("ctrl", "q"),      # quit app
+    ("alt", "f4"),      # close window
+    ("ctrl", "shift", "w"),  # close all tabs
+    ("ctrl", "shift", "q"),  # quit alt
+    ("super", "d"),     # show desktop / minimize all
+    ("ctrl", "z"),      # undo (risky in some contexts)
+    ("ctrl", "shift", "delete"),  # clear data
+    ("ctrl", "alt", "delete"),    # system
+    ("alt", "f2"),      # run dialog
+    ("ctrl", "delete"), # delete word
+})
+
+MODERATE_HOTKEYS: frozenset[tuple[str, ...]] = frozenset({
+    ("ctrl", "s"),      # save
+    ("ctrl", "a"),      # select all
+    ("ctrl", "c"),      # copy
+    ("ctrl", "v"),      # paste
+    ("ctrl", "x"),      # cut
+    ("ctrl", "f"),      # find
+    ("ctrl", "n"),      # new
+    ("ctrl", "t"),      # new tab
+    ("ctrl", "l"),      # address bar
+    ("ctrl", "p"),      # print
+    ("alt", "tab"),     # switch window
+    ("enter",),         # confirm
+    ("tab",),           # tab
+    ("escape",),        # escape
+})
+
+
+def classify_action(action: str, **kwargs) -> str:
+    """
+    Classify an input action's risk level.
+
+    Returns: "safe", "moderate", or "destructive"
+    """
+    action = action.lower()
+
+    if action in ("click", "move_to", "scroll", "get_position"):
+        return "safe"
+
+    if action in ("double_click", "right_click", "drag"):
+        return "moderate"
+
+    if action == "type_text":
+        text = kwargs.get("text", "")
+        if len(text) > 100:
+            return "moderate"
+        return "moderate"
+
+    if action == "hotkey":
+        keys = kwargs.get("keys", ())
+        if isinstance(keys, str):
+            keys = tuple(k.strip().lower() for k in keys.split("+"))
+        else:
+            keys = tuple(k.lower() for k in keys)
+
+        if keys in DESTRUCTIVE_HOTKEYS:
+            return "destructive"
+        if keys in MODERATE_HOTKEYS:
+            return "moderate"
+        # Unknown hotkey combos → default moderate
+        return "moderate"
+
+    return "moderate"
+
+
+# ── Action logging ────────────────────────────────────────────────────────
+
+_action_log: list[dict] = []
+
+
+def _log_action(action: str, details: dict, risk: str) -> None:
+    """Log every input action with timestamp for RL training data."""
+    entry = {
+        "timestamp": datetime.now().isoformat(timespec="milliseconds"),
+        "action": action,
+        "risk": risk,
+        **details,
+    }
+    _action_log.append(entry)
+    # Keep last 500 entries in memory
+    if len(_action_log) > 500:
+        _action_log.pop(0)
+
+    # Also log to memory store if available
+    try:
+        from bantz.core.memory import memory
+        memory.add(
+            "system",
+            f"[input] {action}: {details}",
+        )
+    except Exception:
+        pass
+
+    log.info("Input action [%s]: %s %s", risk, action, details)
+
+
+def get_action_log() -> list[dict]:
+    """Return the in-memory action log."""
+    return list(_action_log)
+
+
+# ── Core input functions ──────────────────────────────────────────────────
+
+async def click(x: int, y: int) -> dict:
+    """Click at (x, y) coordinates."""
+    backend = _detect_backend()
+
+    if backend == "pyautogui":
+        pag = _get_pyautogui()
+        await asyncio.get_event_loop().run_in_executor(None, pag.click, x, y)
+    elif backend == "pynput":
+        mc, _ = _get_pynput()
+        from pynput.mouse import Button
+        mc.position = (x, y)
+        mc.click(Button.left, 1)
+    elif backend == "xdotool":
+        await asyncio.create_subprocess_exec(
+            "xdotool", "mousemove", str(x), str(y), "click", "1",
+        )
+    else:
+        raise RuntimeError("No input backend available")
+
+    result = {"x": x, "y": y, "button": "left"}
+    _log_action("click", result, "safe")
+    return result
+
+
+async def double_click(x: int, y: int) -> dict:
+    """Double-click at (x, y)."""
+    backend = _detect_backend()
+
+    if backend == "pyautogui":
+        pag = _get_pyautogui()
+        await asyncio.get_event_loop().run_in_executor(None, pag.doubleClick, x, y)
+    elif backend == "pynput":
+        mc, _ = _get_pynput()
+        from pynput.mouse import Button
+        mc.position = (x, y)
+        mc.click(Button.left, 2)
+    elif backend == "xdotool":
+        await asyncio.create_subprocess_exec(
+            "xdotool", "mousemove", str(x), str(y),
+            "click", "--repeat", "2", "--delay", "50", "1",
+        )
+    else:
+        raise RuntimeError("No input backend available")
+
+    result = {"x": x, "y": y, "button": "left", "clicks": 2}
+    _log_action("double_click", result, "moderate")
+    return result
+
+
+async def right_click(x: int, y: int) -> dict:
+    """Right-click at (x, y)."""
+    backend = _detect_backend()
+
+    if backend == "pyautogui":
+        pag = _get_pyautogui()
+        await asyncio.get_event_loop().run_in_executor(None, pag.rightClick, x, y)
+    elif backend == "pynput":
+        mc, _ = _get_pynput()
+        from pynput.mouse import Button
+        mc.position = (x, y)
+        mc.click(Button.right, 1)
+    elif backend == "xdotool":
+        await asyncio.create_subprocess_exec(
+            "xdotool", "mousemove", str(x), str(y), "click", "3",
+        )
+    else:
+        raise RuntimeError("No input backend available")
+
+    result = {"x": x, "y": y, "button": "right"}
+    _log_action("right_click", result, "moderate")
+    return result
+
+
+async def move_to(x: int, y: int) -> dict:
+    """Move mouse to (x, y) without clicking."""
+    backend = _detect_backend()
+
+    if backend == "pyautogui":
+        pag = _get_pyautogui()
+        await asyncio.get_event_loop().run_in_executor(None, pag.moveTo, x, y)
+    elif backend == "pynput":
+        mc, _ = _get_pynput()
+        mc.position = (x, y)
+    elif backend == "xdotool":
+        await asyncio.create_subprocess_exec("xdotool", "mousemove", str(x), str(y))
+    else:
+        raise RuntimeError("No input backend available")
+
+    result = {"x": x, "y": y}
+    _log_action("move_to", result, "safe")
+    return result
+
+
+async def get_position() -> dict:
+    """Get current mouse position."""
+    backend = _detect_backend()
+
+    if backend == "pyautogui":
+        pag = _get_pyautogui()
+        pos = pag.position()
+        return {"x": pos[0], "y": pos[1]}
+    elif backend == "pynput":
+        mc, _ = _get_pynput()
+        pos = mc.position
+        return {"x": pos[0], "y": pos[1]}
+    elif backend == "xdotool":
+        proc = await asyncio.create_subprocess_exec(
+            "xdotool", "getmouselocation",
+            stdout=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await proc.communicate()
+        text = stdout.decode()
+        match = re.search(r"x:(\d+)\s+y:(\d+)", text)
+        if match:
+            return {"x": int(match.group(1)), "y": int(match.group(2))}
+        return {"x": 0, "y": 0}
+
+    return {"x": 0, "y": 0}
+
+
+async def type_text(text: str, interval: float = 0.05) -> dict:
+    """Type text with human-like intervals (default 50ms between chars)."""
+    backend = _detect_backend()
+
+    if backend == "pyautogui":
+        pag = _get_pyautogui()
+        await asyncio.get_event_loop().run_in_executor(
+            None, lambda: pag.typewrite(text, interval=interval)
+        )
+    elif backend == "pynput":
+        _, kc = _get_pynput()
+        for char in text:
+            kc.type(char)
+            await asyncio.sleep(interval)
+    elif backend == "xdotool":
+        await asyncio.create_subprocess_exec(
+            "xdotool", "type", "--delay", str(int(interval * 1000)), text,
+        )
+    else:
+        raise RuntimeError("No input backend available")
+
+    result = {"text": text[:50], "length": len(text), "interval_ms": int(interval * 1000)}
+    _log_action("type_text", result, "moderate")
+    return result
+
+
+async def scroll(direction: str = "down", amount: int = 3) -> dict:
+    """Scroll up/down/left/right by amount."""
+    backend = _detect_backend()
+    direction = direction.lower()
+
+    if backend == "pyautogui":
+        pag = _get_pyautogui()
+        clicks = amount if direction == "up" else -amount
+        if direction in ("left", "right"):
+            await asyncio.get_event_loop().run_in_executor(
+                None, lambda: pag.hscroll(amount if direction == "right" else -amount)
+            )
+        else:
+            await asyncio.get_event_loop().run_in_executor(None, pag.scroll, clicks)
+    elif backend == "pynput":
+        mc, _ = _get_pynput()
+        if direction in ("up", "down"):
+            dy = amount if direction == "up" else -amount
+            mc.scroll(0, dy)
+        else:
+            dx = amount if direction == "right" else -amount
+            mc.scroll(dx, 0)
+    elif backend == "xdotool":
+        button = "4" if direction == "up" else "5"
+        for _ in range(amount):
+            await asyncio.create_subprocess_exec(
+                "xdotool", "click", button,
+            )
+    else:
+        raise RuntimeError("No input backend available")
+
+    result = {"direction": direction, "amount": amount}
+    _log_action("scroll", result, "safe")
+    return result
+
+
+async def drag(from_x: int, from_y: int, to_x: int, to_y: int, duration: float = 0.5) -> dict:
+    """Drag from (from_x, from_y) to (to_x, to_y)."""
+    backend = _detect_backend()
+
+    if backend == "pyautogui":
+        pag = _get_pyautogui()
+        await asyncio.get_event_loop().run_in_executor(
+            None, lambda: (pag.moveTo(from_x, from_y), pag.drag(to_x - from_x, to_y - from_y, duration=duration))
+        )
+    elif backend == "pynput":
+        mc, _ = _get_pynput()
+        from pynput.mouse import Button
+        mc.position = (from_x, from_y)
+        mc.press(Button.left)
+        steps = max(10, int(duration * 60))
+        dx = (to_x - from_x) / steps
+        dy = (to_y - from_y) / steps
+        for i in range(steps):
+            mc.position = (int(from_x + dx * (i + 1)), int(from_y + dy * (i + 1)))
+            await asyncio.sleep(duration / steps)
+        mc.release(Button.left)
+    elif backend == "xdotool":
+        await asyncio.create_subprocess_exec(
+            "xdotool", "mousemove", str(from_x), str(from_y),
+            "mousedown", "1",
+        )
+        await asyncio.sleep(0.05)
+        await asyncio.create_subprocess_exec(
+            "xdotool", "mousemove", "--sync", str(to_x), str(to_y),
+            "mouseup", "1",
+        )
+    else:
+        raise RuntimeError("No input backend available")
+
+    result = {"from": (from_x, from_y), "to": (to_x, to_y), "duration_ms": int(duration * 1000)}
+    _log_action("drag", result, "moderate")
+    return result
+
+
+async def hotkey(*keys: str) -> dict:
+    """
+    Press a keyboard shortcut.
+    Examples: hotkey("ctrl", "s"), hotkey("alt", "f4")
+    """
+    backend = _detect_backend()
+    key_list = [k.lower().strip() for k in keys]
+
+    if backend == "pyautogui":
+        pag = _get_pyautogui()
+        await asyncio.get_event_loop().run_in_executor(
+            None, lambda: pag.hotkey(*key_list)
+        )
+    elif backend == "pynput":
+        _, kc = _get_pynput()
+        from pynput.keyboard import Key as PKey
+
+        _KEY_MAP = {
+            "ctrl": PKey.ctrl, "control": PKey.ctrl,
+            "alt": PKey.alt, "shift": PKey.shift,
+            "super": PKey.cmd, "win": PKey.cmd, "meta": PKey.cmd,
+            "tab": PKey.tab, "enter": PKey.enter, "return": PKey.enter,
+            "escape": PKey.esc, "esc": PKey.esc,
+            "space": PKey.space, "backspace": PKey.backspace,
+            "delete": PKey.delete, "del": PKey.delete,
+            "home": PKey.home, "end": PKey.end,
+            "pageup": PKey.page_up, "page_up": PKey.page_up,
+            "pagedown": PKey.page_down, "page_down": PKey.page_down,
+            "up": PKey.up, "down": PKey.down,
+            "left": PKey.left, "right": PKey.right,
+            "f1": PKey.f1, "f2": PKey.f2, "f3": PKey.f3, "f4": PKey.f4,
+            "f5": PKey.f5, "f6": PKey.f6, "f7": PKey.f7, "f8": PKey.f8,
+            "f9": PKey.f9, "f10": PKey.f10, "f11": PKey.f11, "f12": PKey.f12,
+        }
+
+        mapped: list = []
+        for k in key_list:
+            if k in _KEY_MAP:
+                mapped.append(_KEY_MAP[k])
+            elif len(k) == 1:
+                mapped.append(k)
+            else:
+                log.warning("Unknown key: %s", k)
+                mapped.append(k)
+
+        # Press all modifiers, tap the last key, release
+        for mk in mapped[:-1]:
+            kc.press(mk)
+        if mapped:
+            kc.press(mapped[-1])
+            kc.release(mapped[-1])
+        for mk in reversed(mapped[:-1]):
+            kc.release(mk)
+    elif backend == "xdotool":
+        xdo_keys = "+".join(key_list)
+        await asyncio.create_subprocess_exec("xdotool", "key", xdo_keys)
+    else:
+        raise RuntimeError("No input backend available")
+
+    risk = classify_action("hotkey", keys=key_list)
+    result = {"keys": key_list, "combo": "+".join(key_list)}
+    _log_action("hotkey", result, risk)
+    return result
+
+
+# ── Tool class ─────────────────────────────────────────────────────────────
+
+class InputControlTool(BaseTool):
+    name = "input_control"
+    description = (
+        "Simulate mouse and keyboard input: click, type, scroll, drag, hotkey. "
+        "Use after accessibility tool locates UI element coordinates. "
+        "Safety: safe=click/scroll, moderate=type/drag, destructive=hotkey(ctrl+w)."
+    )
+    risk_level = "destructive"
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        action = kwargs.get("action", "click")
+        backend = _detect_backend()
+
+        if backend == "none":
+            return ToolResult(
+                success=False, output="",
+                error=(
+                    "No input backend available. Install:\n"
+                    "  pip install pyautogui pynput\n"
+                    "or: sudo apt install xdotool"
+                ),
+            )
+
+        # Check if input control is enabled
+        if not config.input_control_enabled:
+            return ToolResult(
+                success=False, output="",
+                error="Input control is disabled. Set BANTZ_INPUT_CONTROL_ENABLED=true.",
+            )
+
+        try:
+            if action == "click":
+                return await self._click(kwargs)
+            elif action == "double_click":
+                return await self._double_click(kwargs)
+            elif action == "right_click":
+                return await self._right_click(kwargs)
+            elif action == "move_to":
+                return await self._move_to(kwargs)
+            elif action == "type_text":
+                return await self._type_text(kwargs)
+            elif action == "scroll":
+                return await self._scroll(kwargs)
+            elif action == "drag":
+                return await self._drag(kwargs)
+            elif action == "hotkey":
+                return await self._hotkey(kwargs)
+            elif action == "get_position":
+                return await self._get_position()
+            elif action == "action_log":
+                return self._action_log_result()
+            else:
+                return ToolResult(
+                    success=False, output="",
+                    error=f"Unknown action: {action}. Use: click, double_click, right_click, "
+                          f"move_to, type_text, scroll, drag, hotkey, get_position, action_log",
+                )
+        except Exception as exc:
+            return ToolResult(success=False, output="", error=f"Input error: {exc}")
+
+    async def _click(self, kwargs: dict) -> ToolResult:
+        x = int(kwargs.get("x", 0))
+        y = int(kwargs.get("y", 0))
+        if x == 0 and y == 0:
+            return ToolResult(success=False, output="", error="Specify x and y coordinates.")
+        result = await click(x, y)
+        return ToolResult(
+            success=True,
+            output=f"🖱  Clicked at ({x}, {y})",
+            data=result,
+        )
+
+    async def _double_click(self, kwargs: dict) -> ToolResult:
+        x = int(kwargs.get("x", 0))
+        y = int(kwargs.get("y", 0))
+        if x == 0 and y == 0:
+            return ToolResult(success=False, output="", error="Specify x and y coordinates.")
+        result = await double_click(x, y)
+        return ToolResult(
+            success=True,
+            output=f"🖱  Double-clicked at ({x}, {y})",
+            data=result,
+        )
+
+    async def _right_click(self, kwargs: dict) -> ToolResult:
+        x = int(kwargs.get("x", 0))
+        y = int(kwargs.get("y", 0))
+        if x == 0 and y == 0:
+            return ToolResult(success=False, output="", error="Specify x and y coordinates.")
+        result = await right_click(x, y)
+        return ToolResult(
+            success=True,
+            output=f"🖱  Right-clicked at ({x}, {y})",
+            data=result,
+        )
+
+    async def _move_to(self, kwargs: dict) -> ToolResult:
+        x = int(kwargs.get("x", 0))
+        y = int(kwargs.get("y", 0))
+        result = await move_to(x, y)
+        return ToolResult(
+            success=True,
+            output=f"🖱  Moved to ({x}, {y})",
+            data=result,
+        )
+
+    async def _type_text(self, kwargs: dict) -> ToolResult:
+        text = kwargs.get("text", "")
+        interval = float(kwargs.get("interval", 0.05))
+        if not text:
+            return ToolResult(success=False, output="", error="Specify text to type.")
+
+        # Safety preview for confirm_input_destructive
+        if config.input_confirm_destructive and len(text) > 50:
+            preview = text[:50] + "..."
+            # Brain handles confirmation; we just note it
+            log.info("Typing %d chars (preview: %s)", len(text), preview)
+
+        result = await type_text(text, interval)
+        display = text[:80] + "..." if len(text) > 80 else text
+        return ToolResult(
+            success=True,
+            output=f"⌨  Typed: \"{display}\" ({len(text)} chars, {int(interval*1000)}ms interval)",
+            data=result,
+        )
+
+    async def _scroll(self, kwargs: dict) -> ToolResult:
+        direction = kwargs.get("direction", "down")
+        amount = int(kwargs.get("amount", 3))
+        result = await scroll(direction, amount)
+        return ToolResult(
+            success=True,
+            output=f"🖱  Scrolled {direction} × {amount}",
+            data=result,
+        )
+
+    async def _drag(self, kwargs: dict) -> ToolResult:
+        from_x = int(kwargs.get("from_x", 0))
+        from_y = int(kwargs.get("from_y", 0))
+        to_x = int(kwargs.get("to_x", 0))
+        to_y = int(kwargs.get("to_y", 0))
+        duration = float(kwargs.get("duration", 0.5))
+        result = await drag(from_x, from_y, to_x, to_y, duration)
+        return ToolResult(
+            success=True,
+            output=f"🖱  Dragged ({from_x},{from_y}) → ({to_x},{to_y})",
+            data=result,
+        )
+
+    async def _hotkey(self, kwargs: dict) -> ToolResult:
+        keys_raw = kwargs.get("keys", "")
+        if isinstance(keys_raw, str):
+            key_list = [k.strip() for k in keys_raw.split("+") if k.strip()]
+        elif isinstance(keys_raw, (list, tuple)):
+            key_list = list(keys_raw)
+        else:
+            return ToolResult(success=False, output="", error="Specify keys (e.g., 'ctrl+s').")
+
+        if not key_list:
+            return ToolResult(success=False, output="", error="Specify keys (e.g., 'ctrl+s').")
+
+        risk = classify_action("hotkey", keys=key_list)
+        combo = "+".join(key_list)
+
+        # Destructive hotkeys require confirmation
+        if risk == "destructive" and config.input_confirm_destructive:
+            return ToolResult(
+                success=True,
+                output=f"⚠️  Destructive hotkey: {combo}\n   This may close windows or delete data.\n   Confirm to proceed.",
+                data={"keys": key_list, "combo": combo, "risk": risk, "_needs_confirm": True},
+            )
+
+        result = await hotkey(*key_list)
+        return ToolResult(
+            success=True,
+            output=f"⌨  Pressed: {combo}",
+            data=result,
+        )
+
+    async def _get_position(self) -> ToolResult:
+        pos = await get_position()
+        return ToolResult(
+            success=True,
+            output=f"🖱  Mouse at ({pos['x']}, {pos['y']})",
+            data=pos,
+        )
+
+    def _action_log_result(self) -> ToolResult:
+        log_entries = get_action_log()
+        if not log_entries:
+            return ToolResult(success=True, output="No input actions logged yet.", data={"log": []})
+
+        lines = [f"📋 Last {min(len(log_entries), 20)} input actions:"]
+        for entry in log_entries[-20:]:
+            lines.append(
+                f"  [{entry['risk']}] {entry['action']} "
+                f"@ {entry['timestamp']}"
+            )
+        return ToolResult(
+            success=True,
+            output="\n".join(lines),
+            data={"log": log_entries[-20:]},
+        )
+
+
+# ── Register ──────────────────────────────────────────────────────────────
+
+try:
+    registry.register(InputControlTool())
+except Exception:
+    pass  # pyautogui/pynput may not be installed

--- a/tests/test_input_control.py
+++ b/tests/test_input_control.py
@@ -1,0 +1,431 @@
+"""
+Tests for Bantz v3 — Input Control Tool (#122)
+
+Coverage:
+  - Backend detection
+  - Safety classification (safe/moderate/destructive)
+  - Action logging
+  - Click, double_click, right_click, move_to, scroll, drag, hotkey, type_text
+  - Tool class execute dispatch
+  - Config gating (input_control_enabled)
+  - Brain quick_route patterns
+  - Destructive hotkey confirmation
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch, MagicMock, AsyncMock
+
+import pytest
+
+from bantz.tools.input_control import (
+    classify_action,
+    _log_action,
+    _action_log,
+    get_action_log,
+    InputControlTool,
+    DESTRUCTIVE_HOTKEYS,
+    MODERATE_HOTKEYS,
+)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+@pytest.fixture(autouse=True)
+def clear_action_log():
+    """Clear action log before each test."""
+    _action_log.clear()
+    yield
+    _action_log.clear()
+
+
+@pytest.fixture
+def tool():
+    return InputControlTool()
+
+
+# ── Safety Classification ─────────────────────────────────────────────────
+
+class TestClassifyAction:
+    def test_click_is_safe(self):
+        assert classify_action("click") == "safe"
+
+    def test_move_to_is_safe(self):
+        assert classify_action("move_to") == "safe"
+
+    def test_scroll_is_safe(self):
+        assert classify_action("scroll") == "safe"
+
+    def test_get_position_is_safe(self):
+        assert classify_action("get_position") == "safe"
+
+    def test_double_click_moderate(self):
+        assert classify_action("double_click") == "moderate"
+
+    def test_right_click_moderate(self):
+        assert classify_action("right_click") == "moderate"
+
+    def test_drag_moderate(self):
+        assert classify_action("drag") == "moderate"
+
+    def test_type_text_moderate(self):
+        assert classify_action("type_text") == "moderate"
+
+    def test_hotkey_ctrl_s_moderate(self):
+        assert classify_action("hotkey", keys=("ctrl", "s")) == "moderate"
+
+    def test_hotkey_ctrl_w_destructive(self):
+        assert classify_action("hotkey", keys=("ctrl", "w")) == "destructive"
+
+    def test_hotkey_alt_f4_destructive(self):
+        assert classify_action("hotkey", keys=("alt", "f4")) == "destructive"
+
+    def test_hotkey_ctrl_q_destructive(self):
+        assert classify_action("hotkey", keys=("ctrl", "q")) == "destructive"
+
+    def test_hotkey_string_parsing(self):
+        assert classify_action("hotkey", keys="ctrl+w") == "destructive"
+
+    def test_hotkey_enter_moderate(self):
+        assert classify_action("hotkey", keys=("enter",)) == "moderate"
+
+    def test_unknown_hotkey_moderate(self):
+        assert classify_action("hotkey", keys=("ctrl", "shift", "f7")) == "moderate"
+
+    def test_unknown_action_moderate(self):
+        assert classify_action("unknown_action") == "moderate"
+
+
+class TestDestructiveHotkeySet:
+    def test_ctrl_w_in_set(self):
+        assert ("ctrl", "w") in DESTRUCTIVE_HOTKEYS
+
+    def test_alt_f4_in_set(self):
+        assert ("alt", "f4") in DESTRUCTIVE_HOTKEYS
+
+    def test_ctrl_s_not_destructive(self):
+        assert ("ctrl", "s") not in DESTRUCTIVE_HOTKEYS
+
+    def test_ctrl_s_in_moderate(self):
+        assert ("ctrl", "s") in MODERATE_HOTKEYS
+
+
+# ── Action Logging ────────────────────────────────────────────────────────
+
+class TestActionLog:
+    def test_log_adds_entry(self):
+        with patch("bantz.tools.input_control.log"):
+            _log_action("click", {"x": 100, "y": 200}, "safe")
+        entries = get_action_log()
+        assert len(entries) == 1
+        assert entries[0]["action"] == "click"
+        assert entries[0]["risk"] == "safe"
+        assert "timestamp" in entries[0]
+
+    def test_log_caps_at_500(self):
+        with patch("bantz.tools.input_control.log"):
+            for i in range(510):
+                _log_action("click", {"x": i}, "safe")
+        assert len(get_action_log()) == 500
+
+    def test_log_returns_copy(self):
+        with patch("bantz.tools.input_control.log"):
+            _log_action("click", {"x": 0}, "safe")
+        log1 = get_action_log()
+        log1.clear()
+        assert len(get_action_log()) == 1  # original not affected
+
+
+# ── Backend Detection ─────────────────────────────────────────────────────
+
+class TestBackendDetection:
+    @patch.dict("os.environ", {"XDG_SESSION_TYPE": "x11"}, clear=False)
+    @patch("bantz.tools.input_control._backend", None)
+    def test_x11_prefers_pyautogui(self):
+        from bantz.tools.input_control import _detect_backend
+        with patch.dict("sys.modules", {"pyautogui": MagicMock()}):
+            import bantz.tools.input_control as ic
+            ic._backend = None
+            backend = _detect_backend()
+            assert backend == "pyautogui"
+
+    @patch.dict("os.environ", {"XDG_SESSION_TYPE": "wayland", "WAYLAND_DISPLAY": "wayland-0"}, clear=False)
+    @patch("bantz.tools.input_control._backend", None)
+    def test_wayland_prefers_pynput(self):
+        from bantz.tools.input_control import _detect_backend
+        with patch.dict("sys.modules", {
+            "pynput": MagicMock(),
+            "pynput.mouse": MagicMock(),
+            "pynput.keyboard": MagicMock(),
+        }):
+            import bantz.tools.input_control as ic
+            ic._backend = None
+            backend = _detect_backend()
+            assert backend == "pynput"
+
+
+# ── Tool Execute (mocked backends) ───────────────────────────────────────
+
+class TestToolExecute:
+    @patch("bantz.tools.input_control.config")
+    @patch("bantz.tools.input_control._detect_backend", return_value="none")
+    async def test_no_backend(self, mock_detect, mock_cfg, tool):
+        mock_cfg.input_control_enabled = True
+        result = await tool.execute(action="click", x=100, y=200)
+        assert not result.success
+        assert "No input backend" in result.error
+
+    @patch("bantz.tools.input_control.config")
+    async def test_disabled(self, mock_cfg, tool):
+        mock_cfg.input_control_enabled = False
+        result = await tool.execute(action="click", x=100, y=200)
+        assert not result.success
+        assert "disabled" in result.error
+
+    @patch("bantz.tools.input_control.config")
+    @patch("bantz.tools.input_control._detect_backend", return_value="pyautogui")
+    @patch("bantz.tools.input_control.click", new_callable=AsyncMock, return_value={"x": 100, "y": 200, "button": "left"})
+    async def test_click(self, mock_click, mock_detect, mock_cfg, tool):
+        mock_cfg.input_control_enabled = True
+        result = await tool.execute(action="click", x=100, y=200)
+        assert result.success
+        assert "Clicked" in result.output
+        mock_click.assert_called_once_with(100, 200)
+
+    @patch("bantz.tools.input_control.config")
+    @patch("bantz.tools.input_control._detect_backend", return_value="pyautogui")
+    @patch("bantz.tools.input_control.double_click", new_callable=AsyncMock, return_value={"x": 100, "y": 200})
+    async def test_double_click(self, mock_dc, mock_detect, mock_cfg, tool):
+        mock_cfg.input_control_enabled = True
+        result = await tool.execute(action="double_click", x=100, y=200)
+        assert result.success
+        assert "Double-clicked" in result.output
+
+    @patch("bantz.tools.input_control.config")
+    @patch("bantz.tools.input_control._detect_backend", return_value="pyautogui")
+    @patch("bantz.tools.input_control.right_click", new_callable=AsyncMock, return_value={"x": 100, "y": 200})
+    async def test_right_click(self, mock_rc, mock_detect, mock_cfg, tool):
+        mock_cfg.input_control_enabled = True
+        result = await tool.execute(action="right_click", x=100, y=200)
+        assert result.success
+        assert "Right-clicked" in result.output
+
+    @patch("bantz.tools.input_control.config")
+    @patch("bantz.tools.input_control._detect_backend", return_value="pyautogui")
+    @patch("bantz.tools.input_control.move_to", new_callable=AsyncMock, return_value={"x": 300, "y": 400})
+    async def test_move_to(self, mock_move, mock_detect, mock_cfg, tool):
+        mock_cfg.input_control_enabled = True
+        result = await tool.execute(action="move_to", x=300, y=400)
+        assert result.success
+        assert "Moved" in result.output
+
+    @patch("bantz.tools.input_control.config")
+    @patch("bantz.tools.input_control._detect_backend", return_value="pyautogui")
+    @patch("bantz.tools.input_control.type_text", new_callable=AsyncMock, return_value={"text": "hello", "length": 5, "interval_ms": 50})
+    async def test_type_text(self, mock_type, mock_detect, mock_cfg, tool):
+        mock_cfg.input_control_enabled = True
+        mock_cfg.input_confirm_destructive = False
+        result = await tool.execute(action="type_text", text="hello")
+        assert result.success
+        assert "Typed" in result.output
+
+    @patch("bantz.tools.input_control.config")
+    @patch("bantz.tools.input_control._detect_backend", return_value="pyautogui")
+    @patch("bantz.tools.input_control.scroll", new_callable=AsyncMock, return_value={"direction": "down", "amount": 3})
+    async def test_scroll(self, mock_scroll, mock_detect, mock_cfg, tool):
+        mock_cfg.input_control_enabled = True
+        result = await tool.execute(action="scroll", direction="down", amount=3)
+        assert result.success
+        assert "Scrolled" in result.output
+
+    @patch("bantz.tools.input_control.config")
+    @patch("bantz.tools.input_control._detect_backend", return_value="pyautogui")
+    @patch("bantz.tools.input_control.drag", new_callable=AsyncMock, return_value={"from": (0, 0), "to": (100, 100)})
+    async def test_drag(self, mock_drag, mock_detect, mock_cfg, tool):
+        mock_cfg.input_control_enabled = True
+        result = await tool.execute(action="drag", from_x=0, from_y=0, to_x=100, to_y=100)
+        assert result.success
+        assert "Dragged" in result.output
+
+    @patch("bantz.tools.input_control.config")
+    @patch("bantz.tools.input_control._detect_backend", return_value="pyautogui")
+    @patch("bantz.tools.input_control.hotkey", new_callable=AsyncMock, return_value={"keys": ["ctrl", "s"], "combo": "ctrl+s"})
+    async def test_hotkey_safe(self, mock_hk, mock_detect, mock_cfg, tool):
+        mock_cfg.input_control_enabled = True
+        mock_cfg.input_confirm_destructive = True
+        result = await tool.execute(action="hotkey", keys="ctrl+s")
+        assert result.success
+        assert "Pressed" in result.output
+
+    @patch("bantz.tools.input_control.config")
+    @patch("bantz.tools.input_control._detect_backend", return_value="pyautogui")
+    async def test_hotkey_destructive_confirm(self, mock_detect, mock_cfg, tool):
+        mock_cfg.input_control_enabled = True
+        mock_cfg.input_confirm_destructive = True
+        result = await tool.execute(action="hotkey", keys="ctrl+w")
+        assert result.success
+        assert "_needs_confirm" in result.data
+        assert "Destructive" in result.output
+
+    @patch("bantz.tools.input_control.config")
+    @patch("bantz.tools.input_control._detect_backend", return_value="pyautogui")
+    @patch("bantz.tools.input_control.get_position", new_callable=AsyncMock, return_value={"x": 500, "y": 300})
+    async def test_get_position(self, mock_pos, mock_detect, mock_cfg, tool):
+        mock_cfg.input_control_enabled = True
+        result = await tool.execute(action="get_position")
+        assert result.success
+        assert "500" in result.output
+
+    @patch("bantz.tools.input_control.config")
+    @patch("bantz.tools.input_control._detect_backend", return_value="pyautogui")
+    async def test_action_log_result(self, mock_detect, mock_cfg, tool):
+        mock_cfg.input_control_enabled = True
+        result = await tool.execute(action="action_log")
+        assert result.success
+        assert "No input actions logged" in result.output
+
+    @patch("bantz.tools.input_control.config")
+    @patch("bantz.tools.input_control._detect_backend", return_value="pyautogui")
+    async def test_unknown_action(self, mock_detect, mock_cfg, tool):
+        mock_cfg.input_control_enabled = True
+        result = await tool.execute(action="nonexistent")
+        assert not result.success
+        assert "Unknown action" in result.error
+
+    @patch("bantz.tools.input_control.config")
+    @patch("bantz.tools.input_control._detect_backend", return_value="pyautogui")
+    async def test_click_no_coords(self, mock_detect, mock_cfg, tool):
+        mock_cfg.input_control_enabled = True
+        result = await tool.execute(action="click")
+        assert not result.success
+        assert "coordinates" in result.error
+
+    @patch("bantz.tools.input_control.config")
+    @patch("bantz.tools.input_control._detect_backend", return_value="pyautogui")
+    async def test_type_text_empty(self, mock_detect, mock_cfg, tool):
+        mock_cfg.input_control_enabled = True
+        result = await tool.execute(action="type_text", text="")
+        assert not result.success
+
+    @patch("bantz.tools.input_control.config")
+    @patch("bantz.tools.input_control._detect_backend", return_value="pyautogui")
+    async def test_hotkey_empty(self, mock_detect, mock_cfg, tool):
+        mock_cfg.input_control_enabled = True
+        result = await tool.execute(action="hotkey", keys="")
+        assert not result.success
+
+
+# ── Tool Properties ───────────────────────────────────────────────────────
+
+class TestToolProperties:
+    def test_name(self, tool):
+        assert tool.name == "input_control"
+
+    def test_risk_level(self, tool):
+        assert tool.risk_level == "destructive"
+
+    def test_description(self, tool):
+        assert "mouse" in tool.description.lower()
+        assert "keyboard" in tool.description.lower()
+
+    def test_schema(self, tool):
+        s = tool.schema()
+        assert s["name"] == "input_control"
+        assert s["risk_level"] == "destructive"
+
+
+# ── Brain Quick Route ─────────────────────────────────────────────────────
+
+class TestQuickRoute:
+    """Test brain._quick_route patterns for input control."""
+
+    @staticmethod
+    def _route(text: str):
+        from bantz.core.brain import Brain
+        return Brain._quick_route(text, text)
+
+    def test_scroll_down(self):
+        r = self._route("scroll down")
+        assert r is not None
+        assert r["tool"] == "input_control"
+        assert r["args"]["action"] == "scroll"
+        assert r["args"]["direction"] == "down"
+
+    def test_scroll_up_5(self):
+        r = self._route("scroll up 5")
+        assert r is not None
+        assert r["tool"] == "input_control"
+        assert r["args"]["direction"] == "up"
+        assert r["args"]["amount"] == 5
+
+    def test_type_quoted_text(self):
+        r = self._route('type "hello world"')
+        assert r is not None
+        assert r["tool"] == "input_control"
+        assert r["args"]["action"] == "type_text"
+        assert r["args"]["text"] == "hello world"
+
+    def test_hotkey_ctrl_s(self):
+        r = self._route("press ctrl+s")
+        assert r is not None
+        assert r["tool"] == "input_control"
+        assert r["args"]["action"] == "hotkey"
+        assert "ctrl+s" in r["args"]["keys"]
+
+    def test_press_enter(self):
+        r = self._route("press enter")
+        assert r is not None
+        assert r["tool"] == "input_control"
+        assert r["args"]["keys"] == "enter"
+
+    def test_press_escape(self):
+        r = self._route("press escape")
+        assert r is not None
+        assert r["tool"] == "input_control"
+        assert r["args"]["keys"] == "escape"
+
+    def test_double_click_coords(self):
+        r = self._route("double click at 500, 300")
+        assert r is not None
+        assert r["tool"] == "input_control"
+        assert r["args"]["action"] == "double_click"
+        assert r["args"]["x"] == 500
+        assert r["args"]["y"] == 300
+
+    def test_right_click_coords(self):
+        r = self._route("right click at 200, 100")
+        assert r is not None
+        assert r["tool"] == "input_control"
+        assert r["args"]["action"] == "right_click"
+
+    def test_drag_coords(self):
+        r = self._route("drag from 100, 200 to 300, 400")
+        assert r is not None
+        assert r["tool"] == "input_control"
+        assert r["args"]["action"] == "drag"
+        assert r["args"]["from_x"] == 100
+        assert r["args"]["to_x"] == 300
+
+    def test_mouse_position(self):
+        r = self._route("mouse position")
+        assert r is not None
+        assert r["tool"] == "input_control"
+        assert r["args"]["action"] == "get_position"
+
+    def test_move_mouse(self):
+        r = self._route("move mouse to 500, 300")
+        assert r is not None
+        assert r["tool"] == "input_control"
+        assert r["args"]["action"] == "move_to"
+        assert r["args"]["x"] == 500
+
+    def test_click_the_still_goes_to_a11y(self):
+        """'click the Send button' should go to accessibility, not input_control."""
+        r = self._route("click the Send button in Firefox")
+        assert r is not None
+        assert r["tool"] == "accessibility"
+
+    def test_scroll_doesnt_match_random(self):
+        r = self._route("what is a scrollbar?")
+        # Should NOT match input_control
+        assert r is None or r.get("tool") != "input_control"


### PR DESCRIPTION
## Issue #122 — PyAutoGUI/pynput Input Simulation

### Changes

- **`src/bantz/tools/input_control.py`** (~550 lines) — Mouse & keyboard automation
  - `click(x,y)`, `double_click(x,y)`, `right_click(x,y)`
  - `type_text(text, interval)` — human-like 50ms default delay
  - `scroll(direction, amount)`, `drag(from_xy, to_xy)`
  - `hotkey(*keys)` — e.g., `hotkey('ctrl', 's')`
  - `move_to(x,y)`, `get_position()`
  - X11: pyautogui | Wayland: pynput | fallback: xdotool
  - `pyautogui.FAILSAFE = True` — corner mouse abort
  - Safety: safe/moderate/destructive classification per action
  - All actions logged with timestamps (RL training data)
  - Destructive hotkeys (ctrl+w, alt+f4) require confirmation

- **`src/bantz/config.py`** — New fields:
  - `BANTZ_INPUT_CONTROL_ENABLED` (default: false)
  - `BANTZ_INPUT_CONFIRM_DESTRUCTIVE` (default: true)
  - `BANTZ_INPUT_TYPE_INTERVAL_MS` (default: 50)

- **`src/bantz/core/brain.py`** — Quick route patterns:
  - scroll, type_text, hotkey, double/right click, drag, mouse position, move

- **`src/bantz/__main__.py`** — `--doctor` shows:
  - Input control status + backend detection
  - Spatial cache statistics (#121)

- **`pyproject.toml`** — `[automation]` optional deps group
- **`tests/test_input_control.py`** — 59 tests

### Test Results
386 tests passed (327 existing + 59 new), zero regressions.

Closes #122