### PR TITLE
feat(memory): nightly reflection workflow (#130)

### DIFF
--- a/src/bantz/__main__.py
+++ b/src/bantz/__main__.py
@@ -36,8 +36,12 @@ def main() -> None:
                         help="Manually trigger a scheduled job by ID")
     parser.add_argument("--maintenance", action="store_true",
                         help="Run nightly maintenance workflow now")
+    parser.add_argument("--reflect", action="store_true",
+                        help="Run nightly memory reflection now")
+    parser.add_argument("--reflections", action="store_true",
+                        help="View past daily reflections")
     parser.add_argument("--dry-run", action="store_true",
-                        help="Simulate actions without making changes (use with --maintenance)")
+                        help="Simulate actions without changes (use with --maintenance/--reflect)")
     args = parser.parse_args()
 
     if args.doctor:
@@ -62,6 +66,14 @@ def main() -> None:
 
     if args.maintenance:
         asyncio.run(_maintenance(args.dry_run))
+        return
+
+    if args.reflect:
+        asyncio.run(_reflect(args.dry_run))
+        return
+
+    if args.reflections:
+        _view_reflections()
         return
 
     if args.once:
@@ -831,6 +843,56 @@ async def _maintenance(dry_run: bool) -> None:
     print(f"🔧 Running maintenance{tag}...")
     report = await run_maintenance(dry_run=dry_run)
     print(report.summary())
+
+
+async def _reflect(dry_run: bool) -> None:
+    """Run the nightly memory reflection workflow (bantz --reflect)."""
+    from bantz.config import config
+    config.ensure_dirs()
+
+    from bantz.core.memory import memory
+    memory.init(config.db_path)
+
+    from bantz.agent.workflows.reflection import run_reflection
+
+    tag = " (dry-run)" if dry_run else ""
+    print(f"🤔 Running reflection{tag}...")
+    result = await run_reflection(dry_run=dry_run)
+    print(result.summary_line())
+
+
+def _view_reflections() -> None:
+    """View past daily reflections (bantz --reflections)."""
+    from bantz.config import config
+    config.ensure_dirs()
+
+    from bantz.core.memory import memory
+    memory.init(config.db_path)
+
+    from bantz.agent.workflows.reflection import list_reflections
+
+    reflections = list_reflections(limit=10)
+    if not reflections:
+        print("No reflections yet. Run 'bantz --reflect' first.")
+        return
+
+    for r in reflections:
+        date = r.get("date", "?")
+        summary = r.get("summary", "")
+        sessions = r.get("sessions", 0)
+        msgs = r.get("total_messages", 0)
+        print(f"\n📅 {date} ({sessions} sessions, {msgs} msgs)")
+        if summary:
+            print(f"   {summary}")
+        reflection = r.get("reflection", "")
+        if reflection:
+            print(f"   💡 {reflection}")
+        decisions = r.get("decisions", [])
+        if decisions:
+            print(f"   Decisions: {', '.join(decisions)}")
+        unresolved = r.get("unresolved", [])
+        if unresolved:
+            print(f"   ❓ {', '.join(unresolved)}")
 
 
 async def _once(query: str) -> None:

--- a/src/bantz/agent/job_scheduler.py
+++ b/src/bantz/agent/job_scheduler.py
@@ -176,23 +176,11 @@ async def _job_maintenance() -> None:
 
 
 async def _job_reflection() -> None:
-    """Summarize today's conversations via distiller."""
-    log.info("🤔 Reflection starting...")
-    try:
-        from bantz.memory.distiller import distiller
-        if distiller.initialized:
-            summary = await distiller.distill_session()
-            if summary:
-                log.info("Reflection summary: %s", summary[:200])
-            else:
-                log.info("Reflection: no conversations to summarize")
-        else:
-            log.debug("Distiller not initialized — skipping reflection")
-    except ImportError:
-        log.debug("Distiller not available")
-    except Exception as exc:
-        log.warning("Reflection failed: %s", exc)
-    log.info("🤔 Reflection complete")
+    """Run the nightly memory reflection workflow (#130)."""
+    from bantz.agent.workflows.reflection import run_reflection
+    result = await run_reflection(dry_run=False)
+    log.info("🤔 Reflection finished: %d sessions, %d entities",
+             result.sessions, result.entities_extracted)
 
 
 async def _job_overnight_poll() -> None:
