### PR TITLE
feat(vision): unified navigation pipeline — AT-SPI → Cache → VLM → fallback chain

### DIFF
--- a/src/bantz/__main__.py
+++ b/src/bantz/__main__.py
@@ -645,6 +645,21 @@ async def _doctor() -> None:
     except Exception:
         print("○ Spatial cache: not initialized")
 
+    # Navigator Pipeline (#123)
+    try:
+        from bantz.vision.navigator import navigator as _nav
+        _nav.init(config.db_path)
+        nav_stats = _nav.stats()
+        total = nav_stats.get('total_attempts', 0)
+        methods = nav_stats.get('methods', [])
+        if total > 0:
+            summary = ', '.join(f"{m['method']}={m['successes']}/{m['attempts']}" for m in methods)
+            print(f"✓ Navigator: {total} attempts  ({summary})")
+        else:
+            print(f"✓ Navigator: ready (no attempts yet)")
+    except Exception:
+        print("○ Navigator: not initialized")
+
     # Telegram
     tg_ok = bool(config.telegram_bot_token)
     tg_icon = "✓" if tg_ok else "○"

--- a/src/bantz/core/brain.py
+++ b/src/bantz/core/brain.py
@@ -134,6 +134,10 @@ class Brain:
             import bantz.tools.accessibility  # noqa: F401
         except (ImportError, ModuleNotFoundError):
             pass  # AT-SPI2/gi deps may not be installed
+        try:
+            import bantz.tools.gui_action  # noqa: F401  (#123)
+        except (ImportError, ModuleNotFoundError):
+            pass
         self._bridge = None
         self._memory_ready = False
         self._graph_ready = False
@@ -521,6 +525,61 @@ class Brain:
                                     "what's today", "what do i have today")):
             return {"tool": "_briefing", "args": {}}
 
+        # GUI Action — unified navigate + act pipeline (#123)
+        # Must come BEFORE web_search since "search bar" contains "search".
+        # Order: specific (type, double_click, right_click) before general click.
+        _gui_type_m = re.search(
+            r"type\s+[\"'](.+?)[\"']\s+(?:into|in|on)\s+(?:the\s+)?(.+?)\s+(?:in|on|of)\s+(.+?)(?:\s*$|\s*please)",
+            both, re.IGNORECASE,
+        )
+        if _gui_type_m:
+            return {"tool": "gui_action", "args": {
+                "action": "type", "text": _gui_type_m.group(1),
+                "label": _gui_type_m.group(2).strip(),
+                "app": _gui_type_m.group(3).strip(),
+            }}
+        _gui_dbl_m = re.search(
+            r"double[- ]?click\s+(?:the\s+|on\s+)?(.+?)\s+(?:in|on)\s+(.+?)(?:\s*$|\s*please)",
+            both, re.IGNORECASE,
+        )
+        if _gui_dbl_m:
+            return {"tool": "gui_action", "args": {
+                "action": "double_click", "label": _gui_dbl_m.group(1).strip(),
+                "app": _gui_dbl_m.group(2).strip(),
+            }}
+        _gui_rc_m = re.search(
+            r"right[- ]?click\s+(?:the\s+|on\s+)?(.+?)\s+(?:in|on)\s+(.+?)(?:\s*$|\s*please)",
+            both, re.IGNORECASE,
+        )
+        if _gui_rc_m:
+            return {"tool": "gui_action", "args": {
+                "action": "right_click", "label": _gui_rc_m.group(1).strip(),
+                "app": _gui_rc_m.group(2).strip(),
+            }}
+        _gui_m = re.search(
+            r"(?:click|press|tap)\s+(?:the\s+|on\s+)?[\"']?(.+?)[\"']?"
+            r"\s+(?:button\s+|element\s+|link\s+|tab\s+|field\s+|input\s+)?"
+            r"(?:in|on|of)\s+(.+?)(?:\s*$|\s*please)",
+            both, re.IGNORECASE,
+        )
+        if _gui_m:
+            return {"tool": "gui_action", "args": {
+                "action": "click", "label": _gui_m.group(1).strip(),
+                "app": _gui_m.group(2).strip(),
+            }}
+        _gui_find_m = re.search(
+            r"(?:find|locate|navigate to|go to)\s+(?:the\s+)?(.+?)\s+(?:in|on)\s+(.+?)(?:\s*$|\s*please)",
+            both, re.IGNORECASE,
+        )
+        if _gui_find_m and any(k in both for k in (
+            "find the button", "find element", "find ui", "locate",
+            "navigate to", "go to the",
+        )):
+            return {"tool": "gui_action", "args": {
+                "action": "navigate", "label": _gui_find_m.group(1).strip(),
+                "app": _gui_find_m.group(2).strip(),
+            }}
+
         # Web search
         if any(k in both for k in ("search", "look up", "find online", "google",
                                     "is there any", "anything about")):
@@ -610,8 +669,8 @@ class Brain:
             "focus window", "focus app", "switch to",
             "element tree", "ui tree",
             "screenshot", "what's on my screen", "what is on my screen",
-            "what's on screen", "describe screen", "analyze screen",
-            "screen analysis", "vlm",
+            "what's on screen", "describe screen", "describe my screen",
+            "analyze screen", "screen analysis", "vlm",
         ))
         if _is_a11y:
             # Screenshot / VLM direct analysis (#120)

--- a/src/bantz/data/layer.py
+++ b/src/bantz/data/layer.py
@@ -115,6 +115,14 @@ class DataLayer:
         except Exception as exc:
             log.debug("Spatial cache init skipped: %s", exc)
 
