### PR TITLE
fix: Wire observer intervention queue into process() (#124)

### DIFF
--- a/src/bantz/core/brain.py
+++ b/src/bantz/core/brain.py
@@ -828,6 +828,14 @@ class Brain:
         except Exception:
             return None
 
+    def _prepend_intervention(self, response: str) -> str:
+        """If an intervention was popped at process() start, prepend it (#124)."""
+        iv = getattr(self, "_pending_intervention", None)
+        if iv:
+            self._pending_intervention = None
+            return f"{iv}\n\n{response}"
+        return response
+
     # ── Maintenance & Reflection handlers (#129, #130) ────────────────
 
     async def _handle_maintenance(self, dry_run: bool = False) -> str:
@@ -964,6 +972,9 @@ class Brain:
         await self._ensure_graph()
         en_input = await self._to_en(user_input)
         tc = time_ctx.snapshot()
+
+        # ── Surface pending observer/intervention alerts (#124) ──
+        self._pending_intervention = await self._check_intervention_queue()
 
         # Save user message ONCE — before any branching
         data_layer.conversations.add("user", user_input)
@@ -1200,6 +1211,7 @@ class Brain:
 
         # Short output — non-streaming finalize
         resp = await self._finalize(en_input, result, tc)
+        resp = self._prepend_intervention(resp)
         data_layer.conversations.add("assistant", resp, tool_used=tool_name)
         await self._graph_store(user_input, resp, tool_name,
                                 result.data if result else None)

--- a/tests/test_brain_integrations.py
+++ b/tests/test_brain_integrations.py
@@ -241,6 +241,27 @@ class TestInterventionQueueHook:
             text = _run(b._check_intervention_queue())
         assert text is None
 
+    def test_prepend_intervention_with_text(self):
+        b = self._make_brain()
+        b._pending_intervention = "💡 [observer] High CPU\n   CPU at 95%"
+        result = b._prepend_intervention("It's sunny outside.")
+        assert result.startswith("💡 [observer]")
+        assert "It's sunny outside." in result
+        # Consumed after use
+        assert b._pending_intervention is None
+
+    def test_prepend_intervention_none(self):
+        b = self._make_brain()
+        b._pending_intervention = None
+        result = b._prepend_intervention("Hello")
+        assert result == "Hello"
+
+    def test_prepend_intervention_no_attr(self):
+        b = self._make_brain()
+        # No _pending_intervention set at all
+        result = b._prepend_intervention("Hello")
+        assert result == "Hello"
+
 
 # ═══════════════════════════════════════════════════════════════════════════
 # 4. Reminder → job_scheduler bridge (#128)


### PR DESCRIPTION
Fixes dead code from PR #161. _check_intervention_queue() was defined but never called in process(). Now polled at the start of every process() call and prepended to the final response via _prepend_intervention(). 3 new tests (1037 total). Closes #124