@@ -304,7 +292,7 @@ async def _fire_dynamic_reminder(title: str, repeat: str = "none") -> None:
 
 _JOB_REGISTRY: dict[str, tuple[Callable, str]] = {
     "maintenance": (_job_maintenance, "Nightly 6-step maintenance workflow"),
-    "reflection": (_job_reflection, "Summarize conversations"),
+    "reflection": (_job_reflection, "Nightly memory reflection workflow"),
     "overnight_poll": (_job_overnight_poll, "Check email/calendar"),
     "briefing_prep": (_job_briefing_prep, "Pre-fetch morning briefing data"),
     "reminder_check": (_job_reminder_check, "Check due reminders"),

--- a/src/bantz/agent/workflows/reflection.py
+++ b/src/bantz/agent/workflows/reflection.py
@@ -1,0 +1,899 @@
+"""
+Bantz — Nightly Memory Reflection Workflow (#130)
+
+Runs at 11 PM daily via APScheduler.  Compresses the day's conversations
+into a coherent daily reflection with entity extraction and graph updates.
+
+Architecture (user's 4 strategic fixes applied):
+
+  1. **Hierarchical Summarisation** — reads today's *session distillation*
+     summaries (Issue #118) instead of raw messages.  Saves tokens, avoids
+     blowing the context window on 50+ message days.
+
+  2. **Generous Timeout** — 10-min total cap (instead of 2 min).  This is
+     a night job running while the user sleeps; no rush.
+
+  3. **Vector Orphan Cleanup** — when pruning raw messages older than 30
+     days, also deletes their corresponding embeddings from vector_store
+     so no "ghost vectors" remain in semantic search.
+
+  4. **Entity Resolution** — before asking the LLM to extract entities,
+     fetches existing Person/Topic/Decision nodes from Neo4j and injects
+     them into the prompt so the model merges "Ali (study group)" with
+     "Ali" instead of creating duplicates.
+
+Pipeline:
+    1. Collect today's session distillation summaries
+    2. LLM daily reflection prompt (using summaries, not raw messages)
+    3. Parse structured JSON output
+    4. Entity extraction with graph context injection
+    5. Store reflection in vector DB + KV store
+    6. Optional raw-message pruning (> 30 days) with vector cleanup
+    7. Report (notification + Telegram)
+
+Usage:
+    from bantz.agent.workflows.reflection import run_reflection
+    report = await run_reflection(dry_run=False)
+
+    # CLI
+    bantz --reflect              # run now
+    bantz --reflect --dry-run    # simulate
+    bantz --reflections          # view past reflections
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sqlite3
+import threading
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import Optional
+
+log = logging.getLogger("bantz.reflection")
+
+# ── Constants ────────────────────────────────────────────────────────────
+
+_TOTAL_TIMEOUT = 600            # 10 min total (generous for local LLM)
+_LLM_TIMEOUT = 120             # 2 min per LLM call
+_PRUNE_RAW_DAYS = 30           # delete raw messages older than this
+_REFLECTION_RETENTION_DAYS = 0  # 0 = keep forever
+
+# ── Prompts ──────────────────────────────────────────────────────────────
+
+_REFLECTION_SYSTEM = """\
+You are Bantz's nightly self-reflection engine.  Given today's conversation \
+summaries, produce a structured daily reflection in JSON format.
+
+OUTPUT — valid JSON only, no markdown fences:
+{
+  "summary": "2-3 sentence overview of the day",
+  "decisions": ["decision 1", "decision 2"],
+  "tasks_created": ["task 1"],
+  "tasks_completed": ["task 1"],
+  "people_mentioned": ["Name (context)"],
+  "reflection": "Pattern observations, meta-insights, suggestions",
+  "unresolved": ["item 1"]
+}
+
+RULES:
+— Be factual: only include what actually appears in the summaries.
+— Keep 'summary' to max 3 sentences.
+— Use empty lists [] if none found — never omit keys.
+— 'reflection' should note patterns, context-switches, or focus suggestions.
+— 'people_mentioned' should include context in parentheses if available.
+"""
+
+_REFLECTION_USER = """\
+Today is {date}.  Here are today's conversation session summaries:
+
+{summaries}
+
+Produce the daily reflection JSON.
+"""
+
+_ENTITY_SYSTEM = """\
+You are an entity extraction assistant.  Given a daily reflection and a \
+list of EXISTING entities in the knowledge graph, extract new entities and \
+relationships.  MERGE with existing entities when possible (same person, \
+same topic) — do NOT create duplicates.
+
+EXISTING ENTITIES:
+{existing_entities}
+
+OUTPUT — valid JSON array, no markdown fences:
+[
+  {{"label": "Person|Topic|Decision|Task|Event|Location", "key_prop": "name|what|description|title", "value": "...", "context": "..."}}
+]
+
+RULES:
+— Match names case-insensitively against EXISTING ENTITIES.
+— If "Ali (study group)" exists and you see "Ali", use the existing entry.
+— Only extract entities that are clearly mentioned.
+— Return [] if no entities found.
+"""
+
+_ENTITY_USER = """\
+Daily reflection for {date}:
+{reflection_json}
+
+Extract entities and relationships.
+"""
+
+
+# ── Data classes ─────────────────────────────────────────────────────────
+
+@dataclass
+class ReflectionResult:
+    """Structured output from nightly reflection."""
+    date: str = ""
+    sessions: int = 0
+    total_messages: int = 0
+    summary: str = ""
+    decisions: list[str] = field(default_factory=list)
+    tasks_created: list[str] = field(default_factory=list)
+    tasks_completed: list[str] = field(default_factory=list)
+    people_mentioned: list[str] = field(default_factory=list)
+    reflection: str = ""
+    unresolved: list[str] = field(default_factory=list)
+    entities_extracted: int = 0
+    raw_pruned: int = 0
+    vectors_pruned: int = 0
+
+    def to_dict(self) -> dict:
+        return {
+            "date": self.date,
+            "sessions": self.sessions,
+            "total_messages": self.total_messages,
+            "summary": self.summary,
+            "decisions": self.decisions,
+            "tasks_created": self.tasks_created,
+            "tasks_completed": self.tasks_completed,
+            "people_mentioned": self.people_mentioned,
+            "reflection": self.reflection,
+            "unresolved": self.unresolved,
+            "entities_extracted": self.entities_extracted,
+            "raw_pruned": self.raw_pruned,
+            "vectors_pruned": self.vectors_pruned,
+        }
+
+    def summary_line(self) -> str:
+        """One-paragraph human-readable summary."""
+        parts = [f"🤔 Reflection ({self.date}): {self.sessions} sessions, {self.total_messages} msgs"]
+        if self.summary:
+            parts.append(f"   {self.summary}")
+        if self.decisions:
+            parts.append(f"   Decisions: {', '.join(self.decisions)}")
+        if self.tasks_created:
+            parts.append(f"   Tasks created: {', '.join(self.tasks_created)}")
+        if self.tasks_completed:
+            parts.append(f"   Tasks done: {', '.join(self.tasks_completed)}")
+        if self.people_mentioned:
+            parts.append(f"   People: {', '.join(self.people_mentioned)}")
+        if self.reflection:
+            parts.append(f"   💡 {self.reflection}")
+        if self.unresolved:
+            parts.append(f"   ❓ Unresolved: {', '.join(self.unresolved)}")
+        if self.entities_extracted:
+            parts.append(f"   🔗 {self.entities_extracted} entities → graph")
+        if self.raw_pruned:
+            parts.append(f"   🗑 Pruned {self.raw_pruned} old messages + {self.vectors_pruned} vectors")
+        return "\n".join(parts)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Helpers
+# ═══════════════════════════════════════════════════════════════════════════
+
+def _data_dir():
+    from bantz.config import config
+    return config.db_path.parent
+
+
+def _get_conn_and_lock():
+    """Get the memory module's shared connection and lock."""
+    from bantz.core.memory import memory
+    return memory._conn, memory._lock
+
+
+# ── Step 1: Collect today's session distillations ────────────────────────
+
+def _collect_today_distillations(
+    conn: sqlite3.Connection,
+    date_str: str,
+) -> list[dict]:
+    """
+    Hierarchical summarisation (Recommendation #1):
+    Read today's session distillation summaries from #118
+    instead of raw messages — massive token savings.
+    """
+    rows = conn.execute(
+        """SELECT sd.conversation_id, sd.summary, sd.topics,
+                  sd.decisions, sd.people, sd.tools_used,
+                  sd.exchange_count, sd.created_at
+           FROM session_distillations sd
+           WHERE sd.created_at LIKE ?
+           ORDER BY sd.created_at ASC""",
+        (f"{date_str}%",),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def _collect_today_sessions_meta(
+    conn: sqlite3.Connection,
+    date_str: str,
+) -> tuple[int, int]:
+    """Count today's sessions and total messages."""
+    sessions = conn.execute(
+        "SELECT COUNT(*) FROM conversations WHERE started_at LIKE ?",
+        (f"{date_str}%",),
+    ).fetchone()[0]
+    messages = conn.execute(
+        """SELECT COUNT(*) FROM messages m
+           JOIN conversations c ON c.id = m.conversation_id
+           WHERE c.started_at LIKE ?""",
+        (f"{date_str}%",),
+    ).fetchone()[0]
+    return sessions, messages
+
+
+def _collect_undistilled_sessions(
+    conn: sqlite3.Connection,
+    date_str: str,
+) -> list[dict]:
+    """Fallback: if no distillations exist, fetch raw session summaries.
+
+    Returns lightweight summaries — first/last user messages only.
+    """
+    rows = conn.execute(
+        """SELECT c.id as conversation_id,
+                  (SELECT GROUP_CONCAT(content, ' | ')
+                   FROM (SELECT content FROM messages
+                         WHERE conversation_id = c.id AND role = 'user'
+                         ORDER BY created_at LIMIT 3)) as user_preview,
+                  COUNT(m.id) as msg_count
+           FROM conversations c
+           LEFT JOIN messages m ON m.conversation_id = c.id
+           LEFT JOIN session_distillations sd ON sd.conversation_id = c.id
+           WHERE c.started_at LIKE ? AND sd.id IS NULL
+           GROUP BY c.id
+           HAVING msg_count > 0
+           ORDER BY c.started_at ASC""",
+        (f"{date_str}%",),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+# ── Step 2: LLM daily reflection ────────────────────────────────────────
+
+def _build_summaries_text(
+    distillations: list[dict],
+    undistilled: list[dict],
+) -> str:
+    """Build the summaries block for the reflection prompt."""
+    parts = []
+    for i, d in enumerate(distillations, 1):
+        topics = d.get("topics", "")
+        decisions = d.get("decisions", "")
+        people = d.get("people", "")
+        summary = d.get("summary", "")
+        parts.append(
+            f"Session {i} ({d.get('exchange_count', '?')} exchanges):\n"
+            f"  Summary: {summary}\n"
+            f"  Topics: {topics or 'n/a'}\n"
+            f"  Decisions: {decisions or 'none'}\n"
+            f"  People: {people or 'none'}"
+        )
+
+    for i, u in enumerate(undistilled, len(distillations) + 1):
+        parts.append(
+            f"Session {i} ({u.get('msg_count', '?')} messages, no distillation):\n"
+            f"  Preview: {(u.get('user_preview') or 'empty')[:300]}"
+        )
+
+    return "\n\n".join(parts) if parts else "(No conversations today)"
+
+
+async def _llm_reflect(date_str: str, summaries_text: str) -> str:
+    """Call LLM to produce the daily reflection JSON."""
+    messages = [
+        {"role": "system", "content": _REFLECTION_SYSTEM},
+        {"role": "user", "content": _REFLECTION_USER.format(
+            date=date_str, summaries=summaries_text,
+        )},
+    ]
+
+    # Try Gemini first (fast)
+    try:
+        from bantz.llm.gemini import gemini
+        if gemini.is_enabled():
+            return await asyncio.wait_for(
+                gemini.chat(messages, temperature=0.2),
+                timeout=_LLM_TIMEOUT,
+            )
+    except asyncio.TimeoutError:
+        log.warning("Gemini reflection timed out after %ds", _LLM_TIMEOUT)
+    except Exception:
+        pass
+
+    # Ollama fallback
+    from bantz.llm.ollama import ollama
+    return await asyncio.wait_for(
+        ollama.chat(messages),
+        timeout=_LLM_TIMEOUT,
+    )
+
+
+def _parse_reflection_json(raw: str) -> dict:
+    """Parse the LLM's JSON output, tolerant of markdown fences."""
+    text = raw.strip()
+    # Strip markdown code fences
+    if text.startswith("```"):
+        lines = text.split("\n")
+        # Remove first and last fence lines
+        lines = [l for l in lines if not l.strip().startswith("```")]
+        text = "\n".join(lines)
+
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+
+    # Attempt to find JSON object within the text
+    start = text.find("{")
+    end = text.rfind("}")
+    if start != -1 and end != -1 and end > start:
+        try:
+            return json.loads(text[start:end + 1])
+        except json.JSONDecodeError:
+            pass
+
+    # Last resort: extract what we can
+    log.warning("Could not parse reflection JSON, using raw text as summary")
+    return {
+        "summary": text[:500],
+        "decisions": [],
+        "tasks_created": [],
+        "tasks_completed": [],
+        "people_mentioned": [],
+        "reflection": "",
+        "unresolved": [],
+    }
+
+
+# ── Step 3: Entity extraction with graph context (Rec #4) ───────────────
+
+async def _fetch_existing_entities_from_graph() -> str:
+    """
+    Entity Resolution (Recommendation #4):
+    Fetch existing Person/Topic/Decision nodes from Neo4j
+    so the LLM can merge instead of creating duplicates.
+    """
+    try:
+        from bantz.memory.graph import graph_memory
+        if not graph_memory.enabled:
+            return "(Graph not available)"
+
+        entities = []
+        for label in ("Person", "Topic", "Decision", "Task"):
+            try:
+                rows = await graph_memory._query(
+                    f"MATCH (n:{label}) RETURN n.name AS name "
+                    f"ORDER BY n.last_seen DESC LIMIT 50"
+                )
+                for r in rows:
+                    name = r.get("name")
+                    if name:
+                        entities.append(f"{label}: {name}")
+            except Exception:
+                # Some labels use different key props
+                try:
+                    key = {"Decision": "what", "Task": "description"}.get(label, "name")
+                    rows = await graph_memory._query(
+                        f"MATCH (n:{label}) RETURN n.{key} AS name "
+                        f"ORDER BY n.created_at DESC LIMIT 30"
+                    )
+                    for r in rows:
+                        name = r.get("name")
+                        if name:
+                            entities.append(f"{label}: {name}")
+                except Exception:
+                    pass
+
+        return "\n".join(entities) if entities else "(Empty graph — this is the first run)"
+    except (ImportError, Exception) as exc:
+        log.debug("Could not fetch graph entities: %s", exc)
+        return "(Graph not available)"
+
+
+async def _llm_extract_entities(
+    date_str: str,
+    reflection_json: dict,
+    existing_entities: str,
+) -> list[dict]:
+    """
+    LLM-based entity extraction with graph context injection.
+    Falls back to rule-based extraction if LLM fails.
+    """
+    messages = [
+        {"role": "system", "content": _ENTITY_SYSTEM.format(
+            existing_entities=existing_entities,
+        )},
+        {"role": "user", "content": _ENTITY_USER.format(
+            date=date_str,
+            reflection_json=json.dumps(reflection_json, ensure_ascii=False, indent=2),
+        )},
+    ]
+
+    raw = None
+    try:
+        from bantz.llm.gemini import gemini
+        if gemini.is_enabled():
+            raw = await asyncio.wait_for(
+                gemini.chat(messages, temperature=0.1),
+                timeout=_LLM_TIMEOUT,
+            )
+    except Exception:
+        pass
+
+    if not raw:
+        try:
+            from bantz.llm.ollama import ollama
+            raw = await asyncio.wait_for(
+                ollama.chat(messages),
+                timeout=_LLM_TIMEOUT,
+            )
+        except Exception as exc:
+            log.debug("LLM entity extraction failed: %s", exc)
+
+    if raw:
+        entities = _parse_entity_json(raw)
+        if entities:
+            return entities
+
+    # Fallback: rule-based extraction from the reflection summary
+    return _rule_based_entity_extraction(reflection_json)
+
+
+def _parse_entity_json(raw: str) -> list[dict]:
+    """Parse entity extraction JSON from LLM."""
+    text = raw.strip()
+    if text.startswith("```"):
+        lines = text.split("\n")
+        lines = [l for l in lines if not l.strip().startswith("```")]
+        text = "\n".join(lines)
+
+    try:
+        result = json.loads(text)
+        if isinstance(result, list):
+            return result
+    except json.JSONDecodeError:
+        pass
+
+    start = text.find("[")
+    end = text.rfind("]")
+    if start != -1 and end != -1:
+        try:
+            result = json.loads(text[start:end + 1])
+            if isinstance(result, list):
+                return result
+        except json.JSONDecodeError:
+            pass
+
+    return []
+
+
+def _rule_based_entity_extraction(reflection: dict) -> list[dict]:
+    """Fallback rule-based extraction from reflection dict."""
+    entities = []
+
+    for person in reflection.get("people_mentioned", []):
+        name = person.split("(")[0].strip()
+        if name and len(name) > 1:
+            entities.append({
+                "label": "Person",
+                "key_prop": "name",
+                "value": name,
+                "context": person,
+            })
+
+    for decision in reflection.get("decisions", []):
+        if decision:
+            entities.append({
+                "label": "Decision",
+                "key_prop": "what",
+                "value": decision[:100],
+                "context": "",
+            })
+
+    for task in reflection.get("tasks_created", []):
+        if task:
+            entities.append({
+                "label": "Task",
+                "key_prop": "description",
+                "value": task[:100],
+                "context": "created",
+            })
+
+    for task in reflection.get("tasks_completed", []):
+        if task:
+            entities.append({
+                "label": "Task",
+                "key_prop": "description",
+                "value": task[:100],
+                "context": "completed",
+            })
+
+    return entities
+
+
+async def _store_entities_to_graph(entities: list[dict]) -> int:
+    """Upsert extracted entities into Neo4j graph."""
+    try:
+        from bantz.memory.graph import graph_memory
+        if not graph_memory.enabled:
+            return 0
+
+        stored = 0
+        now = datetime.now().isoformat(timespec="seconds")
+
+        for ent in entities:
+            label = ent.get("label", "")
+            key_prop = ent.get("key_prop", "name")
+            value = ent.get("value", "")
+            context = ent.get("context", "")
+
+            if not label or not value:
+                continue
+
+            # Build entity dict compatible with graph_memory._upsert_entities
+            graph_ent = {
+                "label": label,
+                "key": key_prop,
+                "props": {
+                    key_prop: value,
+                    "last_seen": now,
+                    "source": "reflection",
+                },
+                "rels": [],
+            }
+            if context:
+                graph_ent["props"]["context"] = context
+
+            try:
+                await graph_memory._upsert_entities([graph_ent], now)
+                stored += 1
+            except Exception as exc:
+                log.debug("Graph upsert failed for %s: %s", value, exc)
+
+        return stored
+    except (ImportError, Exception) as exc:
+        log.debug("Graph entity storage failed: %s", exc)
+        return 0
+
+
+# ── Step 4: Store reflection ────────────────────────────────────────────
+
+async def _store_reflection(
+    conn: sqlite3.Connection,
+    lock: threading.Lock,
+    result: ReflectionResult,
+) -> None:
+    """Store reflection in KV store, vector DB, and memory."""
+    # KV store for --reflections and morning briefing
+    try:
+        from bantz.data.sqlite_store import SQLiteKVStore
+        kv = SQLiteKVStore(_data_dir() / "bantz.db")
+        kv.set(f"reflection_{result.date}", json.dumps(result.to_dict(), ensure_ascii=False))
+        kv.set("reflection_latest", json.dumps(result.to_dict(), ensure_ascii=False))
+        kv.set("reflection_latest_date", result.date)
+    except Exception as exc:
+        log.warning("Failed to store reflection in KV: %s", exc)
+
+    # Embed reflection summary into vector space
+    try:
+        from bantz.config import config
+        if config.embedding_enabled:
+            from bantz.memory.embeddings import embedder
+            embed_text = f"Daily reflection {result.date}: {result.summary} {result.reflection}"
+            vec = await embedder.embed(embed_text)
+            if vec:
+                from bantz.memory.distiller import store_distillation, DistillationResult
+                # Store as a special "reflection" distillation (conversation_id = -date_hash)
+                # Use negative ID to distinguish from session distillations
+                date_hash = abs(hash(result.date)) % 10_000_000
+                dr = DistillationResult(
+                    session_id=-date_hash,
+                    summary=f"[Daily Reflection] {result.summary}",
+                    topics=[],
+                    decisions=result.decisions,
+                    people=result.people_mentioned,
+                    tools_used=[],
+                    exchange_count=result.total_messages,
+                )
+                try:
+                    store_distillation(
+                        conn, lock, -date_hash, dr,
+                        embedding=vec,
+                        embed_model=embedder.model,
+                    )
+                except Exception:
+                    # Might conflict on session_id — update instead
+                    pass
+    except Exception as exc:
+        log.debug("Reflection embedding failed: %s", exc)
+
+    # Log to memory
+    try:
+        from bantz.core.memory import memory
+        if memory._conn:
+            memory.add("assistant", result.summary_line(), tool_used="reflection")
+    except Exception:
+        pass
+
+
+# ── Step 5: Prune old raw messages (Rec #3: vector orphan cleanup) ───────
+
+def _prune_old_messages(
+    conn: sqlite3.Connection,
+    lock: threading.Lock,
+    keep_days: int = _PRUNE_RAW_DAYS,
+    dry_run: bool = False,
+) -> tuple[int, int]:
+    """
+    Delete raw messages older than keep_days, KEEPING distilled summaries.
+    Also cleans up orphaned vector embeddings (Recommendation #3).
+
+    Returns (messages_deleted, vectors_deleted).
+    """
+    cutoff = (datetime.now() - timedelta(days=keep_days)).isoformat()
+
+    # Find message IDs that will be deleted
+    rows = conn.execute(
+        """SELECT m.id FROM messages m
+           JOIN conversations c ON c.id = m.conversation_id
+           WHERE c.last_active < ?
+             AND c.id IN (
+                SELECT conversation_id FROM session_distillations
+             )""",
+        (cutoff,),
+    ).fetchall()
+    msg_ids = [r[0] if isinstance(r, (tuple, list)) else r["id"] for r in rows]
+
+    if dry_run:
+        return len(msg_ids), len(msg_ids)  # estimate vectors = messages
+
+    if not msg_ids:
+        return 0, 0
+
+    # Delete vector embeddings FIRST (Rec #3: no ghost vectors)
+    vectors_deleted = 0
+    try:
+        placeholders = ",".join("?" * len(msg_ids))
+        with lock:
+            cur = conn.execute(
+                f"DELETE FROM message_vectors WHERE message_id IN ({placeholders})",
+                msg_ids,
+            )
+            vectors_deleted = cur.rowcount
+    except Exception as exc:
+        log.debug("Vector pruning error: %s", exc)
+
+    # Then delete the messages
+    messages_deleted = 0
+    try:
+        placeholders = ",".join("?" * len(msg_ids))
+        with lock:
+            cur = conn.execute(
+                f"DELETE FROM messages WHERE id IN ({placeholders})",
+                msg_ids,
+            )
+            messages_deleted = cur.rowcount
+    except Exception as exc:
+        log.debug("Message pruning error: %s", exc)
+
+    # Clean up empty conversations
+    try:
+        with lock:
+            conn.execute(
+                """DELETE FROM conversations
+                   WHERE last_active < ?
+                     AND id NOT IN (SELECT DISTINCT conversation_id FROM messages)""",
+                (cutoff,),
+            )
+    except Exception:
+        pass
+
+    log.info("Pruned %d messages + %d vectors (older than %d days)",
+             messages_deleted, vectors_deleted, keep_days)
+    return messages_deleted, vectors_deleted
+
+
+# ── Step 6: Report ──────────────────────────────────────────────────────
+
+async def _send_report(result: ReflectionResult, dry_run: bool) -> None:
+    """Desktop notification + Telegram summary."""
+    tag = " (dry-run)" if dry_run else ""
+    summary = result.summary_line()
+
+    # Desktop notification
+    try:
+        from bantz.agent.notifier import notifier
+        if notifier.enabled:
+            one_line = (
+                f"🤔 Reflection{tag}: "
+                f"{result.sessions} sessions, "
+                f"{result.total_messages} msgs"
+            )
+            notifier.send(one_line, urgency="normal", expire_ms=10_000)
+    except Exception:
+        pass
+
+    # Telegram
+    try:
+        from bantz.config import config
+        if config.telegram_bot_token and config.telegram_allowed_users:
+            import httpx
+            users = [u.strip() for u in config.telegram_allowed_users.split(",") if u.strip()]
+            for uid in users:
+                try:
+                    async with httpx.AsyncClient(timeout=10) as client:
+                        await client.post(
+                            f"https://api.telegram.org/bot{config.telegram_bot_token}/sendMessage",
+                            json={"chat_id": uid, "text": summary, "parse_mode": ""},
+                        )
+                except Exception:
+                    pass
+    except Exception:
+        pass
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# View past reflections
+# ═══════════════════════════════════════════════════════════════════════════
+
+def list_reflections(limit: int = 10) -> list[dict]:
+    """List recent daily reflections from KV store."""
+    try:
+        from bantz.data.sqlite_store import SQLiteKVStore
+        kv = SQLiteKVStore(_data_dir() / "bantz.db")
+        all_keys = kv.all()
+        reflection_keys = sorted(
+            [k for k in all_keys if k.startswith("reflection_2")],
+            reverse=True,
+        )[:limit]
+        results = []
+        for key in reflection_keys:
+            try:
+                data = json.loads(kv.get(key, "{}"))
+                results.append(data)
+            except Exception:
+                pass
+        return results
+    except Exception:
+        return []
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Main entrypoint
+# ═══════════════════════════════════════════════════════════════════════════
+
+async def run_reflection(
+    *,
+    dry_run: bool = False,
+    date_override: str = "",
+) -> ReflectionResult:
+    """Execute the nightly reflection workflow.
+
+    Args:
+        dry_run: If True, print what would be done without LLM calls/writes.
+        date_override: ISO date string (YYYY-MM-DD) to reflect on. Defaults to today.
+
+    Returns:
+        ReflectionResult with the day's reflection and metadata.
+    """
+    from bantz.agent.job_scheduler import inhibit_sleep
+
+    date_str = date_override or datetime.now().strftime("%Y-%m-%d")
+    tag = " (DRY-RUN)" if dry_run else ""
+    log.info("🤔 Reflection starting for %s%s...", date_str, tag)
+
+    result = ReflectionResult(date=date_str)
+
+    with inhibit_sleep("Bantz nightly reflection"):
+        deadline = time.monotonic() + _TOTAL_TIMEOUT
+
+        # ── 1. Collect today's data ──────────────────────────────────────
+        conn, lock = _get_conn_and_lock()
+
+        sessions, messages = _collect_today_sessions_meta(conn, date_str)
+        result.sessions = sessions
+        result.total_messages = messages
+
+        if sessions == 0:
+            result.summary = "No conversations today."
+            result.reflection = "Quiet day — no interactions recorded."
+            log.info("🤔 Reflection: 0 sessions for %s, skipping LLM", date_str)
+            # Still store the empty reflection
+            if not dry_run:
+                await _store_reflection(conn, lock, result)
+            await _send_report(result, dry_run)
+            return result
+
+        # ── 2. Hierarchical summarisation (Rec #1) ──────────────────────
+        distillations = _collect_today_distillations(conn, date_str)
+        undistilled = _collect_undistilled_sessions(conn, date_str)
+        summaries_text = _build_summaries_text(distillations, undistilled)
+
+        log.info("Reflection: %d distillations + %d undistilled for %s",
+                 len(distillations), len(undistilled), date_str)
+
+        if dry_run:
+            result.summary = f"[DRY-RUN] Would reflect on {sessions} sessions ({messages} messages)"
+            result.reflection = f"Summaries text:\n{summaries_text[:500]}"
+            await _send_report(result, dry_run)
+            return result
+
+        # ── 3. LLM reflection ───────────────────────────────────────────
+        if time.monotonic() > deadline:
+            result.summary = "Timed out before LLM call"
+            return result
+
+        try:
+            raw = await _llm_reflect(date_str, summaries_text)
+            parsed = _parse_reflection_json(raw)
+
+            result.summary = parsed.get("summary", "")
+            result.decisions = parsed.get("decisions", [])
+            result.tasks_created = parsed.get("tasks_created", [])
+            result.tasks_completed = parsed.get("tasks_completed", [])
+            result.people_mentioned = parsed.get("people_mentioned", [])
+            result.reflection = parsed.get("reflection", "")
+            result.unresolved = parsed.get("unresolved", [])
+        except asyncio.TimeoutError:
+            log.warning("Reflection LLM timed out")
+            result.summary = "LLM timed out during reflection"
+        except Exception as exc:
+            log.warning("Reflection LLM failed: %s", exc)
+            result.summary = f"LLM error: {exc}"
+
+        # ── 4. Entity extraction with graph context (Rec #4) ─────────────
+        if time.monotonic() < deadline:
+            try:
+                existing = await _fetch_existing_entities_from_graph()
+                entities = await _llm_extract_entities(
+                    date_str, result.to_dict(), existing,
+                )
+                if entities:
+                    stored = await _store_entities_to_graph(entities)
+                    result.entities_extracted = stored
+            except Exception as exc:
+                log.debug("Entity extraction failed: %s", exc)
+
+                # Fallback to rule-based
+                fallback = _rule_based_entity_extraction(result.to_dict())
+                if fallback:
+                    stored = await _store_entities_to_graph(fallback)
+                    result.entities_extracted = stored
+
+        # ── 5. Store reflection ──────────────────────────────────────────
+        if time.monotonic() < deadline:
+            await _store_reflection(conn, lock, result)
+
+        # ── 6. Prune old raw messages + vectors (Rec #3) ────────────────
+        if time.monotonic() < deadline:
+            try:
+                result.raw_pruned, result.vectors_pruned = _prune_old_messages(
+                    conn, lock, keep_days=_PRUNE_RAW_DAYS,
+                )
+            except Exception as exc:
+                log.debug("Pruning failed: %s", exc)
+
+        # ── 7. Report ───────────────────────────────────────────────────
+        await _send_report(result, dry_run)
+
+    log.info("🤔 Reflection complete for %s: %s", date_str,
+             result.summary_line().split("\n")[0])
+    return result

--- a/tests/test_job_scheduler.py
+++ b/tests/test_job_scheduler.py
@@ -645,11 +645,12 @@ class TestNightJobFunctions:
                 await _job_maintenance()
 
     @pytest.mark.asyncio
-    async def test_reflection_no_distiller(self):
-        """Reflection gracefully handles missing distiller."""
+    async def test_reflection_delegates_to_workflow(self):
+        """Reflection delegates to run_reflection workflow."""
         from bantz.agent.job_scheduler import _job_reflection
-        with patch.dict("sys.modules", {"bantz.memory.distiller": None}):
-            await _job_reflection()  # Should not raise
+        with patch("bantz.agent.workflows.reflection.run_reflection", new_callable=AsyncMock) as mock_run:
+            await _job_reflection()
+            mock_run.assert_awaited_once_with(dry_run=False)
 
     @pytest.mark.asyncio
     async def test_overnight_poll_no_gmail(self):

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -1,0 +1,966 @@
+"""
+Tests for bantz.agent.workflows.reflection — Nightly memory reflection (#130).
+
+Coverage:
+  - ReflectionResult dataclass (to_dict, summary_line)
+  - Prompt constants and formatting
+  - _collect_today_distillations (hierarchical summarisation — Rec #1)
+  - _collect_today_sessions_meta
+  - _collect_undistilled_sessions
+  - _build_summaries_text
+  - _parse_reflection_json (valid, fenced, malformed, fallback)
+  - _parse_entity_json (valid, fenced, malformed)
+  - _rule_based_entity_extraction (people, decisions, tasks)
+  - _fetch_existing_entities_from_graph (Rec #4: entity resolution)
+  - _llm_extract_entities (with graph context injection)
+  - _prune_old_messages + vector cleanup (Rec #3: orphan vectors)
+  - _store_reflection (KV + vector + memory)
+  - _send_report (notification + Telegram)
+  - run_reflection: dry-run mode
+  - run_reflection: zero sessions graceful handling
+  - run_reflection: normal run with mocked LLM
+  - run_reflection: timeout enforcement (Rec #2: generous timeout)
+  - list_reflections
+  - CLI --reflect / --reflections / --dry-run arg presence
+  - Job scheduler delegation
+  - Edge cases (empty inputs, LLM failures)
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Fixtures
+# ═══════════════════════════════════════════════════════════════════════════
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    """Create a test SQLite DB with conversations, messages, and distillations."""
+    import threading
+    db_path = tmp_path / "bantz.db"
+    conn = sqlite3.connect(str(db_path), check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+
+    # conversations table
+    conn.execute("""
+        CREATE TABLE conversations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            started_at TEXT NOT NULL,
+            last_active TEXT NOT NULL
+        )
+    """)
+
+    # messages table
+    conn.execute("""
+        CREATE TABLE messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            conversation_id INTEGER NOT NULL,
+            role TEXT NOT NULL,
+            content TEXT NOT NULL,
+            tool_used TEXT,
+            created_at TEXT NOT NULL,
+            FOREIGN KEY (conversation_id) REFERENCES conversations(id)
+        )
+    """)
+
+    # session_distillations table
+    conn.execute("""
+        CREATE TABLE session_distillations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            conversation_id INTEGER NOT NULL UNIQUE,
+            summary TEXT NOT NULL,
+            topics TEXT NOT NULL DEFAULT '',
+            decisions TEXT NOT NULL DEFAULT '',
+            people TEXT NOT NULL DEFAULT '',
+            tools_used TEXT NOT NULL DEFAULT '',
+            exchange_count INTEGER NOT NULL DEFAULT 0,
+            embedding BLOB,
+            embed_dim INTEGER,
+            embed_model TEXT,
+            created_at TEXT NOT NULL
+        )
+    """)
+
+    # message_vectors table
+    conn.execute("""
+        CREATE TABLE message_vectors (
+            message_id INTEGER PRIMARY KEY,
+            embedding BLOB NOT NULL,
+            dim INTEGER NOT NULL,
+            model TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        )
+    """)
+
+    lock = threading.Lock()
+    return conn, lock, tmp_path
+
+
+@pytest.fixture
+def populated_db(tmp_db):
+    """DB with today's conversations and distillations."""
+    conn, lock, tmp_path = tmp_db
+    today = datetime.now().strftime("%Y-%m-%d")
+
+    # Insert 2 conversations with messages
+    conn.execute(
+        "INSERT INTO conversations (id, started_at, last_active) VALUES (1, ?, ?)",
+        (f"{today}T10:00:00", f"{today}T10:30:00"),
+    )
+    conn.execute(
+        "INSERT INTO conversations (id, started_at, last_active) VALUES (2, ?, ?)",
+        (f"{today}T14:00:00", f"{today}T15:00:00"),
+    )
+
+    for conv_id, msgs in [
+        (1, [
+            ("user", "What's the weather?", "weather"),
+            ("assistant", "Sunny, 22°C in Ankara.", None),
+            ("user", "Check my calendar", "calendar"),
+            ("assistant", "You have a meeting with Prof. Yilmaz at 3pm.", None),
+            ("user", "Remind me to study", None),
+            ("assistant", "Reminder set for 8pm.", "reminder"),
+        ]),
+        (2, [
+            ("user", "Help me with Docker networking", "shell"),
+            ("assistant", "The bridge network is misconfigured. Try...", None),
+            ("user", "That worked, thanks!", None),
+            ("assistant", "Great! Docker bridge is fixed.", None),
+            ("user", "Now let's work on Bantz v3 planning", None),
+            ("assistant", "Let's outline the architecture. I suggest LanceDB for vectors.", None),
+        ]),
+    ]:
+        for role, content, tool in msgs:
+            conn.execute(
+                "INSERT INTO messages (conversation_id, role, content, tool_used, created_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (conv_id, role, content, tool, f"{today}T10:00:00"),
+            )
+
+    # Insert distillation for conversation 1
+    conn.execute(
+        """INSERT INTO session_distillations
+           (conversation_id, summary, topics, decisions, people,
+            tools_used, exchange_count, created_at)
+           VALUES (1, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            "Checked weather and calendar. Reminder to study set.",
+            "weather,calendar,reminder",
+            "none",
+            "Prof. Yilmaz",
+            "weather,calendar",
+            3,
+            f"{today}T10:30:00",
+        ),
+    )
+
+    # Insert distillation for conversation 2
+    conn.execute(
+        """INSERT INTO session_distillations
+           (conversation_id, summary, topics, decisions, people,
+            tools_used, exchange_count, created_at)
+           VALUES (2, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            "Fixed Docker networking. Started Bantz v3 planning. Chose LanceDB for vectors.",
+            "docker,architecture,planning",
+            "Chose LanceDB over ChromaDB",
+            "",
+            "shell",
+            3,
+            f"{today}T15:00:00",
+        ),
+    )
+
+    return conn, lock, tmp_path
+
+
+@pytest.fixture
+def mock_memory(populated_db):
+    """Mock the memory singleton to use our test DB."""
+    conn, lock, tmp_path = populated_db
+    mock_mem = MagicMock()
+    mock_mem._conn = conn
+    mock_mem._lock = lock
+    mock_mem.add = MagicMock()
+    return mock_mem, conn, lock, tmp_path
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# ReflectionResult tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestReflectionResult:
+    def test_defaults(self):
+        from bantz.agent.workflows.reflection import ReflectionResult
+        r = ReflectionResult()
+        assert r.date == ""
+        assert r.sessions == 0
+        assert r.decisions == []
+        assert r.entities_extracted == 0
+
+    def test_to_dict(self):
+        from bantz.agent.workflows.reflection import ReflectionResult
+        r = ReflectionResult(
+            date="2026-03-10",
+            sessions=3,
+            total_messages=25,
+            summary="Productive day",
+            decisions=["Use LanceDB"],
+            people_mentioned=["Ali"],
+            reflection="Good focus",
+        )
+        d = r.to_dict()
+        assert d["date"] == "2026-03-10"
+        assert d["sessions"] == 3
+        assert d["decisions"] == ["Use LanceDB"]
+        assert "people_mentioned" in d
+
+    def test_to_dict_roundtrip(self):
+        from bantz.agent.workflows.reflection import ReflectionResult
+        r = ReflectionResult(date="2026-03-10", summary="Test")
+        s = json.dumps(r.to_dict())
+        d = json.loads(s)
+        assert d["date"] == "2026-03-10"
+
+    def test_summary_line(self):
+        from bantz.agent.workflows.reflection import ReflectionResult
+        r = ReflectionResult(
+            date="2026-03-10",
+            sessions=4,
+            total_messages=47,
+            summary="Worked on planning.",
+            decisions=["Chose LanceDB"],
+            reflection="Pattern: context-switching",
+            unresolved=["Exam prep"],
+            entities_extracted=5,
+            raw_pruned=100,
+            vectors_pruned=80,
+        )
+        line = r.summary_line()
+        assert "2026-03-10" in line
+        assert "4 sessions" in line
+        assert "Chose LanceDB" in line
+        assert "context-switching" in line
+        assert "Exam prep" in line
+        assert "5 entities" in line
+        assert "100 old messages" in line
+
+    def test_summary_line_empty(self):
+        from bantz.agent.workflows.reflection import ReflectionResult
+        r = ReflectionResult(date="2026-03-10")
+        line = r.summary_line()
+        assert "2026-03-10" in line
+
+    def test_summary_line_with_pruning(self):
+        from bantz.agent.workflows.reflection import ReflectionResult
+        r = ReflectionResult(raw_pruned=50, vectors_pruned=40)
+        line = r.summary_line()
+        assert "50" in line
+        assert "40" in line
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Data collection tests (Rec #1: hierarchical summarisation)
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestDataCollection:
+    def test_collect_today_distillations(self, populated_db):
+        from bantz.agent.workflows.reflection import _collect_today_distillations
+        conn, lock, _ = populated_db
+        today = datetime.now().strftime("%Y-%m-%d")
+        distills = _collect_today_distillations(conn, today)
+        assert len(distills) == 2
+        assert "weather" in distills[0]["summary"].lower() or "docker" in distills[0]["summary"].lower()
+
+    def test_collect_today_distillations_empty(self, tmp_db):
+        from bantz.agent.workflows.reflection import _collect_today_distillations
+        conn, lock, _ = tmp_db
+        distills = _collect_today_distillations(conn, "2099-01-01")
+        assert distills == []
+
+    def test_collect_today_sessions_meta(self, populated_db):
+        from bantz.agent.workflows.reflection import _collect_today_sessions_meta
+        conn, lock, _ = populated_db
+        today = datetime.now().strftime("%Y-%m-%d")
+        sessions, messages = _collect_today_sessions_meta(conn, today)
+        assert sessions == 2
+        assert messages == 12
+
+    def test_collect_undistilled_sessions(self, populated_db):
+        from bantz.agent.workflows.reflection import _collect_undistilled_sessions
+        conn, lock, _ = populated_db
+        today = datetime.now().strftime("%Y-%m-%d")
+        # All sessions have distillations
+        undistilled = _collect_undistilled_sessions(conn, today)
+        assert len(undistilled) == 0
+
+    def test_collect_undistilled_sessions_with_gap(self, populated_db):
+        from bantz.agent.workflows.reflection import _collect_undistilled_sessions
+        conn, lock, _ = populated_db
+        today = datetime.now().strftime("%Y-%m-%d")
+        # Add a third conversation without distillation
+        conn.execute(
+            "INSERT INTO conversations (id, started_at, last_active) VALUES (3, ?, ?)",
+            (f"{today}T18:00:00", f"{today}T18:30:00"),
+        )
+        conn.execute(
+            "INSERT INTO messages (conversation_id, role, content, created_at) "
+            "VALUES (3, 'user', 'Quick question', ?)",
+            (f"{today}T18:00:00",),
+        )
+        undistilled = _collect_undistilled_sessions(conn, today)
+        assert len(undistilled) == 1
+        assert undistilled[0]["conversation_id"] == 3
+
+
+class TestBuildSummariesText:
+    def test_with_distillations(self):
+        from bantz.agent.workflows.reflection import _build_summaries_text
+        distills = [
+            {"summary": "Checked weather", "topics": "weather", "decisions": "", "people": "Ali", "exchange_count": 5},
+            {"summary": "Fixed Docker", "topics": "docker", "decisions": "Use bridge", "people": "", "exchange_count": 3},
+        ]
+        text = _build_summaries_text(distills, [])
+        assert "Session 1" in text
+        assert "Session 2" in text
+        assert "Checked weather" in text
+        assert "Fixed Docker" in text
+
+    def test_with_undistilled(self):
+        from bantz.agent.workflows.reflection import _build_summaries_text
+        undistilled = [{"msg_count": 5, "user_preview": "help with Docker"}]
+        text = _build_summaries_text([], undistilled)
+        assert "no distillation" in text
+        assert "Docker" in text
+
+    def test_empty(self):
+        from bantz.agent.workflows.reflection import _build_summaries_text
+        text = _build_summaries_text([], [])
+        assert "No conversations" in text
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# JSON parsing tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestParseReflectionJson:
+    def test_valid_json(self):
+        from bantz.agent.workflows.reflection import _parse_reflection_json
+        raw = json.dumps({
+            "summary": "Good day",
+            "decisions": ["Use LanceDB"],
+            "tasks_created": ["Write DAL"],
+            "tasks_completed": [],
+            "people_mentioned": ["Ali (study)"],
+            "reflection": "Focus improved",
+            "unresolved": ["Exam prep"],
+        })
+        result = _parse_reflection_json(raw)
+        assert result["summary"] == "Good day"
+        assert result["decisions"] == ["Use LanceDB"]
+
+    def test_fenced_json(self):
+        from bantz.agent.workflows.reflection import _parse_reflection_json
+        raw = '```json\n{"summary": "Test", "decisions": [], "tasks_created": [], "tasks_completed": [], "people_mentioned": [], "reflection": "", "unresolved": []}\n```'
+        result = _parse_reflection_json(raw)
+        assert result["summary"] == "Test"
+
+    def test_json_with_prefix(self):
+        from bantz.agent.workflows.reflection import _parse_reflection_json
+        raw = 'Here is the reflection:\n{"summary": "Test", "decisions": []}'
+        result = _parse_reflection_json(raw)
+        assert result["summary"] == "Test"
+
+    def test_malformed_fallback(self):
+        from bantz.agent.workflows.reflection import _parse_reflection_json
+        raw = "This is just plain text without JSON"
+        result = _parse_reflection_json(raw)
+        assert result["summary"]  # should contain the raw text
+        assert isinstance(result["decisions"], list)
+
+
+class TestParseEntityJson:
+    def test_valid_array(self):
+        from bantz.agent.workflows.reflection import _parse_entity_json
+        raw = json.dumps([
+            {"label": "Person", "key_prop": "name", "value": "Ali"},
+        ])
+        result = _parse_entity_json(raw)
+        assert len(result) == 1
+        assert result[0]["label"] == "Person"
+
+    def test_fenced_array(self):
+        from bantz.agent.workflows.reflection import _parse_entity_json
+        raw = '```json\n[{"label": "Topic", "key_prop": "name", "value": "Docker"}]\n```'
+        result = _parse_entity_json(raw)
+        assert len(result) == 1
+
+    def test_empty(self):
+        from bantz.agent.workflows.reflection import _parse_entity_json
+        assert _parse_entity_json("[]") == []
+
+    def test_malformed(self):
+        from bantz.agent.workflows.reflection import _parse_entity_json
+        assert _parse_entity_json("not json") == []
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Rule-based entity extraction tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestRuleBasedEntityExtraction:
+    def test_extracts_people(self):
+        from bantz.agent.workflows.reflection import _rule_based_entity_extraction
+        reflection = {
+            "people_mentioned": ["Ali (study group)", "Prof. Yilmaz (exam)"],
+            "decisions": [],
+            "tasks_created": [],
+            "tasks_completed": [],
+        }
+        entities = _rule_based_entity_extraction(reflection)
+        person_names = [e["value"] for e in entities if e["label"] == "Person"]
+        assert "Ali" in person_names
+        assert "Prof. Yilmaz" in person_names
+
+    def test_extracts_decisions(self):
+        from bantz.agent.workflows.reflection import _rule_based_entity_extraction
+        reflection = {
+            "people_mentioned": [],
+            "decisions": ["Use LanceDB", "AT-SPI before VLM"],
+            "tasks_created": [],
+            "tasks_completed": [],
+        }
+        entities = _rule_based_entity_extraction(reflection)
+        decision_vals = [e["value"] for e in entities if e["label"] == "Decision"]
+        assert "Use LanceDB" in decision_vals
+
+    def test_extracts_tasks(self):
+        from bantz.agent.workflows.reflection import _rule_based_entity_extraction
+        reflection = {
+            "people_mentioned": [],
+            "decisions": [],
+            "tasks_created": ["Write DAL"],
+            "tasks_completed": ["Fix Docker"],
+        }
+        entities = _rule_based_entity_extraction(reflection)
+        task_vals = [e["value"] for e in entities if e["label"] == "Task"]
+        assert "Write DAL" in task_vals
+        assert "Fix Docker" in task_vals
+
+    def test_empty_reflection(self):
+        from bantz.agent.workflows.reflection import _rule_based_entity_extraction
+        entities = _rule_based_entity_extraction({})
+        assert entities == []
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Entity resolution tests (Rec #4)
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestEntityResolution:
+    @pytest.mark.asyncio
+    async def test_fetch_existing_entities_graph_disabled(self):
+        from bantz.agent.workflows.reflection import _fetch_existing_entities_from_graph
+        mock_graph = MagicMock()
+        mock_graph.enabled = False
+        with patch("bantz.memory.graph.graph_memory", mock_graph):
+            result = await _fetch_existing_entities_from_graph()
+        assert "not available" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_fetch_existing_entities_graph_enabled(self):
+        from bantz.agent.workflows.reflection import _fetch_existing_entities_from_graph
+        mock_graph = MagicMock()
+        mock_graph.enabled = True
+        mock_graph._query = AsyncMock(return_value=[
+            {"name": "Ali"}, {"name": "Bantz Project"},
+        ])
+        with patch("bantz.memory.graph.graph_memory", mock_graph):
+            result = await _fetch_existing_entities_from_graph()
+        assert "Ali" in result
+        assert "Bantz Project" in result
+
+    @pytest.mark.asyncio
+    async def test_fetch_existing_entities_no_graph(self):
+        from bantz.agent.workflows.reflection import _fetch_existing_entities_from_graph
+        with patch.dict("sys.modules", {"bantz.memory.graph": None}):
+            result = await _fetch_existing_entities_from_graph()
+        assert "not available" in result.lower() or "graph" in result.lower()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Prune tests (Rec #3: vector orphan cleanup)
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestPruneOldMessages:
+    def test_prune_removes_old_messages_and_vectors(self, populated_db):
+        """Messages AND vectors older than 30 days should be deleted."""
+        from bantz.agent.workflows.reflection import _prune_old_messages
+        conn, lock, _ = populated_db
+
+        # Add an old conversation (40 days ago) with distillation
+        old_date = (datetime.now() - timedelta(days=40)).isoformat()
+        conn.execute(
+            "INSERT INTO conversations (id, started_at, last_active) VALUES (10, ?, ?)",
+            (old_date, old_date),
+        )
+        conn.execute(
+            "INSERT INTO messages (id, conversation_id, role, content, created_at) "
+            "VALUES (100, 10, 'user', 'old message', ?)",
+            (old_date,),
+        )
+        conn.execute(
+            "INSERT INTO messages (id, conversation_id, role, content, created_at) "
+            "VALUES (101, 10, 'assistant', 'old response', ?)",
+            (old_date,),
+        )
+        conn.execute(
+            """INSERT INTO session_distillations
+               (conversation_id, summary, created_at)
+               VALUES (10, 'Old session summary', ?)""",
+            (old_date,),
+        )
+        # Add vector embeddings for those messages
+        import struct
+        dummy_blob = struct.pack("3f", 0.1, 0.2, 0.3)
+        conn.execute(
+            "INSERT INTO message_vectors (message_id, embedding, dim, model, created_at) "
+            "VALUES (100, ?, 3, 'test', ?)",
+            (dummy_blob, old_date),
+        )
+        conn.execute(
+            "INSERT INTO message_vectors (message_id, embedding, dim, model, created_at) "
+            "VALUES (101, ?, 3, 'test', ?)",
+            (dummy_blob, old_date),
+        )
+
+        msgs_deleted, vecs_deleted = _prune_old_messages(conn, lock, keep_days=30)
+        assert msgs_deleted == 2
+        assert vecs_deleted == 2
+
+        # Verify vectors are actually gone
+        remaining = conn.execute(
+            "SELECT COUNT(*) FROM message_vectors WHERE message_id IN (100, 101)"
+        ).fetchone()[0]
+        assert remaining == 0
+
+        # Distillation should STILL exist (we keep summaries)
+        dist = conn.execute(
+            "SELECT COUNT(*) FROM session_distillations WHERE conversation_id = 10"
+        ).fetchone()[0]
+        assert dist == 1
+
+    def test_prune_skips_recent_messages(self, populated_db):
+        from bantz.agent.workflows.reflection import _prune_old_messages
+        conn, lock, _ = populated_db
+        msgs_deleted, vecs_deleted = _prune_old_messages(conn, lock, keep_days=30)
+        # Today's messages should NOT be deleted
+        assert msgs_deleted == 0
+
+    def test_prune_dry_run(self, populated_db):
+        from bantz.agent.workflows.reflection import _prune_old_messages
+        conn, lock, _ = populated_db
+        # Add old data
+        old_date = (datetime.now() - timedelta(days=40)).isoformat()
+        conn.execute(
+            "INSERT INTO conversations (id, started_at, last_active) VALUES (10, ?, ?)",
+            (old_date, old_date),
+        )
+        conn.execute(
+            "INSERT INTO messages (id, conversation_id, role, content, created_at) "
+            "VALUES (100, 10, 'user', 'old', ?)",
+            (old_date,),
+        )
+        conn.execute(
+            """INSERT INTO session_distillations
+               (conversation_id, summary, created_at)
+               VALUES (10, 'summary', ?)""",
+            (old_date,),
+        )
+
+        msgs, vecs = _prune_old_messages(conn, lock, keep_days=30, dry_run=True)
+        assert msgs > 0  # would delete
+
+        # But messages should still exist
+        remaining = conn.execute(
+            "SELECT COUNT(*) FROM messages WHERE id = 100"
+        ).fetchone()[0]
+        assert remaining == 1
+
+    def test_prune_only_distilled_conversations(self, populated_db):
+        """Only conversations WITH distillations should be pruned."""
+        from bantz.agent.workflows.reflection import _prune_old_messages
+        conn, lock, _ = populated_db
+
+        old_date = (datetime.now() - timedelta(days=40)).isoformat()
+        # Old conversation WITHOUT distillation — should NOT be pruned
+        conn.execute(
+            "INSERT INTO conversations (id, started_at, last_active) VALUES (11, ?, ?)",
+            (old_date, old_date),
+        )
+        conn.execute(
+            "INSERT INTO messages (id, conversation_id, role, content, created_at) "
+            "VALUES (110, 11, 'user', 'important', ?)",
+            (old_date,),
+        )
+
+        msgs_deleted, _ = _prune_old_messages(conn, lock, keep_days=30)
+        # Should NOT delete this undistilled conversation's messages
+        remaining = conn.execute(
+            "SELECT COUNT(*) FROM messages WHERE id = 110"
+        ).fetchone()[0]
+        assert remaining == 1
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Store reflection tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestStoreReflection:
+    @pytest.mark.asyncio
+    async def test_stores_to_kv(self, tmp_path):
+        from bantz.agent.workflows.reflection import _store_reflection, ReflectionResult
+        import threading
+        # The KV store inside _store_reflection opens _data_dir()/bantz.db
+        kv_db_path = tmp_path / "bantz.db"
+        # Use a separate connection for the test fixture
+        conn = sqlite3.connect(str(tmp_path / "memory.db"), check_same_thread=False)
+        conn.row_factory = sqlite3.Row
+        lock = threading.Lock()
+
+        result = ReflectionResult(
+            date="2026-03-10",
+            sessions=2,
+            total_messages=12,
+            summary="Good day",
+        )
+        with patch("bantz.agent.workflows.reflection._data_dir", return_value=tmp_path):
+            with patch("bantz.core.memory.memory") as mock_mem:
+                mock_mem._conn = conn
+                mock_mem.add = MagicMock()
+                with patch("bantz.config.config") as mock_cfg:
+                    mock_cfg.embedding_enabled = False
+                    await _store_reflection(conn, lock, result)
+        conn.close()
+
+        from bantz.data.sqlite_store import SQLiteKVStore
+        kv = SQLiteKVStore(kv_db_path)
+        stored = json.loads(kv.get("reflection_2026-03-10", "{}"))
+        assert stored["summary"] == "Good day"
+        assert kv.get("reflection_latest_date") == "2026-03-10"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Send report tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestSendReport:
+    @pytest.mark.asyncio
+    async def test_sends_notification(self):
+        from bantz.agent.workflows.reflection import _send_report, ReflectionResult
+        result = ReflectionResult(date="2026-03-10", sessions=2, total_messages=12)
+        mock_notifier = MagicMock()
+        mock_notifier.enabled = True
+        with patch("bantz.agent.notifier.notifier", mock_notifier):
+            with patch("bantz.config.config") as mock_cfg:
+                mock_cfg.telegram_bot_token = ""
+                mock_cfg.telegram_allowed_users = ""
+                await _send_report(result, dry_run=False)
+        mock_notifier.send.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_skips_telegram_if_no_token(self):
+        from bantz.agent.workflows.reflection import _send_report, ReflectionResult
+        result = ReflectionResult(date="2026-03-10")
+        with patch("bantz.agent.notifier.notifier") as mock_not:
+            mock_not.enabled = False
+            with patch("bantz.config.config") as mock_cfg:
+                mock_cfg.telegram_bot_token = ""
+                mock_cfg.telegram_allowed_users = ""
+                with patch("httpx.AsyncClient") as mock_http:
+                    await _send_report(result, dry_run=False)
+        mock_http.assert_not_called()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# run_reflection integration tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestRunReflection:
+    @pytest.mark.asyncio
+    async def test_zero_sessions_graceful(self, tmp_db):
+        """0 sessions → immediate return with 'No conversations today'."""
+        from bantz.agent.workflows.reflection import run_reflection
+        conn, lock, tmp_path = tmp_db
+
+        with patch("bantz.agent.workflows.reflection._get_conn_and_lock", return_value=(conn, lock)):
+            with patch("bantz.agent.workflows.reflection._data_dir", return_value=tmp_path):
+                with patch("bantz.agent.job_scheduler.inhibit_sleep") as mock_inh:
+                    mock_inh.return_value.__enter__ = MagicMock()
+                    mock_inh.return_value.__exit__ = MagicMock(return_value=False)
+                    with patch("bantz.agent.notifier.notifier") as mock_not:
+                        mock_not.enabled = False
+                        with patch("bantz.config.config") as mock_cfg:
+                            mock_cfg.telegram_bot_token = ""
+                            mock_cfg.telegram_allowed_users = ""
+                            mock_cfg.embedding_enabled = False
+                            result = await run_reflection(dry_run=False)
+
+        assert result.sessions == 0
+        assert "No conversations" in result.summary
+
+    @pytest.mark.asyncio
+    async def test_dry_run_no_llm_calls(self, populated_db):
+        """Dry-run mode should NOT call the LLM."""
+        from bantz.agent.workflows.reflection import run_reflection
+        conn, lock, tmp_path = populated_db
+
+        with patch("bantz.agent.workflows.reflection._get_conn_and_lock", return_value=(conn, lock)):
+            with patch("bantz.agent.workflows.reflection._data_dir", return_value=tmp_path):
+                with patch("bantz.agent.workflows.reflection._llm_reflect") as mock_llm:
+                    with patch("bantz.agent.job_scheduler.inhibit_sleep") as mock_inh:
+                        mock_inh.return_value.__enter__ = MagicMock()
+                        mock_inh.return_value.__exit__ = MagicMock(return_value=False)
+                        with patch("bantz.agent.notifier.notifier") as mock_not:
+                            mock_not.enabled = False
+                            with patch("bantz.config.config") as mock_cfg:
+                                mock_cfg.telegram_bot_token = ""
+                                mock_cfg.telegram_allowed_users = ""
+                                result = await run_reflection(dry_run=True)
+
+        mock_llm.assert_not_called()
+        assert "DRY-RUN" in result.summary
+
+    @pytest.mark.asyncio
+    async def test_normal_run_with_mocked_llm(self, populated_db):
+        """Normal run should call LLM, parse result, and store."""
+        from bantz.agent.workflows.reflection import run_reflection
+        conn, lock, tmp_path = populated_db
+
+        llm_response = json.dumps({
+            "summary": "Worked on weather, Docker, and Bantz v3 planning.",
+            "decisions": ["Chose LanceDB"],
+            "tasks_created": ["Write DAL"],
+            "tasks_completed": ["Fixed Docker bridge"],
+            "people_mentioned": ["Prof. Yilmaz (exam)"],
+            "reflection": "Context-switching between coding and study prep.",
+            "unresolved": ["Exam prep"],
+        })
+
+        with patch("bantz.agent.workflows.reflection._get_conn_and_lock", return_value=(conn, lock)):
+            with patch("bantz.agent.workflows.reflection._data_dir", return_value=tmp_path):
+                with patch("bantz.agent.workflows.reflection._llm_reflect",
+                           new_callable=AsyncMock, return_value=llm_response):
+                    with patch("bantz.agent.workflows.reflection._llm_extract_entities",
+                               new_callable=AsyncMock, return_value=[]):
+                        with patch("bantz.agent.workflows.reflection._store_entities_to_graph",
+                                   new_callable=AsyncMock, return_value=0):
+                            with patch("bantz.agent.job_scheduler.inhibit_sleep") as mock_inh:
+                                mock_inh.return_value.__enter__ = MagicMock()
+                                mock_inh.return_value.__exit__ = MagicMock(return_value=False)
+                                with patch("bantz.agent.notifier.notifier") as mock_not:
+                                    mock_not.enabled = False
+                                    with patch("bantz.config.config") as mock_cfg:
+                                        mock_cfg.telegram_bot_token = ""
+                                        mock_cfg.telegram_allowed_users = ""
+                                        mock_cfg.embedding_enabled = False
+                                        mock_cfg.db_path = tmp_path / "bantz.db"
+                                        with patch("bantz.core.memory.memory") as mock_mem:
+                                            mock_mem._conn = conn
+                                            mock_mem.add = MagicMock()
+                                            result = await run_reflection(dry_run=False)
+
+        assert result.sessions == 2
+        assert result.summary == "Worked on weather, Docker, and Bantz v3 planning."
+        assert "Chose LanceDB" in result.decisions
+        assert "Prof. Yilmaz (exam)" in result.people_mentioned
+
+    @pytest.mark.asyncio
+    async def test_timeout_constant_is_generous(self):
+        """Rec #2: verify total timeout is 10 min (generous for local LLM)."""
+        from bantz.agent.workflows.reflection import _TOTAL_TIMEOUT
+        assert _TOTAL_TIMEOUT >= 600  # at least 10 minutes
+
+    @pytest.mark.asyncio
+    async def test_llm_timeout_is_reasonable(self):
+        """Each LLM call should have a per-call timeout."""
+        from bantz.agent.workflows.reflection import _LLM_TIMEOUT
+        assert _LLM_TIMEOUT >= 60  # at least 1 minute per call
+
+    @pytest.mark.asyncio
+    async def test_date_override(self, populated_db):
+        """date_override should reflect on a specific date."""
+        from bantz.agent.workflows.reflection import run_reflection
+        conn, lock, tmp_path = populated_db
+
+        with patch("bantz.agent.workflows.reflection._get_conn_and_lock", return_value=(conn, lock)):
+            with patch("bantz.agent.workflows.reflection._data_dir", return_value=tmp_path):
+                with patch("bantz.agent.job_scheduler.inhibit_sleep") as mock_inh:
+                    mock_inh.return_value.__enter__ = MagicMock()
+                    mock_inh.return_value.__exit__ = MagicMock(return_value=False)
+                    with patch("bantz.agent.notifier.notifier") as mock_not:
+                        mock_not.enabled = False
+                        with patch("bantz.config.config") as mock_cfg:
+                            mock_cfg.telegram_bot_token = ""
+                            mock_cfg.telegram_allowed_users = ""
+                            mock_cfg.embedding_enabled = False
+                            result = await run_reflection(
+                                dry_run=False,
+                                date_override="2099-12-31",
+                            )
+
+        assert result.date == "2099-12-31"
+        assert result.sessions == 0
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# list_reflections tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestListReflections:
+    def test_list_empty(self, tmp_db):
+        from bantz.agent.workflows.reflection import list_reflections
+        _, _, tmp_path = tmp_db
+        with patch("bantz.agent.workflows.reflection._data_dir", return_value=tmp_path):
+            results = list_reflections()
+        assert results == []
+
+    def test_list_with_data(self, tmp_db):
+        from bantz.agent.workflows.reflection import list_reflections
+        from bantz.data.sqlite_store import SQLiteKVStore
+        _, _, tmp_path = tmp_db
+        kv = SQLiteKVStore(tmp_path / "bantz.db")
+        kv.set("reflection_2026-03-08", json.dumps({"date": "2026-03-08", "summary": "Day 1"}))
+        kv.set("reflection_2026-03-09", json.dumps({"date": "2026-03-09", "summary": "Day 2"}))
+        kv.set("reflection_latest", json.dumps({"date": "2026-03-09"}))  # should be filtered
+
+        with patch("bantz.agent.workflows.reflection._data_dir", return_value=tmp_path):
+            results = list_reflections(limit=10)
+
+        assert len(results) == 2
+        # Should be sorted descending
+        assert results[0]["date"] == "2026-03-09"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# CLI argument tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestCLIArgs:
+    def test_reflect_arg(self):
+        import argparse
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--reflect", action="store_true")
+        parser.add_argument("--reflections", action="store_true")
+        parser.add_argument("--dry-run", action="store_true")
+        ns = parser.parse_args(["--reflect", "--dry-run"])
+        assert ns.reflect
+        assert ns.dry_run
+
+    def test_reflections_arg(self):
+        import argparse
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--reflections", action="store_true")
+        ns = parser.parse_args(["--reflections"])
+        assert ns.reflections
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Job scheduler delegation
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestJobSchedulerDelegation:
+    @pytest.mark.asyncio
+    async def test_job_reflection_delegates(self):
+        from bantz.agent.job_scheduler import _job_reflection
+        from bantz.agent.workflows.reflection import ReflectionResult
+
+        mock_result = ReflectionResult(
+            date="2026-03-10",
+            sessions=3,
+            entities_extracted=5,
+        )
+        with patch("bantz.agent.workflows.reflection.run_reflection",
+                   new_callable=AsyncMock,
+                   return_value=mock_result) as mock_run:
+            await _job_reflection()
+        mock_run.assert_awaited_once_with(dry_run=False)
+
+    def test_registry_updated(self):
+        from bantz.agent.job_scheduler import _JOB_REGISTRY
+        assert "reflection" in _JOB_REGISTRY
+        fn, desc = _JOB_REGISTRY["reflection"]
+        assert "reflection" in desc.lower()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Edge cases
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestEdgeCases:
+    def test_parse_reflection_empty_decisions(self):
+        from bantz.agent.workflows.reflection import _parse_reflection_json
+        raw = json.dumps({
+            "summary": "Quiet day", "decisions": [],
+            "tasks_created": [], "tasks_completed": [],
+            "people_mentioned": [], "reflection": "",
+            "unresolved": [],
+        })
+        result = _parse_reflection_json(raw)
+        assert result["decisions"] == []
+
+    def test_reflection_result_serializable(self):
+        from bantz.agent.workflows.reflection import ReflectionResult
+        r = ReflectionResult(
+            date="2026-03-10",
+            decisions=["a", "b"],
+            people_mentioned=["Ali"],
+        )
+        s = json.dumps(r.to_dict())
+        assert json.loads(s)["date"] == "2026-03-10"
+
+    @pytest.mark.asyncio
+    async def test_llm_failure_falls_back_to_rules(self, populated_db):
+        """If LLM entity extraction fails, fallback to rule-based."""
+        from bantz.agent.workflows.reflection import _llm_extract_entities
+
+        with patch("bantz.llm.gemini.gemini") as mock_gemini:
+            mock_gemini.is_enabled.return_value = False
+            with patch("bantz.llm.ollama.ollama") as mock_ollama:
+                mock_ollama.chat = AsyncMock(side_effect=Exception("timeout"))
+                entities = await _llm_extract_entities(
+                    "2026-03-10",
+                    {
+                        "people_mentioned": ["Ali"],
+                        "decisions": ["Use LanceDB"],
+                        "tasks_created": [],
+                        "tasks_completed": [],
+                    },
+                    "(empty graph)",
+                )
+        assert len(entities) >= 2  # Ali + Use LanceDB
+
+    def test_prune_raw_days_constant(self):
+        from bantz.agent.workflows.reflection import _PRUNE_RAW_DAYS
+        assert _PRUNE_RAW_DAYS == 30
+
+    @pytest.mark.asyncio
+    async def test_store_entities_graph_disabled(self):
+        from bantz.agent.workflows.reflection import _store_entities_to_graph
+        mock_graph = MagicMock()
+        mock_graph.enabled = False
+        with patch("bantz.memory.graph.graph_memory", mock_graph):
+            count = await _store_entities_to_graph([
+                {"label": "Person", "key_prop": "name", "value": "Test"},
+            ])
+        assert count == 0


### PR DESCRIPTION
## Issue #130 — Nightly Memory Reflection

### 7-Step Pipeline
1. **Collect** session distillation summaries (not raw messages — Rec #1)
2. **LLM Reflect** — generate daily reflection JSON (Gemini → Ollama fallback)
3. **Extract entities** with graph context injection (Rec #4)
4. **Store** to KV store + vector DB + memory log
5. **Prune** old messages + orphan vectors (Rec #3)
6. **Report** via desktop notification + Telegram
7. **Deadline guard** — generous 10-min total timeout (Rec #2)

### User Recommendations Implemented
- **Rec #1** Hierarchical summarisation: reads `session_distillations` instead of raw messages
- **Rec #2** Generous timeout: `_TOTAL_TIMEOUT=600` (10 min) for nightly job
- **Rec #3** Vector orphan cleanup: deletes embeddings before pruning old messages
- **Rec #4** Entity resolution: queries Neo4j for existing Person/Topic/Decision/Task before LLM extraction

### Changes
- `src/bantz/agent/workflows/reflection.py` — ~900 lines, full pipeline
- `src/bantz/__main__.py` — `--reflect`, `--reflections`, `--dry-run` CLI flags
- `src/bantz/agent/job_scheduler.py` — delegates to `run_reflection()` (fixes old ImportError bug)
- `tests/test_reflection.py` — 53 tests
- `tests/test_job_scheduler.py` — updated delegation test

**Tests:** 934 passing (881 + 53 new)