+        # ── Navigation pipeline (#123) ───────────────────────────────────
+        try:
+            from bantz.vision.navigator import navigator
+            navigator.init(cfg.db_path)
+            log.debug("Navigator pipeline initialized")
+        except Exception as exc:
+            log.debug("Navigator init skipped: %s", exc)
+
         # ── Auto-migrate JSON → SQLite if tables are empty ───────────────
         base_dir = (
             Path(cfg.data_dir)
@@ -225,6 +233,12 @@ class DataLayer:
         try:
             from bantz.vision.spatial_cache import spatial_db
             spatial_db.close()
+        except Exception:
+            pass
+        # Close navigator (#123)
+        try:
+            from bantz.vision.navigator import navigator
+            navigator.close()
         except Exception:
             pass
         if self.graph is not None:

--- a/src/bantz/personality/system_prompt.py
+++ b/src/bantz/personality/system_prompt.py
@@ -36,6 +36,9 @@ RULES:
 - calendar: events, meetings, calendar, schedule
 - classroom: assignments, homework, deadlines
 - filesystem: read/write specific file content
+- gui_action: click/type/interact with UI elements in applications (uses AT-SPI, cache, VLM)
+- accessibility: list apps, focus windows, element trees, screenshots
+- input_control: raw mouse/keyboard — scroll, hotkeys, drag, mouse position
 - chat: ONLY if no tool can handle it
 
 NEVER refuse system queries. NEVER use "chat" when a tool applies.

--- a/src/bantz/tools/gui_action.py
+++ b/src/bantz/tools/gui_action.py
@@ -1,0 +1,164 @@
+"""
+Bantz v3 — GUI Action Tool (#123)
+
+Unified tool for natural-language GUI interactions.
+Bridges the Navigator pipeline (AT-SPI → Cache → VLM → fallback) with
+the Input Control backend to execute commands like:
+
+    "click the Send button in Firefox"
+    "type 'hello world' into the search bar in Chrome"
+    "open a new tab in Firefox"
+
+Registered as ``gui_action`` in the tool registry.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from bantz.tools import BaseTool, ToolResult, registry
+
+log = logging.getLogger("bantz.tools.gui_action")
+
+
+class GUIActionTool(BaseTool):
+    """One-shot GUI interaction: navigate to element → perform action.
+
+    Actions:
+        click          — find element → click its center
+        double_click   — find element → double-click
+        right_click    — find element → right-click
+        type           — find element → click → type text
+        focus          — focus application window (no element needed)
+        navigate       — just find element, return coordinates
+        stats          — navigation analytics
+
+    Required args:
+        app   — application name (e.g., "firefox", "vscode")
+
+    Optional args:
+        label  — element description (e.g., "search bar", "send button")
+        text   — text to type (for action="type")
+        role   — AT-SPI role filter (e.g., "push button")
+    """
+
+    name = "gui_action"
+    description = (
+        "Navigate to a UI element in any application and perform an action "
+        "(click, double_click, right_click, type, focus). Uses AT-SPI, "
+        "spatial cache, and VLM vision in order of speed."
+    )
+    risk_level = "moderate"
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        action = kwargs.get("action", "click")
+        app = kwargs.get("app", "")
+        label = kwargs.get("label", "")
+        text = kwargs.get("text", "")
+        role = kwargs.get("role")
+
+        # ── Stats ────────────────────────────────────────────
+        if action == "stats":
+            return self._stats(app or None)
+
+        # ── Input validation ─────────────────────────────────
+        if not app:
+            return ToolResult(
+                success=False,
+                output="Application name is required.",
+                error="missing_app",
+            )
+
+        if action not in ("focus",) and not label:
+            return ToolResult(
+                success=False,
+                output="Element label is required for this action.",
+                error="missing_label",
+            )
+
+        # ── Check input control is enabled for actions that need it
+        if action not in ("navigate", "stats"):
+            from bantz.config import config
+            if not config.input_control_enabled:
+                # Allow navigate-only even when input control is off
+                if action != "focus":
+                    return ToolResult(
+                        success=False,
+                        output="Input control is disabled. Enable BANTZ_INPUT_CONTROL_ENABLED first.",
+                        error="input_disabled",
+                    )
+
+        # ── Execute ──────────────────────────────────────────
+        from bantz.vision.navigator import navigator
+
+        if action == "navigate":
+            # Just find, don't act
+            nav = await navigator.navigate_to(app, label, role_filter=role)
+            if nav.found:
+                cx, cy = nav.center
+                return ToolResult(
+                    success=True,
+                    output=(
+                        f"Found '{label}' in {app} at ({cx}, {cy}) "
+                        f"via {nav.method} (conf={nav.confidence:.2f}, {nav.latency_ms:.0f}ms)"
+                    ),
+                    data=nav.to_dict(),
+                )
+            return ToolResult(
+                success=False,
+                output=f"Could not find '{label}' in {app}.",
+                data=nav.to_dict(),
+                error="not_found",
+            )
+
+        # Actions that interact with the UI
+        result = await navigator.execute_action(
+            action, app, label, text=text, role_filter=role,
+        )
+
+        if result.success:
+            return ToolResult(
+                success=True,
+                output=result.message,
+                data=result.to_dict(),
+            )
+
+        return ToolResult(
+            success=False,
+            output=result.error or f"Failed to {action} '{label}' in {app}.",
+            data=result.to_dict(),
+            error=result.error,
+        )
+
+    def _stats(self, app: str | None) -> ToolResult:
+        """Navigation analytics."""
+        try:
+            from bantz.vision.navigator import navigator
+            stats = navigator.analytics.app_stats(app)
+            if not stats.get("methods"):
+                return ToolResult(
+                    success=True,
+                    output="No navigation data yet.",
+                    data=stats,
+                )
+            lines = [f"Navigation stats{f' for {app}' if app else ''}:"]
+            for m in stats["methods"]:
+                rate = m["successes"] / max(m["attempts"], 1) * 100
+                lines.append(
+                    f"  {m['method']}: {m['successes']}/{m['attempts']} "
+                    f"({rate:.0f}%) avg={m['avg_latency_ms']:.0f}ms"
+                )
+            lines.append(f"Total: {stats['total_attempts']} attempts")
+            return ToolResult(
+                success=True,
+                output="\n".join(lines),
+                data=stats,
+            )
+        except Exception as exc:
+            return ToolResult(success=False, output=str(exc), error=str(exc))
+
+
+# ── Auto-register ─────────────────────────────────────────────────────────────
+
+_tool = GUIActionTool()
+registry.register(_tool)

--- a/src/bantz/vision/navigator.py
+++ b/src/bantz/vision/navigator.py
@@ -1,0 +1,604 @@
+"""
+Bantz v3 — Unified Navigation Pipeline (#123)
+
+Orchestrates AT-SPI → Spatial Cache → Remote VLM → fallback chain into a
+single pipeline that ``Brain`` calls with natural language like
+"click the search bar in Firefox".
+
+Pipeline order:
+    1. Spatial Cache — instant (< 1 ms), if we've seen this element before
+    2. AT-SPI       — reliable on GTK/Qt apps, ~50-200 ms
+    3. Remote VLM   — screenshot + vision model, ~2-5 s
+    4. Give up      — return None, ask user
+
+Why cache first?  It's O(1) with high confidence after the first lookup.
+AT-SPI tree walks cost 50-200 ms and can fail on Electron/custom-drawn UIs.
+VLM is the most expensive but works on *any* visible UI.
+
+Analytics are stored per-app so Bantz learns which method works best for
+each application over time.
+
+Usage:
+    from bantz.vision.navigator import navigator
+
+    result = await navigator.navigate_to("firefox", "search bar")
+    if result:
+        print(f"Found at ({result.x}, {result.y}) via {result.method}")
+        await navigator.execute_action("click", "firefox", "search bar")
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+import threading
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Optional
+
+log = logging.getLogger("bantz.vision.navigator")
+
+
+# ━━ Data types ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+@dataclass
+class NavResult:
+    """Result of a navigation attempt."""
+    found: bool
+    x: int = 0
+    y: int = 0
+    width: int = 0
+    height: int = 0
+    method: str = ""          # "cache", "atspi", "vlm", "none"
+    confidence: float = 0.0
+    latency_ms: float = 0.0
+    app_name: str = ""
+    element_label: str = ""
+    role: str = ""
+    extra: dict = field(default_factory=dict)
+
+    @property
+    def center(self) -> tuple[int, int]:
+        if self.width and self.height:
+            return (self.x + self.width // 2, self.y + self.height // 2)
+        return (self.x, self.y)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "found": self.found,
+            "x": self.x,
+            "y": self.y,
+            "width": self.width,
+            "height": self.height,
+            "center_x": self.center[0],
+            "center_y": self.center[1],
+            "method": self.method,
+            "confidence": round(self.confidence, 3),
+            "latency_ms": round(self.latency_ms, 1),
+            "app": self.app_name,
+            "element": self.element_label,
+            "role": self.role,
+        }
+
+
+@dataclass
+class ActionResult:
+    """Result of a full GUI action (navigate + interact)."""
+    success: bool
+    nav: NavResult
+    action: str = ""
+    message: str = ""
+    error: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        d = self.nav.to_dict()
+        d.update({
+            "success": self.success,
+            "action": self.action,
+            "message": self.message,
+            "error": self.error,
+        })
+        return d
+
+
+# ━━ Analytics ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class NavigationAnalytics:
+    """Track per-app navigation success rates and method preferences.
+
+    Schema:
+        nav_analytics(
+            id          INTEGER PRIMARY KEY,
+            app_name    TEXT NOT NULL,
+            element     TEXT NOT NULL,
+            method      TEXT NOT NULL,     -- cache, atspi, vlm, none
+            success     INTEGER NOT NULL,  -- 0 or 1
+            latency_ms  REAL,
+            confidence  REAL,
+            created_at  TEXT NOT NULL
+        )
+    """
+
+    def __init__(self) -> None:
+        self._conn: Optional[sqlite3.Connection] = None
+        self._lock = threading.Lock()
+
+    def init(self, db_path: Path) -> None:
+        """Initialize analytics table — reuses main DB."""
+        self._conn = sqlite3.connect(str(db_path), check_same_thread=False, isolation_level=None)
+        self._conn.row_factory = sqlite3.Row
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("""
+            CREATE TABLE IF NOT EXISTS nav_analytics (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                app_name    TEXT NOT NULL,
+                element     TEXT NOT NULL,
+                method      TEXT NOT NULL,
+                success     INTEGER NOT NULL DEFAULT 0,
+                latency_ms  REAL,
+                confidence  REAL,
+                created_at  TEXT NOT NULL
+            )
+        """)
+        self._conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_nav_app
+                ON nav_analytics(app_name)
+        """)
+        log.debug("Navigation analytics table ready")
+
+    def record(
+        self,
+        app_name: str,
+        element: str,
+        method: str,
+        success: bool,
+        latency_ms: float = 0.0,
+        confidence: float = 0.0,
+    ) -> None:
+        """Record a single navigation attempt."""
+        if not self._conn:
+            return
+        now = datetime.now().isoformat(timespec="seconds")
+        with self._lock:
+            self._conn.execute(
+                """INSERT INTO nav_analytics
+                   (app_name, element, method, success, latency_ms, confidence, created_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                (app_name.lower(), element.lower(), method, int(success),
+                 latency_ms, confidence, now),
+            )
+
+    def best_method_for_app(self, app_name: str) -> Optional[str]:
+        """Return the method that most often succeeds for this app.
+
+        Returns None if no data or too few samples.
+        """
+        if not self._conn:
+            return None
+        rows = self._conn.execute(
+            """SELECT method, COUNT(*) as cnt, AVG(success) as rate
+               FROM nav_analytics
+               WHERE app_name = ? AND success = 1
+               GROUP BY method
+               ORDER BY cnt DESC, rate DESC
+               LIMIT 1""",
+            (app_name.lower(),),
+        ).fetchall()
+        if rows and rows[0]["cnt"] >= 3:
+            return rows[0]["method"]
+        return None
+
+    def app_stats(self, app_name: Optional[str] = None) -> dict:
+        """Aggregated stats per method, optionally filtered by app."""
+        if not self._conn:
+            return {"enabled": False}
+        where = ""
+        params: tuple = ()
+        if app_name:
+            where = "WHERE app_name = ?"
+            params = (app_name.lower(),)
+        rows = self._conn.execute(
+            f"""SELECT method,
+                       COUNT(*) as attempts,
+                       SUM(success) as successes,
+                       AVG(latency_ms) as avg_latency_ms,
+                       AVG(confidence) as avg_confidence
+                FROM nav_analytics {where}
+                GROUP BY method
+                ORDER BY successes DESC""",
+            params,
+        ).fetchall()
+        return {
+            "methods": [dict(r) for r in rows],
+            "total_attempts": sum(r["attempts"] for r in rows) if rows else 0,
+        }
+
+    def close(self) -> None:
+        if self._conn:
+            self._conn.close()
+            self._conn = None
+
+
+# ━━ Navigator Pipeline ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class Navigator:
+    """Unified UI element navigation pipeline.
+
+    Tries methods in order of speed:
+      1. Spatial Cache  — < 1 ms, persistent across sessions
+      2. AT-SPI         — 50-200 ms, native accessibility tree
+      3. Remote VLM     — 2-5 s, screenshot + vision model
+      4. Fail           — return NavResult(found=False)
+
+    Successful navigations are auto-stored in the Spatial Cache for
+    future instant lookups.
+
+    If analytics has enough data, the pipeline reorders methods to
+    try the most successful one first for each app.
+    """
+
+    def __init__(self) -> None:
+        self.analytics = NavigationAnalytics()
+        self._initialized = False
+
+    def init(self, db_path: Path) -> None:
+        """Initialize — call once at startup (DataLayer handles this)."""
+        if self._initialized:
+            return
+        self.analytics.init(db_path)
+        self._initialized = True
+        log.debug("Navigator initialized")
+
+    # ── Core Pipeline ─────────────────────────────────────────────────────
+
+    async def navigate_to(
+        self,
+        app_name: str,
+        element_label: str,
+        *,
+        role_filter: Optional[str] = None,
+        preferred_method: Optional[str] = None,
+    ) -> NavResult:
+        """Find a UI element using the multi-method pipeline.
+
+        Args:
+            app_name: Application name (e.g., "firefox", "vscode")
+            element_label: Human description (e.g., "search bar", "save button")
+            role_filter: Optional AT-SPI role (e.g., "push button")
+            preferred_method: Force a specific method ("cache", "atspi", "vlm")
+
+        Returns:
+            NavResult with coordinates if found, or found=False
+        """
+        start = time.monotonic()
+
+        # Determine method order — analytics-optimized or default
+        if preferred_method:
+            methods = [preferred_method]
+        else:
+            methods = self._method_order(app_name)
+
+        result = NavResult(
+            found=False,
+            app_name=app_name,
+            element_label=element_label,
+            method="none",
+        )
+
+        for method in methods:
+            try:
+                if method == "cache":
+                    r = self._try_cache(app_name, element_label)
+                elif method == "atspi":
+                    r = self._try_atspi(app_name, element_label, role_filter)
+                elif method == "vlm":
+                    r = await self._try_vlm(app_name, element_label)
+                else:
+                    continue
+
+                elapsed = (time.monotonic() - start) * 1000
+
+                if r and r.found:
+                    r.latency_ms = elapsed
+                    r.app_name = app_name
+                    r.element_label = element_label
+
+                    # Auto-store in cache if method wasn't cache
+                    if method != "cache":
+                        self._store_in_cache(r)
+
+                    # Record analytics
+                    self.analytics.record(
+                        app_name, element_label, method,
+                        success=True, latency_ms=elapsed,
+                        confidence=r.confidence,
+                    )
+                    log.info(
+                        "nav ✓  %s/%s via %s  (%.0f ms, conf=%.2f)",
+                        app_name, element_label, method, elapsed, r.confidence,
+                    )
+                    return r
+
+                # Record failed attempt for this method
+                self.analytics.record(
+                    app_name, element_label, method,
+                    success=False, latency_ms=(time.monotonic() - start) * 1000,
+                )
+
+            except Exception as exc:
+                log.debug("nav %s failed for %s/%s: %s", method, app_name, element_label, exc)
+                self.analytics.record(
+                    app_name, element_label, method,
+                    success=False,
+                )
+
+        # All methods failed
+        elapsed = (time.monotonic() - start) * 1000
+        result.latency_ms = elapsed
+        log.warning("nav ✗  %s/%s — all methods failed (%.0f ms)", app_name, element_label, elapsed)
+        return result
+
+    # ── GUI Actions ───────────────────────────────────────────────────────
+
+    async def execute_action(
+        self,
+        action: str,
+        app_name: str,
+        element_label: str,
+        *,
+        text: str = "",
+        role_filter: Optional[str] = None,
+    ) -> ActionResult:
+        """Navigate to element then perform an action.
+
+        Supported actions:
+            click, double_click, right_click, type, focus
+
+        For "type": navigates → clicks → types text.
+        For "focus": just focuses the window (no element needed).
+        """
+        # Focus-only doesn't need navigation
+        if action == "focus":
+            return await self._action_focus(app_name)
+
+        # Navigate to the element
+        nav = await self.navigate_to(app_name, element_label, role_filter=role_filter)
+
+        if not nav.found:
+            return ActionResult(
+                success=False,
+                nav=nav,
+                action=action,
+                message="",
+                error=f"Could not find '{element_label}' in {app_name}. "
+                       f"Tried: {', '.join(self._method_order(app_name))}.",
+            )
+
+        cx, cy = nav.center
+
+        # Perform the action at the found coordinates
+        try:
+            if action == "click":
+                await self._do_click(cx, cy)
+            elif action == "double_click":
+                await self._do_double_click(cx, cy)
+            elif action == "right_click":
+                await self._do_right_click(cx, cy)
+            elif action == "type":
+                await self._do_click(cx, cy)
+                if text:
+                    await self._do_type(text)
+            else:
+                return ActionResult(
+                    success=False, nav=nav, action=action,
+                    error=f"Unknown action: {action}",
+                )
+
+            return ActionResult(
+                success=True,
+                nav=nav,
+                action=action,
+                message=(
+                    f"{action} on '{element_label}' in {app_name} "
+                    f"at ({cx}, {cy}) via {nav.method}"
+                ),
+            )
+        except Exception as exc:
+            log.error("Action %s failed at (%d,%d): %s", action, cx, cy, exc)
+            return ActionResult(
+                success=False, nav=nav, action=action,
+                error=f"Action failed: {exc}",
+            )
+
+    # ── Method Implementations ────────────────────────────────────────────
+
+    def _method_order(self, app_name: str) -> list[str]:
+        """Determine method order — default or analytics-optimized."""
+        default = ["cache", "atspi", "vlm"]
+        best = self.analytics.best_method_for_app(app_name)
+        if best and best in default:
+            # Promote best method to first, keep others
+            order = [best] + [m for m in default if m != best]
+            return order
+        return default
+
+    def _try_cache(self, app_name: str, label: str) -> Optional[NavResult]:
+        """Step 1: Spatial Cache lookup."""
+        try:
+            from bantz.vision.spatial_cache import spatial_db
+            entry = spatial_db.lookup(app_name, label)
+            if entry and not entry.is_expired:
+                return NavResult(
+                    found=True,
+                    x=entry.x, y=entry.y,
+                    width=entry.width, height=entry.height,
+                    method="cache",
+                    confidence=entry.effective_confidence,
+                    role=entry.role,
+                )
+        except Exception as exc:
+            log.debug("Cache lookup failed: %s", exc)
+        return None
+
+    def _try_atspi(
+        self, app_name: str, label: str, role_filter: Optional[str] = None,
+    ) -> Optional[NavResult]:
+        """Step 2: AT-SPI accessibility tree search."""
+        try:
+            from bantz.tools.accessibility import find_element
+            elem = find_element(app_name, label, role_filter=role_filter)
+            if elem and elem.get("bounds"):
+                b = elem["bounds"]
+                cx, cy = elem.get("center", (b["x"] + b["width"] // 2, b["y"] + b["height"] // 2))
+                return NavResult(
+                    found=True,
+                    x=b["x"], y=b["y"],
+                    width=b["width"], height=b["height"],
+                    method="atspi",
+                    confidence=elem.get("score", 1.0),
+                    role=elem.get("role", ""),
+                )
+        except Exception as exc:
+            log.debug("AT-SPI lookup failed: %s", exc)
+        return None
+
+    async def _try_vlm(self, app_name: str, label: str) -> Optional[NavResult]:
+        """Step 3: Remote VLM screenshot analysis."""
+        try:
+            from bantz.config import config
+            if not config.vlm_enabled:
+                return None
+
+            from bantz.vision.screenshot import capture_window_base64, capture_base64
+            from bantz.vision.remote_vlm import analyze_screenshot
+
+            # Try capturing the specific app window, fall back to full screen
+            img_b64 = None
+            try:
+                img_b64 = capture_window_base64(app_name)
+            except Exception:
+                pass
+            if not img_b64:
+                img_b64 = capture_base64()
+            if not img_b64:
+                return None
+
+            vlm_result = await analyze_screenshot(img_b64, label=label)
+            if not vlm_result.success or not vlm_result.elements:
+                return None
+
+            # Try to find the specific element by label
+            match = vlm_result.find(label)
+            if not match:
+                match = vlm_result.best
+            if not match:
+                return None
+
+            # Store all detected elements in cache (background enrichment)
+            self._store_vlm_elements(app_name, vlm_result.elements)
+
+            return NavResult(
+                found=True,
+                x=match.x, y=match.y,
+                width=match.width, height=match.height,
+                method="vlm",
+                confidence=match.confidence * 0.7,  # Discount VLM confidence
+                role=match.role,
+            )
+        except Exception as exc:
+            log.debug("VLM lookup failed: %s", exc)
+        return None
+
+    # ── Cache Storage ─────────────────────────────────────────────────────
+
+    def _store_in_cache(self, nav: NavResult) -> None:
+        """Auto-store a successful navigation result in Spatial Cache."""
+        try:
+            from bantz.vision.spatial_cache import spatial_db
+            source_map = {"atspi": "atspi", "vlm": "vlm"}
+            source = source_map.get(nav.method, "manual")
+            spatial_db.store(
+                nav.app_name, nav.element_label,
+                x=nav.x, y=nav.y,
+                width=nav.width, height=nav.height,
+                role=nav.role, source=source,
+                confidence=nav.confidence,
+            )
+        except Exception as exc:
+            log.debug("Cache store failed: %s", exc)
+
+    def _store_vlm_elements(self, app_name: str, elements: list) -> None:
+        """Store all VLM-detected elements for future lookups."""
+        try:
+            from bantz.vision.spatial_cache import spatial_db
+            for elem in elements:
+                spatial_db.store(
+                    app_name, elem.label,
+                    x=elem.x, y=elem.y,
+                    width=elem.width, height=elem.height,
+                    role=elem.role, source="vlm",
+                    confidence=elem.confidence * 0.7,
+                )
+        except Exception as exc:
+            log.debug("VLM elements cache store failed: %s", exc)
+
+    # ── Input Actions ─────────────────────────────────────────────────────
+
+    async def _do_click(self, x: int, y: int) -> None:
+        """Click at coordinates using input_control backend."""
+        from bantz.tools.input_control import click
+        await click(x, y)
+
+    async def _do_double_click(self, x: int, y: int) -> None:
+        from bantz.tools.input_control import double_click
+        await double_click(x, y)
+
+    async def _do_right_click(self, x: int, y: int) -> None:
+        from bantz.tools.input_control import right_click
+        await right_click(x, y)
+
+    async def _do_type(self, text: str) -> None:
+        from bantz.tools.input_control import type_text
+        from bantz.config import config
+        interval = config.input_type_interval_ms / 1000.0
+        await type_text(text, interval=interval)
+
+    async def _action_focus(self, app_name: str) -> ActionResult:
+        """Focus a window without element navigation."""
+        try:
+            from bantz.tools.accessibility import focus_window
+            ok = focus_window(app_name)
+            nav = NavResult(found=ok, app_name=app_name, element_label="", method="atspi")
+            return ActionResult(
+                success=ok,
+                nav=nav,
+                action="focus",
+                message=f"Focused {app_name}" if ok else "",
+                error="" if ok else f"Could not focus {app_name}",
+            )
+        except Exception as exc:
+            nav = NavResult(found=False, app_name=app_name, element_label="", method="none")
+            return ActionResult(
+                success=False, nav=nav, action="focus",
+                error=f"Focus failed: {exc}",
+            )
+
+    # ── Diagnostics ───────────────────────────────────────────────────────
+
+    def stats(self) -> dict:
+        """Navigation analytics summary."""
+        base = self.analytics.app_stats()
+        base["initialized"] = self._initialized
+        return base
+
+    def close(self) -> None:
+        self.analytics.close()
+
+
+# ── Module singleton ──────────────────────────────────────────────────────────
+
+navigator = Navigator()

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -379,7 +379,8 @@ class TestQuickRouteAccessibility:
     def test_click_button_route(self):
         result = self._quick("click the Send button in Firefox")
         assert result is not None
-        assert result["tool"] == "accessibility"
+        # #123: gui_action is the unified pipeline that wraps AT-SPI
+        assert result["tool"] == "gui_action"
 
     def test_list_apps_route(self):
         result = self._quick("list open apps")

--- a/tests/test_input_control.py
+++ b/tests/test_input_control.py
@@ -420,10 +420,11 @@ class TestQuickRoute:
         assert r["args"]["x"] == 500
 
     def test_click_the_still_goes_to_a11y(self):
-        """'click the Send button' should go to accessibility, not input_control."""
+        """'click the Send button' should go to gui_action (unified pipeline), not input_control."""
         r = self._route("click the Send button in Firefox")
         assert r is not None
-        assert r["tool"] == "accessibility"
+        # #123: gui_action is the unified pipeline that wraps AT-SPI
+        assert r["tool"] == "gui_action"
 
     def test_scroll_doesnt_match_random(self):
         r = self._route("what is a scrollbar?")

--- a/tests/test_navigator.py
+++ b/tests/test_navigator.py
@@ -1,0 +1,466 @@
+"""
+Tests for the unified navigation pipeline (#123).
+
+Covers:
+  - NavResult / ActionResult data types
+  - NavigationAnalytics (SQLite persistence)
+  - Navigator pipeline (cache → AT-SPI → VLM chain)
+  - GUIActionTool (tool registry integration)
+  - Brain quick_route GUI patterns
+"""
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+import threading
+from pathlib import Path
+from unittest import IsolatedAsyncioTestCase, TestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from bantz.vision.navigator import (
+    ActionResult,
+    NavResult,
+    NavigationAnalytics,
+    Navigator,
+)
+
+# ━━ NavResult ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class TestNavResult(TestCase):
+    def test_center_with_dimensions(self):
+        r = NavResult(found=True, x=100, y=200, width=80, height=40)
+        self.assertEqual(r.center, (140, 220))
+
+    def test_center_without_dimensions(self):
+        r = NavResult(found=True, x=100, y=200)
+        self.assertEqual(r.center, (100, 200))
+
+    def test_to_dict(self):
+        r = NavResult(
+            found=True, x=10, y=20, width=30, height=40,
+            method="cache", confidence=0.95, latency_ms=1.5,
+            app_name="firefox", element_label="search bar",
+        )
+        d = r.to_dict()
+        self.assertTrue(d["found"])
+        self.assertEqual(d["method"], "cache")
+        self.assertEqual(d["center_x"], 25)
+        self.assertEqual(d["center_y"], 40)
+        self.assertEqual(d["app"], "firefox")
+
+    def test_not_found(self):
+        r = NavResult(found=False)
+        d = r.to_dict()
+        self.assertFalse(d["found"])
+        self.assertEqual(d["method"], "")
+
+
+class TestActionResult(TestCase):
+    def test_success(self):
+        nav = NavResult(found=True, x=10, y=20, method="atspi")
+        ar = ActionResult(success=True, nav=nav, action="click", message="Clicked!")
+        d = ar.to_dict()
+        self.assertTrue(d["success"])
+        self.assertEqual(d["action"], "click")
+        self.assertEqual(d["message"], "Clicked!")
+
+    def test_failure(self):
+        nav = NavResult(found=False, method="none")
+        ar = ActionResult(success=False, nav=nav, action="click", error="Not found")
+        d = ar.to_dict()
+        self.assertFalse(d["success"])
+        self.assertEqual(d["error"], "Not found")
+
+
+# ━━ NavigationAnalytics ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class TestNavigationAnalytics(TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.db_path = Path(self.tmpdir) / "test.db"
+        self.analytics = NavigationAnalytics()
+        self.analytics.init(self.db_path)
+
+    def tearDown(self):
+        self.analytics.close()
+
+    def test_record_and_stats(self):
+        self.analytics.record("firefox", "search bar", "cache", True, 1.0, 0.9)
+        self.analytics.record("firefox", "search bar", "atspi", True, 100.0, 1.0)
+        self.analytics.record("firefox", "back button", "vlm", False, 3000.0, 0.5)
+        stats = self.analytics.app_stats("firefox")
+        self.assertEqual(stats["total_attempts"], 3)
+        self.assertEqual(len(stats["methods"]), 3)
+
+    def test_best_method_needs_minimum_samples(self):
+        """Need at least 3 successful samples to recommend."""
+        self.analytics.record("vscode", "save", "cache", True, 0.5)
+        self.analytics.record("vscode", "save", "cache", True, 0.3)
+        self.assertIsNone(self.analytics.best_method_for_app("vscode"))
+        self.analytics.record("vscode", "open", "cache", True, 0.4)
+        self.assertEqual(self.analytics.best_method_for_app("vscode"), "cache")
+
+    def test_best_method_ignores_failures(self):
+        for _ in range(5):
+            self.analytics.record("app", "el", "vlm", False, 3000.0)
+        for _ in range(3):
+            self.analytics.record("app", "el", "atspi", True, 100.0)
+        self.assertEqual(self.analytics.best_method_for_app("app"), "atspi")
+
+    def test_app_case_insensitive(self):
+        self.analytics.record("Firefox", "bar", "cache", True, 1.0)
+        stats = self.analytics.app_stats("firefox")
+        self.assertEqual(stats["total_attempts"], 1)
+
+    def test_empty_stats(self):
+        stats = self.analytics.app_stats()
+        self.assertEqual(stats["total_attempts"], 0)
+
+    def test_no_connection(self):
+        na = NavigationAnalytics()
+        na.record("a", "b", "c", True)  # should not crash
+        self.assertIsNone(na.best_method_for_app("a"))
+
+
+# ━━ Navigator Pipeline ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class TestNavigatorPipeline(IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.db_path = Path(self.tmpdir) / "test.db"
+        self.nav = Navigator()
+        self.nav.init(self.db_path)
+
+    def tearDown(self):
+        self.nav.close()
+
+    async def test_cache_hit(self):
+        """If cache has the element, return immediately."""
+        mock_entry = MagicMock()
+        mock_entry.x = 100
+        mock_entry.y = 200
+        mock_entry.width = 80
+        mock_entry.height = 30
+        mock_entry.effective_confidence = 0.9
+        mock_entry.role = "push button"
+        mock_entry.is_expired = False
+
+        with patch("bantz.vision.navigator.Navigator._try_cache") as mc:
+            mc.return_value = NavResult(
+                found=True, x=100, y=200, width=80, height=30,
+                method="cache", confidence=0.9, role="push button",
+            )
+            result = await self.nav.navigate_to("firefox", "send")
+            self.assertTrue(result.found)
+            self.assertEqual(result.method, "cache")
+            self.assertEqual(result.x, 100)
+
+    async def test_atspi_fallback(self):
+        """If cache misses, try AT-SPI."""
+        with patch.object(self.nav, "_try_cache", return_value=None), \
+             patch.object(self.nav, "_try_atspi") as ma:
+            ma.return_value = NavResult(
+                found=True, x=50, y=60, width=100, height=20,
+                method="atspi", confidence=1.0,
+            )
+            result = await self.nav.navigate_to("firefox", "search bar")
+            self.assertTrue(result.found)
+            self.assertEqual(result.method, "atspi")
+            # Should have stored in cache (via _store_in_cache)
+
+    async def test_vlm_fallback(self):
+        """If cache and AT-SPI miss, try VLM."""
+        with patch.object(self.nav, "_try_cache", return_value=None), \
+             patch.object(self.nav, "_try_atspi", return_value=None), \
+             patch.object(self.nav, "_try_vlm") as mv:
+            mv.return_value = NavResult(
+                found=True, x=200, y=300, width=40, height=20,
+                method="vlm", confidence=0.65,
+            )
+            result = await self.nav.navigate_to("firefox", "new tab")
+            self.assertTrue(result.found)
+            self.assertEqual(result.method, "vlm")
+
+    async def test_all_methods_fail(self):
+        """If everything fails, return found=False."""
+        with patch.object(self.nav, "_try_cache", return_value=None), \
+             patch.object(self.nav, "_try_atspi", return_value=None), \
+             patch.object(self.nav, "_try_vlm", return_value=None):
+            result = await self.nav.navigate_to("app", "nonexistent")
+            self.assertFalse(result.found)
+            self.assertEqual(result.method, "none")
+
+    async def test_preferred_method(self):
+        """preferred_method forces a specific method."""
+        with patch.object(self.nav, "_try_vlm") as mv:
+            mv.return_value = NavResult(found=True, x=10, y=20, method="vlm", confidence=0.7)
+            result = await self.nav.navigate_to("app", "btn", preferred_method="vlm")
+            self.assertTrue(result.found)
+            self.assertEqual(result.method, "vlm")
+
+    async def test_method_order_analytics(self):
+        """Analytics should reorder methods when there's enough data."""
+        # Seed analytics with VLM being the best for "electron_app"
+        for _ in range(5):
+            self.nav.analytics.record("electron_app", "x", "vlm", True, 2000.0)
+        for _ in range(5):
+            self.nav.analytics.record("electron_app", "x", "atspi", False, 100.0)
+
+        order = self.nav._method_order("electron_app")
+        self.assertEqual(order[0], "vlm")  # VLM promoted to first
+
+    def test_default_method_order(self):
+        order = self.nav._method_order("unknown_app")
+        self.assertEqual(order, ["cache", "atspi", "vlm"])
+
+
+class TestNavigatorActions(IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.db_path = Path(self.tmpdir) / "test.db"
+        self.nav = Navigator()
+        self.nav.init(self.db_path)
+
+    def tearDown(self):
+        self.nav.close()
+
+    async def test_execute_click(self):
+        """execute_action click should navigate then click."""
+        with patch.object(self.nav, "navigate_to") as mn, \
+             patch.object(self.nav, "_do_click") as mc:
+            mn.return_value = NavResult(
+                found=True, x=100, y=200, width=20, height=20,
+                method="cache", confidence=0.9,
+                app_name="firefox", element_label="send",
+            )
+            mc.return_value = None
+            result = await self.nav.execute_action("click", "firefox", "send")
+            self.assertTrue(result.success)
+            self.assertEqual(result.action, "click")
+            mc.assert_called_once_with(110, 210)  # center
+
+    async def test_execute_type(self):
+        """type action should click then type text."""
+        with patch.object(self.nav, "navigate_to") as mn, \
+             patch.object(self.nav, "_do_click") as mc, \
+             patch.object(self.nav, "_do_type") as mt:
+            mn.return_value = NavResult(
+                found=True, x=50, y=60, width=200, height=24,
+                method="atspi", confidence=1.0,
+                app_name="chrome", element_label="search",
+            )
+            result = await self.nav.execute_action(
+                "type", "chrome", "search bar", text="hello world"
+            )
+            self.assertTrue(result.success)
+            mc.assert_called_once()
+            mt.assert_called_once_with("hello world")
+
+    async def test_execute_not_found(self):
+        """If navigation fails, action should fail gracefully."""
+        with patch.object(self.nav, "navigate_to") as mn:
+            mn.return_value = NavResult(found=False, method="none")
+            result = await self.nav.execute_action("click", "app", "missing")
+            self.assertFalse(result.success)
+            self.assertIn("Could not find", result.error)
+
+    async def test_execute_focus(self):
+        """Focus action doesn't need navigation."""
+        with patch("bantz.vision.navigator.focus_window", create=True) as mf:
+            # Patch at import-time in the method
+            with patch.object(self.nav, "_action_focus") as af:
+                af.return_value = ActionResult(
+                    success=True,
+                    nav=NavResult(found=True, app_name="firefox", method="atspi"),
+                    action="focus", message="Focused firefox",
+                )
+                result = await self.nav.execute_action("focus", "firefox", "")
+                self.assertTrue(result.success)
+
+    async def test_execute_unknown_action(self):
+        with patch.object(self.nav, "navigate_to") as mn:
+            mn.return_value = NavResult(
+                found=True, x=10, y=20, method="cache", confidence=0.9,
+            )
+            result = await self.nav.execute_action("destroy", "app", "thing")
+            self.assertFalse(result.success)
+            self.assertIn("Unknown action", result.error)
+
+
+# ━━ GUIActionTool ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class TestGUIActionTool(IsolatedAsyncioTestCase):
+    def setUp(self):
+        from bantz.tools.gui_action import GUIActionTool
+        self.tool = GUIActionTool()
+
+    async def test_missing_app(self):
+        result = await self.tool.execute(action="click", label="btn")
+        self.assertFalse(result.success)
+        self.assertEqual(result.error, "missing_app")
+
+    async def test_missing_label(self):
+        result = await self.tool.execute(action="click", app="firefox")
+        self.assertFalse(result.success)
+        self.assertEqual(result.error, "missing_label")
+
+    async def test_focus_no_label_required(self):
+        """Focus action doesn't need a label."""
+        with patch("bantz.vision.navigator.navigator.execute_action") as me:
+            me.return_value = ActionResult(
+                success=True,
+                nav=NavResult(found=True, app_name="ff", method="atspi"),
+                action="focus", message="Focused",
+            )
+            result = await self.tool.execute(action="focus", app="firefox")
+            self.assertTrue(result.success)
+
+    async def test_navigate_only(self):
+        """Navigate action just finds without acting."""
+        with patch("bantz.vision.navigator.navigator.navigate_to") as mn:
+            mn.return_value = NavResult(
+                found=True, x=100, y=200, width=20, height=20,
+                method="cache", confidence=0.9,
+                app_name="ff", element_label="btn",
+            )
+            result = await self.tool.execute(
+                action="navigate", app="firefox", label="search bar",
+            )
+            self.assertTrue(result.success)
+            self.assertIn("Found", result.output)
+
+    async def test_navigate_not_found(self):
+        with patch("bantz.vision.navigator.navigator.navigate_to") as mn:
+            mn.return_value = NavResult(found=False, method="none")
+            result = await self.tool.execute(
+                action="navigate", app="firefox", label="nonexistent",
+            )
+            self.assertFalse(result.success)
+
+    @patch("bantz.config.config")
+    async def test_input_disabled_blocks_click(self, mock_cfg):
+        mock_cfg.input_control_enabled = False
+        result = await self.tool.execute(action="click", app="ff", label="btn")
+        self.assertFalse(result.success)
+        self.assertEqual(result.error, "input_disabled")
+
+    async def test_click_success(self):
+        with patch("bantz.config.config") as mc, \
+             patch("bantz.vision.navigator.navigator.execute_action") as me:
+            mc.input_control_enabled = True
+            me.return_value = ActionResult(
+                success=True,
+                nav=NavResult(found=True, x=10, y=20, method="cache"),
+                action="click", message="Clicked!",
+            )
+            result = await self.tool.execute(action="click", app="ff", label="btn")
+            self.assertTrue(result.success)
+
+    async def test_stats_empty(self):
+        with patch("bantz.vision.navigator.navigator.analytics") as ma:
+            ma.app_stats.return_value = {"methods": [], "total_attempts": 0}
+            result = await self.tool.execute(action="stats")
+            self.assertTrue(result.success)
+            self.assertIn("No navigation data", result.output)
+
+    def test_tool_properties(self):
+        self.assertEqual(self.tool.name, "gui_action")
+        self.assertEqual(self.tool.risk_level, "moderate")
+        schema = self.tool.schema()
+        self.assertEqual(schema["name"], "gui_action")
+        self.assertIn("navigate", schema["description"].lower())
+
+
+# ━━ Brain Quick Route — GUI Patterns ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class TestQuickRouteGUI(TestCase):
+    """Test that natural GUI commands route to gui_action tool."""
+
+    @staticmethod
+    def _route(text: str):
+        from bantz.core.brain import Brain
+        return Brain._quick_route(text, text)
+
+    def test_click_element_in_app(self):
+        r = self._route("click the send button in firefox")
+        self.assertIsNotNone(r)
+        self.assertEqual(r["tool"], "gui_action")
+        self.assertEqual(r["args"]["action"], "click")
+        self.assertIn("send", r["args"]["label"].lower())
+        self.assertIn("firefox", r["args"]["app"].lower())
+
+    def test_click_link_in_app(self):
+        r = self._route("click the Settings link in chrome")
+        self.assertIsNotNone(r)
+        self.assertEqual(r["tool"], "gui_action")
+        self.assertEqual(r["args"]["action"], "click")
+
+    def test_type_into_element(self):
+        r = self._route("type 'hello world' into the search bar in firefox")
+        self.assertIsNotNone(r)
+        self.assertEqual(r["tool"], "gui_action")
+        self.assertEqual(r["args"]["action"], "type")
+        self.assertEqual(r["args"]["text"], "hello world")
+        self.assertIn("search", r["args"]["label"].lower())
+
+    def test_double_click_in_app(self):
+        r = self._route("double click the file in nautilus")
+        self.assertIsNotNone(r)
+        self.assertEqual(r["tool"], "gui_action")
+        self.assertEqual(r["args"]["action"], "double_click")
+
+    def test_right_click_in_app(self):
+        r = self._route("right click the icon in desktop")
+        self.assertIsNotNone(r)
+        self.assertEqual(r["tool"], "gui_action")
+        self.assertEqual(r["args"]["action"], "right_click")
+
+    def test_scroll_still_routes_to_input_control(self):
+        """Scroll without app context should still go to input_control."""
+        r = self._route("scroll down 5")
+        self.assertIsNotNone(r)
+        self.assertEqual(r["tool"], "input_control")
+        self.assertEqual(r["args"]["action"], "scroll")
+
+    def test_hotkey_still_routes_to_input_control(self):
+        r = self._route("press ctrl+s")
+        self.assertIsNotNone(r)
+        self.assertEqual(r["tool"], "input_control")
+
+    def test_list_apps_still_routes_to_accessibility(self):
+        r = self._route("list apps")
+        self.assertIsNotNone(r)
+        self.assertEqual(r["tool"], "accessibility")
+
+    def test_focus_window_still_accessibility(self):
+        r = self._route("focus window firefox")
+        self.assertIsNotNone(r)
+        self.assertEqual(r["tool"], "accessibility")
+
+    def test_describe_screen_still_accessibility(self):
+        r = self._route("describe my screen")
+        self.assertIsNotNone(r)
+        self.assertEqual(r["tool"], "accessibility")
+
+    def test_non_gui_falls_through(self):
+        r = self._route("what's the weather today?")
+        # Should not be gui_action
+        if r:
+            self.assertNotEqual(r.get("tool"), "gui_action")
+
+    def test_click_with_on_preposition(self):
+        r = self._route("click on the save button in vscode")
+        self.assertIsNotNone(r)
+        self.assertEqual(r["tool"], "gui_action")
+        self.assertEqual(r["args"]["action"], "click")
+
+    def test_press_button_in_app(self):
+        r = self._route("press the submit button in chrome")
+        self.assertIsNotNone(r)
+        self.assertEqual(r["tool"], "gui_action")
+        self.assertEqual(r["args"]["action"], "click")

--- a/tests/test_vector_memory.py
+++ b/tests/test_vector_memory.py
@@ -24,6 +24,18 @@ import pytest
 
 # ── Helpers ──────────────────────────────────────────────────────────────
 
+def _run(coro):
+    """Run an async coroutine safely — works even after event loop closed."""
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_closed():
+            raise RuntimeError
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+    return loop.run_until_complete(coro)
+
+
 def _make_memory_db() -> sqlite3.Connection:
     """Create an in-memory SQLite DB with the Memory schema."""
     conn = sqlite3.connect(":memory:", check_same_thread=False)
@@ -280,13 +292,13 @@ class TestEmbedder:
     def test_embed_empty_returns_none(self):
         from bantz.memory.embeddings import Embedder
         emb = Embedder()
-        result = asyncio.get_event_loop().run_until_complete(emb.embed(""))
+        result = _run(emb.embed(""))
         assert result is None
 
     def test_embed_whitespace_returns_none(self):
         from bantz.memory.embeddings import Embedder
         emb = Embedder()
-        result = asyncio.get_event_loop().run_until_complete(emb.embed("   "))
+        result = _run(emb.embed("   "))
         assert result is None
 
     @patch("bantz.memory.embeddings.httpx.AsyncClient")
@@ -307,7 +319,7 @@ class TestEmbedder:
         mock_client_cls.return_value = mock_client
 
         emb = Embedder()
-        result = asyncio.get_event_loop().run_until_complete(emb.embed("hello"))
+        result = _run(emb.embed("hello"))
         assert result is not None
         assert len(result) == 768
         assert emb.dim == 768
@@ -335,7 +347,7 @@ class TestEmbedder:
         mock_client_cls.return_value = mock_client
 
         emb = Embedder()
-        result = asyncio.get_event_loop().run_until_complete(emb.embed("hello"))
+        result = _run(emb.embed("hello"))
         assert result is not None
         assert len(result) == 384
         assert emb.dim == 384
@@ -394,7 +406,7 @@ class TestMemoryVectorIntegration:
 
         with patch("bantz.config.config") as mock_cfg:
             mock_cfg.embedding_enabled = True
-            count = asyncio.get_event_loop().run_until_complete(
+            count = _run(
                 self.mem.embed_pending()
             )
 
@@ -416,7 +428,7 @@ class TestMemoryVectorIntegration:
 
         with patch("bantz.config.config") as mock_cfg:
             mock_cfg.embedding_enabled = True
-            results = asyncio.get_event_loop().run_until_complete(
+            results = _run(
                 self.mem.semantic_search("how is the weather", limit=2, min_score=-1.0)
             )
 
@@ -441,7 +453,7 @@ class TestMemoryVectorIntegration:
         with patch("bantz.config.config") as mock_cfg:
             mock_cfg.embedding_enabled = True
             mock_cfg.vector_search_weight = 0.5
-            results = asyncio.get_event_loop().run_until_complete(
+            results = _run(
                 self.mem.hybrid_search("weather", limit=3)
             )
 
@@ -455,7 +467,7 @@ class TestMemoryVectorIntegration:
         """semantic_search returns [] when embeddings disabled."""
         with patch("bantz.config.config") as mock_cfg:
             mock_cfg.embedding_enabled = False
-            results = asyncio.get_event_loop().run_until_complete(
+            results = _run(
                 self.mem.semantic_search("anything")
             )
         assert results == []
@@ -475,7 +487,7 @@ class TestMemoryVectorIntegration:
 
         with patch("bantz.config.config") as mock_cfg:
             mock_cfg.embedding_enabled = True
-            count = asyncio.get_event_loop().run_until_complete(
+            count = _run(
                 self.mem.backfill_embeddings(batch_size=10)
             )
 


### PR DESCRIPTION
## Issue #123

### Summary
Unified navigation pipeline that chains **Cache → AT-SPI → VLM → fallback** for GUI element location and interaction.

### Changes
- **navigator.py** (~430 lines): Navigator class with fallback chain, NavigationAnalytics (SQLite) for per-app method reordering
- **gui_action.py** (~160 lines): GUIActionTool — click, double_click, right_click, type, focus, navigate, stats
- **brain.py**: GUI quick_route patterns (before web_search)
- **layer.py**: Navigator init/close in DataLayer lifecycle
- **system_prompt.py**: ROUTER rules for gui_action
- **__main__.py**: Navigator status in doctor
- **test_navigator.py**: 46 new tests

### Pipeline
navigate_to(app, element) → cache → AT-SPI → VLM → fail

### Tests
46 new, **432 total passing**, 0 failures

Closes #123