### PR TITLE
feat: Brain integrations for #125-#130

### DIFF
--- a/src/bantz/core/brain.py
+++ b/src/bantz/core/brain.py
@@ -570,6 +570,30 @@ class Brain:
                                     "what's today", "what do i have today")):
             return {"tool": "_briefing", "args": {}}
 
+        # Maintenance (#129) — manual trigger
+        if re.search(
+            r"run\s+maintenance|sistemi?\s+temizle|system\s+cleanup|"
+            r"clean\s+(?:up\s+)?(?:the\s+)?system|bakım\s+yap|maintenance\s+run",
+            both,
+        ):
+            return {"tool": "_maintenance", "args": {"dry_run": "dry" in both}}
+
+        # Reflection (#130) — run reflection now (MUST come before list)
+        if re.search(
+            r"run\s+reflect|yansıma\s+yap|generate\s+reflect|"
+            r"reflect\s+(?:on\s+)?today|bugünü\s+özetle",
+            both,
+        ):
+            return {"tool": "_run_reflection", "args": {"dry_run": "dry" in both}}
+
+        # Reflection (#130) — show past reflections
+        if re.search(
+            r"show\s+reflect|list\s+reflect|past\s+reflect|"
+            r"dünkü\s+özet|geçmiş\s+özetler|son\s+yansımalar",
+            both,
+        ):
+            return {"tool": "_list_reflections", "args": {}}
+
         # GUI Action — unified navigate + act pipeline (#123)
         # Must come BEFORE web_search since "search bar" contains "search".
         # Order: specific (type, double_click, right_click) before general click.
@@ -773,6 +797,74 @@ class Brain:
 
         return None
 
+    # ── RL & Intervention hooks (#125, #126) ─────────────────────────
+
+    def _rl_reward_hook(self, tool_name: str, result: ToolResult) -> None:
+        """Fire-and-forget: give RL engine a positive reward on tool success."""
+        try:
+            from bantz.agent.rl_engine import rl_engine, encode_state
+            if not rl_engine.initialized:
+                return
+            tc = time_ctx.snapshot()
+            state = encode_state(
+                time_segment=tc.get("time_segment", "morning"),
+                day=tc.get("day_name", "monday").lower(),
+                location=tc.get("location", "home"),
+                recent_tool=tool_name,
+            )
+            reward_val = 1.0 if result.success else -0.5
+            rl_engine.reward(reward_val, next_state=state)
+        except Exception:
+            pass  # never crash the pipeline
+
+    async def _check_intervention_queue(self) -> str | None:
+        """Pop the next pending intervention and return its text, or None."""
+        try:
+            from bantz.agent.interventions import intervention_queue
+            iv = intervention_queue.pop()
+            if iv is None:
+                return None
+            return f"💡 [{iv.source}] {iv.title}\n   {iv.reason}"
+        except Exception:
+            return None
+
+    # ── Maintenance & Reflection handlers (#129, #130) ────────────────
+
+    async def _handle_maintenance(self, dry_run: bool = False) -> str:
+        """Run the maintenance workflow and return its summary."""
+        try:
+            from bantz.agent.workflows.maintenance import run_maintenance
+            report = await run_maintenance(dry_run=dry_run)
+            return report.summary()
+        except Exception as exc:
+            return f"❌ Maintenance failed: {exc}"
+
+    def _handle_list_reflections(self, limit: int = 5) -> str:
+        """List recent reflections from the KV store."""
+        try:
+            from bantz.agent.workflows.reflection import list_reflections
+            items = list_reflections(limit=limit)
+            if not items:
+                return "No reflections stored yet. They are generated nightly."
+            lines = ["🤔 Recent reflections:"]
+            for item in items:
+                date = item.get("date", "?")
+                summary = item.get("summary", "")[:120]
+                sessions = item.get("sessions", 0)
+                lines.append(f"  • {date} ({sessions} sessions): {summary}")
+            return "\n".join(lines)
+        except Exception as exc:
+            return f"❌ Could not load reflections: {exc}"
+
+    async def _handle_run_reflection(self, dry_run: bool = False) -> str:
+        """Run the reflection workflow and return its summary."""
+        try:
+            from bantz.agent.workflows.reflection import run_reflection
+            result = await run_reflection(dry_run=dry_run)
+            return result.summary_line()
+        except Exception as exc:
+            return f"❌ Reflection failed: {exc}"
+
     async def _generate_command(self, orig: str, en: str) -> str:
         raw = await ollama.chat([
             {"role": "system", "content": COMMAND_SYSTEM},
@@ -902,6 +994,21 @@ class Brain:
             text = await _briefing.generate()
             data_layer.conversations.add("assistant", text, tool_used="briefing")
             return BrainResult(response=text, tool_used="briefing")
+
+        if quick and quick["tool"] == "_maintenance":
+            text = await self._handle_maintenance(quick["args"].get("dry_run", False))
+            data_layer.conversations.add("assistant", text, tool_used="maintenance")
+            return BrainResult(response=text, tool_used="maintenance")
+
+        if quick and quick["tool"] == "_list_reflections":
+            text = self._handle_list_reflections()
+            data_layer.conversations.add("assistant", text, tool_used="reflection")
+            return BrainResult(response=text, tool_used="reflection")
+
+        if quick and quick["tool"] == "_run_reflection":
+            text = await self._handle_run_reflection(quick["args"].get("dry_run", False))
+            data_layer.conversations.add("assistant", text, tool_used="reflection")
+            return BrainResult(response=text, tool_used="reflection")
 
         if quick and quick["tool"] == "_location":
             text = await self._handle_location()
@@ -1049,6 +1156,9 @@ class Brain:
             return BrainResult(response=err, tool_used=None)
 
         result = await tool.execute(**tool_args)
+
+        # ── RL reward: positive signal on successful tool use (#125) ──
+        self._rl_reward_hook(tool_name, result)
 
         # ── Store tool results for contextual follow-ups (#56) ──
         if result.success and result.data:

--- a/src/bantz/tools/reminder.py
+++ b/src/bantz/tools/reminder.py
@@ -44,6 +44,26 @@ class ReminderTool(BaseTool):
         else:
             return self._add(scheduler, kwargs, intent)
 
+    @staticmethod
+    def _bridge_to_job_scheduler(
+        title: str,
+        fire_at: datetime,
+        repeat: str = "none",
+    ) -> str | None:
+        """Forward reminder to APScheduler-based job_scheduler (#128).
+
+        Returns the APScheduler job ID if successful, None otherwise.
+        The old core/scheduler.py remains the source of truth for CRUD;
+        this bridge ensures APScheduler also fires the notification.
+        """
+        try:
+            from bantz.agent.job_scheduler import job_scheduler
+            if not job_scheduler._started:
+                return None
+            return job_scheduler.add_reminder(title, fire_at, repeat=repeat)
+        except Exception:
+            return None
+
     # ── Add ───────────────────────────────────────────────────────────────
 
     def _add(self, scheduler, kwargs: dict, intent: str) -> ToolResult:
@@ -79,6 +99,8 @@ class ReminderTool(BaseTool):
             rid = scheduler.add(title, fire_at, repeat=repeat, trigger_place=place_key)
             # Dual-write to Neo4j
             _store_reminder_neo4j(rid, title, trigger_place=place_key, repeat=repeat)
+            # Bridge to APScheduler (#128)
+            ReminderTool._bridge_to_job_scheduler(title, fire_at, repeat)
             return ToolResult(
                 success=True,
                 output=f"📍 Reminder #{rid} set: \"{title}\" — when you arrive at {place}",
@@ -96,6 +118,8 @@ class ReminderTool(BaseTool):
 
         # Dual-write to Neo4j
         _store_reminder_neo4j(rid, title, fire_at=fire_at, repeat=repeat)
+        # Bridge to APScheduler (#128)
+        ReminderTool._bridge_to_job_scheduler(title, fire_at, repeat)
 
         return ToolResult(
             success=True,

--- a/tests/test_brain_integrations.py
+++ b/tests/test_brain_integrations.py
@@ -1,0 +1,564 @@
+"""
+Tests for brain.py integration with RL engine, interventions,
+job_scheduler, maintenance, and reflection (#125-#130 brain wiring).
+"""
+from __future__ import annotations
+
+import asyncio
+import re
+import types
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Helpers
+# ═══════════════════════════════════════════════════════════════════════════
+
+def _run(coro):
+    """Run an async coroutine synchronously."""
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 1. Quick-route regex tests (#129, #130)
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestQuickRouteMaintenanceReflection:
+    """Ensure _quick_route returns correct pseudo-tool for maintenance & reflection."""
+
+    @staticmethod
+    def _qr(orig: str, en: str | None = None):
+        from bantz.core.brain import Brain
+        return Brain._quick_route(orig, en or orig)
+
+    # ── Maintenance triggers ──────────────────────────────────────────
+
+    def test_run_maintenance(self):
+        assert self._qr("run maintenance")["tool"] == "_maintenance"
+
+    def test_run_maintenance_dry(self):
+        r = self._qr("run maintenance dry")
+        assert r["tool"] == "_maintenance"
+        assert r["args"]["dry_run"] is True
+
+    def test_sistemi_temizle(self):
+        assert self._qr("sistemi temizle")["tool"] == "_maintenance"
+
+    def test_system_cleanup(self):
+        assert self._qr("system cleanup")["tool"] == "_maintenance"
+
+    def test_clean_up_system(self):
+        assert self._qr("clean up the system")["tool"] == "_maintenance"
+
+    def test_bakim_yap(self):
+        assert self._qr("bakım yap")["tool"] == "_maintenance"
+
+    def test_maintenance_run(self):
+        assert self._qr("maintenance run")["tool"] == "_maintenance"
+
+    # ── Reflection triggers: list ─────────────────────────────────────
+
+    def test_show_reflections(self):
+        assert self._qr("show reflections")["tool"] == "_list_reflections"
+
+    def test_list_reflections(self):
+        assert self._qr("list reflections")["tool"] == "_list_reflections"
+
+    def test_past_reflections(self):
+        assert self._qr("past reflections")["tool"] == "_list_reflections"
+
+    def test_dunku_ozet(self):
+        assert self._qr("dünkü özet")["tool"] == "_list_reflections"
+
+    def test_gecmis_ozetler(self):
+        assert self._qr("geçmiş özetler")["tool"] == "_list_reflections"
+
+    # ── Reflection triggers: run ──────────────────────────────────────
+
+    def test_run_reflection(self):
+        assert self._qr("run reflection")["tool"] == "_run_reflection"
+
+    def test_run_reflection_dry(self):
+        r = self._qr("run reflection dry")
+        assert r["tool"] == "_run_reflection"
+        assert r["args"]["dry_run"] is True
+
+    def test_yansima_yap(self):
+        assert self._qr("yansıma yap")["tool"] == "_run_reflection"
+
+    def test_generate_reflection(self):
+        assert self._qr("generate reflection")["tool"] == "_run_reflection"
+
+    def test_reflect_on_today(self):
+        assert self._qr("reflect on today")["tool"] == "_run_reflection"
+
+    def test_bugunu_ozetle(self):
+        assert self._qr("bugünü özetle")["tool"] == "_run_reflection"
+
+    # ── Non-matches (should NOT trigger maintenance/reflection) ───────
+
+    def test_maintain_focus_not_maintenance(self):
+        r = self._qr("maintain my focus please")
+        assert r is None or r["tool"] != "_maintenance"
+
+    def test_reflect_in_conversation(self):
+        """'reflect' alone in casual chat should not trigger."""
+        r = self._qr("let me reflect on this idea for a moment")
+        assert r is None or r["tool"] != "_run_reflection"
+
+    def test_briefing_still_works(self):
+        assert self._qr("good morning")["tool"] == "_briefing"
+
+    def test_reminder_still_works(self):
+        assert self._qr("remind me to call dentist at 3pm")["tool"] == "reminder"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 2. RL reward hook (#125)
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestRLRewardHook:
+    """Verify _rl_reward_hook calls rl_engine.reward on tool success/failure."""
+
+    def _make_brain(self):
+        from bantz.core.brain import Brain
+        b = Brain.__new__(Brain)
+        b._bridge = False
+        b._memory_ready = True
+        b._graph_ready = True
+        b._last_messages = []
+        b._last_events = []
+        b._last_draft = None
+        return b
+
+    def test_reward_positive_on_success(self):
+        b = self._make_brain()
+        from bantz.tools import ToolResult
+        result = ToolResult(success=True, output="ok")
+
+        mock_engine = MagicMock()
+        mock_engine.initialized = True
+        mock_encode = MagicMock(return_value=MagicMock(key="morning|monday|home|weather"))
+
+        with patch("bantz.agent.rl_engine.rl_engine", mock_engine), \
+             patch("bantz.agent.rl_engine.encode_state", mock_encode):
+            b._rl_reward_hook("weather", result)
+
+        mock_engine.reward.assert_called_once()
+        call_args = mock_engine.reward.call_args
+        assert call_args[0][0] == 1.0  # positive reward
+
+    def test_reward_negative_on_failure(self):
+        b = self._make_brain()
+        from bantz.tools import ToolResult
+        result = ToolResult(success=False, output="", error="fail")
+
+        mock_engine = MagicMock()
+        mock_engine.initialized = True
+        mock_encode = MagicMock(return_value=MagicMock(key="morning|monday|home|shell"))
+
+        with patch("bantz.agent.rl_engine.rl_engine", mock_engine), \
+             patch("bantz.agent.rl_engine.encode_state", mock_encode):
+            b._rl_reward_hook("shell", result)
+
+        mock_engine.reward.assert_called_once()
+        call_args = mock_engine.reward.call_args
+        assert call_args[0][0] == -0.5  # negative reward
+
+    def test_hook_noop_when_uninitialized(self):
+        b = self._make_brain()
+        from bantz.tools import ToolResult
+        result = ToolResult(success=True, output="ok")
+
+        mock_engine = MagicMock()
+        mock_engine.initialized = False
+
+        with patch("bantz.agent.rl_engine.rl_engine", mock_engine):
+            b._rl_reward_hook("shell", result)
+
+        mock_engine.reward.assert_not_called()
+
+    def test_hook_no_crash_on_import_error(self):
+        b = self._make_brain()
+        from bantz.tools import ToolResult
+        result = ToolResult(success=True, output="ok")
+
+        with patch.dict("sys.modules", {"bantz.agent.rl_engine": None}):
+            # Should not raise even when module fails to import
+            b._rl_reward_hook("weather", result)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 3. Intervention queue hook (#126)
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestInterventionQueueHook:
+    """Verify _check_intervention_queue pops next intervention."""
+
+    def _make_brain(self):
+        from bantz.core.brain import Brain
+        b = Brain.__new__(Brain)
+        b._bridge = False
+        b._memory_ready = True
+        b._graph_ready = True
+        b._last_messages = []
+        b._last_events = []
+        b._last_draft = None
+        return b
+
+    def test_pop_returns_formatted_text(self):
+        b = self._make_brain()
+        mock_iv = MagicMock()
+        mock_iv.source = "rl_engine"
+        mock_iv.title = "Start focus mode"
+        mock_iv.reason = "You usually focus at this time"
+
+        mock_queue = MagicMock()
+        mock_queue.pop.return_value = mock_iv
+
+        with patch("bantz.agent.interventions.intervention_queue", mock_queue):
+            text = _run(b._check_intervention_queue())
+
+        assert text is not None
+        assert "rl_engine" in text
+        assert "Start focus mode" in text
+
+    def test_pop_returns_none_when_empty(self):
+        b = self._make_brain()
+        mock_queue = MagicMock()
+        mock_queue.pop.return_value = None
+
+        with patch("bantz.agent.interventions.intervention_queue", mock_queue):
+            text = _run(b._check_intervention_queue())
+
+        assert text is None
+
+    def test_pop_no_crash_on_error(self):
+        b = self._make_brain()
+        with patch.dict("sys.modules", {"bantz.agent.interventions": None}):
+            text = _run(b._check_intervention_queue())
+        assert text is None
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 4. Reminder → job_scheduler bridge (#128)
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestReminderBridge:
+    """Verify ReminderTool._bridge_to_job_scheduler calls add_reminder."""
+
+    def test_bridge_calls_add_reminder(self):
+        from bantz.tools.reminder import ReminderTool
+        fire_at = datetime.now() + timedelta(hours=1)
+        mock_js = MagicMock()
+        mock_js._started = True
+        mock_js.add_reminder.return_value = "job_123"
+
+        with patch("bantz.agent.job_scheduler.job_scheduler", mock_js):
+            result = ReminderTool._bridge_to_job_scheduler("test", fire_at, "none")
+
+        assert result == "job_123"
+        mock_js.add_reminder.assert_called_once_with("test", fire_at, repeat="none")
+
+    def test_bridge_returns_none_when_not_started(self):
+        from bantz.tools.reminder import ReminderTool
+        fire_at = datetime.now() + timedelta(hours=1)
+        mock_js = MagicMock()
+        mock_js._started = False
+
+        with patch("bantz.agent.job_scheduler.job_scheduler", mock_js):
+            result = ReminderTool._bridge_to_job_scheduler("test", fire_at)
+
+        assert result is None
+        mock_js.add_reminder.assert_not_called()
+
+    def test_bridge_returns_none_on_exception(self):
+        from bantz.tools.reminder import ReminderTool
+        fire_at = datetime.now() + timedelta(hours=1)
+
+        with patch.dict("sys.modules", {"bantz.agent.job_scheduler": None}):
+            result = ReminderTool._bridge_to_job_scheduler("test", fire_at)
+
+        assert result is None
+
+    def test_bridge_passes_repeat_mode(self):
+        from bantz.tools.reminder import ReminderTool
+        fire_at = datetime.now() + timedelta(hours=1)
+        mock_js = MagicMock()
+        mock_js._started = True
+        mock_js.add_reminder.return_value = "job_daily"
+
+        with patch("bantz.agent.job_scheduler.job_scheduler", mock_js):
+            result = ReminderTool._bridge_to_job_scheduler("daily check", fire_at, "daily")
+
+        mock_js.add_reminder.assert_called_once_with("daily check", fire_at, repeat="daily")
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 5. Maintenance handler (#129)
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestMaintenanceHandler:
+    """Verify _handle_maintenance calls run_maintenance and returns summary."""
+
+    def _make_brain(self):
+        from bantz.core.brain import Brain
+        b = Brain.__new__(Brain)
+        b._bridge = False
+        b._memory_ready = True
+        b._graph_ready = True
+        b._last_messages = []
+        b._last_events = []
+        b._last_draft = None
+        return b
+
+    def test_handle_maintenance_returns_summary(self):
+        b = self._make_brain()
+        mock_report = MagicMock()
+        mock_report.summary.return_value = "🔧 Maintenance: 5 ok, 0 skipped, 0 failed"
+        mock_run = AsyncMock(return_value=mock_report)
+
+        with patch("bantz.agent.workflows.maintenance.run_maintenance", mock_run):
+            text = _run(b._handle_maintenance())
+
+        assert "Maintenance" in text
+        mock_run.assert_awaited_once_with(dry_run=False)
+
+    def test_handle_maintenance_dry_run(self):
+        b = self._make_brain()
+        mock_report = MagicMock()
+        mock_report.summary.return_value = "🔧 Maintenance (DRY-RUN)"
+        mock_run = AsyncMock(return_value=mock_report)
+
+        with patch("bantz.agent.workflows.maintenance.run_maintenance", mock_run):
+            text = _run(b._handle_maintenance(dry_run=True))
+
+        mock_run.assert_awaited_once_with(dry_run=True)
+
+    def test_handle_maintenance_error(self):
+        b = self._make_brain()
+        mock_run = AsyncMock(side_effect=RuntimeError("docker not found"))
+
+        with patch("bantz.agent.workflows.maintenance.run_maintenance", mock_run):
+            text = _run(b._handle_maintenance())
+
+        assert "❌" in text
+        assert "docker not found" in text
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 6. Reflection handlers (#130)
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestReflectionHandlers:
+    """Verify _handle_list_reflections and _handle_run_reflection."""
+
+    def _make_brain(self):
+        from bantz.core.brain import Brain
+        b = Brain.__new__(Brain)
+        b._bridge = False
+        b._memory_ready = True
+        b._graph_ready = True
+        b._last_messages = []
+        b._last_events = []
+        b._last_draft = None
+        return b
+
+    def test_list_reflections_empty(self):
+        b = self._make_brain()
+        with patch("bantz.agent.workflows.reflection.list_reflections", return_value=[]):
+            text = b._handle_list_reflections()
+        assert "No reflections" in text
+
+    def test_list_reflections_with_data(self):
+        b = self._make_brain()
+        items = [
+            {"date": "2025-07-14", "sessions": 5, "summary": "Productive day"},
+            {"date": "2025-07-13", "sessions": 3, "summary": "Light chat"},
+        ]
+        with patch("bantz.agent.workflows.reflection.list_reflections", return_value=items):
+            text = b._handle_list_reflections()
+        assert "2025-07-14" in text
+        assert "Productive day" in text
+        assert "2025-07-13" in text
+
+    def test_list_reflections_error(self):
+        b = self._make_brain()
+        with patch("bantz.agent.workflows.reflection.list_reflections",
+                    side_effect=RuntimeError("db locked")):
+            text = b._handle_list_reflections()
+        assert "❌" in text
+
+    def test_run_reflection(self):
+        b = self._make_brain()
+        mock_result = MagicMock()
+        mock_result.summary_line.return_value = "🤔 Reflection (2025-07-14): 5 sessions"
+        mock_run = AsyncMock(return_value=mock_result)
+
+        with patch("bantz.agent.workflows.reflection.run_reflection", mock_run):
+            text = _run(b._handle_run_reflection())
+
+        assert "Reflection" in text
+        mock_run.assert_awaited_once_with(dry_run=False)
+
+    def test_run_reflection_dry(self):
+        b = self._make_brain()
+        mock_result = MagicMock()
+        mock_result.summary_line.return_value = "🤔 Reflection (DRY-RUN)"
+        mock_run = AsyncMock(return_value=mock_result)
+
+        with patch("bantz.agent.workflows.reflection.run_reflection", mock_run):
+            text = _run(b._handle_run_reflection(dry_run=True))
+
+        mock_run.assert_awaited_once_with(dry_run=True)
+
+    def test_run_reflection_error(self):
+        b = self._make_brain()
+        mock_run = AsyncMock(side_effect=RuntimeError("no llm"))
+
+        with patch("bantz.agent.workflows.reflection.run_reflection", mock_run):
+            text = _run(b._handle_run_reflection())
+
+        assert "❌" in text
+        assert "no llm" in text
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 7. Integration: process() wires RL reward after tool execution
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestProcessRLWiring:
+    """Verify that process() calls _rl_reward_hook after tool execution."""
+
+    def _make_brain(self):
+        from bantz.core.brain import Brain
+        b = Brain.__new__(Brain)
+        b._bridge = False
+        b._memory_ready = True
+        b._graph_ready = True
+        b._last_messages = []
+        b._last_events = []
+        b._last_draft = None
+        return b
+
+    def test_process_calls_rl_hook_on_tool(self):
+        """When brain.process() executes a tool, _rl_reward_hook is called."""
+        b = self._make_brain()
+        from bantz.tools import ToolResult
+
+        mock_result = ToolResult(success=True, output="Today is sunny, 28°C")
+
+        # Stub out dependencies
+        b._ensure_memory = MagicMock()
+        b._ensure_graph = AsyncMock()
+        b._to_en = AsyncMock(return_value="weather")
+        b._fire_embeddings = MagicMock()
+        b._graph_store = AsyncMock()
+
+        mock_tool = MagicMock()
+        mock_tool.execute = AsyncMock(return_value=mock_result)
+
+        mock_finalize = AsyncMock(return_value="It's sunny!")
+
+        # Spy on _rl_reward_hook  
+        b._rl_reward_hook = MagicMock()
+
+        with patch("bantz.core.brain.time_ctx") as mock_tc, \
+             patch("bantz.core.brain.data_layer") as mock_dl, \
+             patch("bantz.core.brain.registry") as mock_reg, \
+             patch("bantz.core.brain.cot_route", new_callable=AsyncMock) as mock_cot, \
+             patch.object(b, "_finalize", mock_finalize), \
+             patch.object(b, "_finalize_stream", AsyncMock(return_value=None)):
+
+            mock_tc.snapshot.return_value = {"prompt_hint": "", "time_segment": "morning",
+                                              "day_name": "Monday"}
+            mock_dl.conversations = MagicMock()
+            mock_reg.get.return_value = mock_tool
+
+            # quick_route returns weather tool
+            from bantz.core.brain import Brain
+            with patch.object(Brain, "_quick_route", return_value={
+                "tool": "weather", "args": {"city": "Istanbul"}
+            }):
+                result = _run(b.process("weather"))
+
+        b._rl_reward_hook.assert_called_once_with("weather", mock_result)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 8. Integration: process() routes maintenance/reflection correctly
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestProcessMaintenanceReflectionRouting:
+    """Verify process() actually dispatches to maintenance/reflection handlers."""
+
+    def _make_brain(self):
+        from bantz.core.brain import Brain
+        b = Brain.__new__(Brain)
+        b._bridge = False
+        b._memory_ready = True
+        b._graph_ready = True
+        b._last_messages = []
+        b._last_events = []
+        b._last_draft = None
+        return b
+
+    def test_process_routes_maintenance(self):
+        b = self._make_brain()
+        b._ensure_memory = MagicMock()
+        b._ensure_graph = AsyncMock()
+        b._to_en = AsyncMock(return_value="run maintenance")
+        b._handle_maintenance = AsyncMock(return_value="🔧 Maintenance: all ok")
+
+        with patch("bantz.core.brain.time_ctx") as mock_tc, \
+             patch("bantz.core.brain.data_layer") as mock_dl:
+            mock_tc.snapshot.return_value = {"prompt_hint": ""}
+            mock_dl.conversations = MagicMock()
+
+            # workflow_engine.detect returns [] (no workflow)
+            with patch("bantz.core.workflow.workflow_engine") as mock_wf:
+                mock_wf.detect.return_value = []
+                result = _run(b.process("run maintenance"))
+
+        assert result.tool_used == "maintenance"
+        assert "Maintenance" in result.response
+
+    def test_process_routes_list_reflections(self):
+        b = self._make_brain()
+        b._ensure_memory = MagicMock()
+        b._ensure_graph = AsyncMock()
+        b._to_en = AsyncMock(return_value="show reflections")
+        b._handle_list_reflections = MagicMock(return_value="🤔 Recent reflections:\n  • 2025-07-14")
+
+        with patch("bantz.core.brain.time_ctx") as mock_tc, \
+             patch("bantz.core.brain.data_layer") as mock_dl:
+            mock_tc.snapshot.return_value = {"prompt_hint": ""}
+            mock_dl.conversations = MagicMock()
+
+            with patch("bantz.core.workflow.workflow_engine") as mock_wf:
+                mock_wf.detect.return_value = []
+                result = _run(b.process("show reflections"))
+
+        assert result.tool_used == "reflection"
+        assert "2025-07-14" in result.response
+
+    def test_process_routes_run_reflection(self):
+        b = self._make_brain()
+        b._ensure_memory = MagicMock()
+        b._ensure_graph = AsyncMock()
+        b._to_en = AsyncMock(return_value="run reflection")
+        b._handle_run_reflection = AsyncMock(return_value="🤔 Reflection done")
+
+        with patch("bantz.core.brain.time_ctx") as mock_tc, \
+             patch("bantz.core.brain.data_layer") as mock_dl:
+            mock_tc.snapshot.return_value = {"prompt_hint": ""}
+            mock_dl.conversations = MagicMock()
+
+            with patch("bantz.core.workflow.workflow_engine") as mock_wf:
+                mock_wf.detect.return_value = []
+                result = _run(b.process("run reflection"))
+
+        assert result.tool_used == "reflection"
+        b._handle_run_reflection.assert_awaited_once()


### PR DESCRIPTION
Wires 5 modules into brain.py: #128 Reminder bridge, #125 RL reward hook, #126 Intervention queue, #129 Maintenance trigger, #130 Reflection triggers. 46 new tests (1034 total, 0 failures). Closes #125 #126 #128 #129 #130