### PR TITLE
feat(#131): Streaming TTS pipeline — Piper + aplay audio briefing

### DIFF
--- a/src/bantz/agent/job_scheduler.py
+++ b/src/bantz/agent/job_scheduler.py
@@ -266,6 +266,66 @@ async def _fire_dynamic_reminder(title: str, repeat: str = "none") -> None:
 
 
 # ═══════════════════════════════════════════════════════════════════════════
+# Briefing watcher — IDLE → active TTS trigger (#131)
+# ═══════════════════════════════════════════════════════════════════════════
+
+# Module-level state for activity transition detection
+_last_activity: str = "idle"
+_briefing_spoken_today: str = ""  # date string — prevents double-fire
+
+
+async def _job_briefing_watcher() -> None:
+    """Poll AppDetector for IDLE → active transition.
+
+    When the user's first non-IDLE activity is detected after briefing_prep
+    has cached today's briefing, speak it via TTS.
+
+    Runs every 10s as an APScheduler interval job.
+    One-shot per day: once spoken, won't trigger again.
+    """
+    global _last_activity, _briefing_spoken_today
+
+    from bantz.config import config
+    if not config.tts_enabled or not config.tts_auto_briefing:
+        return
+
+    today = datetime.now().date().isoformat()
+    if _briefing_spoken_today == today:
+        return  # Already spoken today
+
+    # Only trigger after the briefing prep hour
+    now = datetime.now()
+    if now.hour < config.briefing_prep_hour:
+        return
+
+    try:
+        from bantz.agent.app_detector import app_detector, Activity
+        current = app_detector.get_activity_category()
+        prev = _last_activity
+        _last_activity = current.value
+
+        # Detect IDLE → non-IDLE transition
+        if prev == "idle" and current != Activity.IDLE:
+            log.info("🔊 Activity transition: IDLE → %s — checking briefing", current.value)
+            text = check_briefing_trigger()
+            if text:
+                _briefing_spoken_today = today
+                from bantz.agent.tts import tts_engine
+                await tts_engine.speak_background(text)
+                log.info("🔊 Morning briefing TTS triggered (%d chars)", len(text))
+
+                # Also send desktop notification
+                try:
+                    from bantz.agent.notifier import notifier
+                    if notifier.enabled:
+                        notifier.send("🌅 Good morning! Briefing playing…")
+                except Exception:
+                    pass
+    except Exception as exc:
+        log.debug("Briefing watcher error: %s", exc)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
 # Job registry — maps job_id to (async_func, description)
 # ═══════════════════════════════════════════════════════════════════════════
 
@@ -275,6 +335,7 @@ _JOB_REGISTRY: dict[str, tuple[Callable, str]] = {
     "overnight_poll": (_job_overnight_poll, "Overnight poll: Gmail/Calendar/Classroom → KV store"),
     "briefing_prep": (_job_briefing_prep, "Pre-fetch morning briefing data"),
     "reminder_check": (_job_reminder_check, "Check due reminders"),
+    "briefing_watcher": (_job_briefing_watcher, "Watch for IDLE→active to speak briefing"),
 }
 
 
@@ -353,6 +414,9 @@ class JobScheduler:
         # Always register reminder check (30s interval)
         self._register_reminder_check()
 
+        # Register briefing watcher (10s interval) for TTS auto-trigger (#131)
+        self._register_briefing_watcher()
+
         # APScheduler event listeners for history tracking
         from apscheduler.events import EVENT_JOB_EXECUTED, EVENT_JOB_ERROR
         self._scheduler.add_listener(self._on_job_executed, EVENT_JOB_EXECUTED)
@@ -420,6 +484,24 @@ class JobScheduler:
             jobstore="default",
         )
         log.info("Registered reminder check (30s interval)")
+
+    def _register_briefing_watcher(self) -> None:
+        """Register 10s interval job for IDLE→active TTS trigger (#131)."""
+        from bantz.config import config
+        if not config.tts_enabled:
+            return
+
+        from apscheduler.triggers.interval import IntervalTrigger
+
+        self._scheduler.add_job(
+            _job_briefing_watcher,
+            IntervalTrigger(seconds=10),
+            id="briefing_watcher",
+            name="Watch for IDLE→active to speak briefing",
+            replace_existing=True,
+            jobstore="default",
+        )
+        log.info("Registered briefing watcher (10s interval, TTS)")
 
     # ── Dynamic reminder bridge ───────────────────────────────────────
 

--- a/src/bantz/agent/tts.py
+++ b/src/bantz/agent/tts.py
@@ -1,0 +1,386 @@
+"""
+Bantz — Streaming TTS Pipeline (#131)
+
+Sentence-by-sentence text-to-speech using Piper + aplay.
+Designed for audio morning briefings with interrupt support.
+
+Architecture:
+    ┌─────────────────────────────────────────────────────┐
+    │                 TTSEngine                           │
+    │                                                     │
+    │  text → sentence_split → Queue<str>                 │
+    │                             ↓                       │
+    │         ┌── synthesize(sentence) ──→ wav bytes ──┐  │
+    │         │   (Piper subprocess)                   │  │
+    │         └────────────────────────────────────────┘  │
+    │                             ↓                       │
+    │         ┌── play(wav_bytes) ──→ aplay subprocess ┐  │
+    │         │   (cancellable via SIGTERM)             │  │
+    │         └────────────────────────────────────────┘  │
+    └─────────────────────────────────────────────────────┘
+
+Key design:
+  - Producer-consumer with asyncio.Queue
+  - Synthesize sentence N+1 while playing sentence N
+  - stop() sends SIGTERM to active aplay → immediate silence
+  - Graceful fallback: if Piper/aplay missing, logs warning and returns
+  - English-first: en_US-lessac-medium Piper model
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import shutil
+import signal
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+log = logging.getLogger(__name__)
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Sentence splitter
+# ═══════════════════════════════════════════════════════════════════════════
+
+# Split on sentence-ending punctuation followed by whitespace or end.
+# Keeps emoji headers (📅, 🌤️ etc.) attached to following text.
+_SENTENCE_RE = re.compile(
+    r'(?<=[.!?;:])\s+|(?<=\n)\s*'
+)
+
+
+def split_sentences(text: str) -> list[str]:
+    """Split briefing text into speakable chunks.
+
+    Strategy: split on sentence boundaries (. ! ? ; :) and newlines.
+    Merge very short fragments (< 10 chars) with their predecessor.
+    Strip emoji and markdown formatting for cleaner speech.
+    """
+    if not text:
+        return []
+
+    # Normalize whitespace
+    text = text.strip()
+
+    # Split on sentence endings + newlines
+    raw = _SENTENCE_RE.split(text)
+    raw = [s.strip() for s in raw if s.strip()]
+
+    if not raw:
+        return []
+
+    # Merge very short fragments with previous
+    merged: list[str] = [raw[0]]
+    for chunk in raw[1:]:
+        if len(merged[-1]) < 10:
+            merged[-1] = merged[-1] + " " + chunk
+        else:
+            merged.append(chunk)
+
+    # Clean for speech: strip emoji, markdown bold/italic
+    cleaned = []
+    for s in merged:
+        # Remove emoji (rough range)
+        s = re.sub(
+            r'[\U0001F300-\U0001F9FF\U00002702-\U000027B0'
+            r'\U0000FE00-\U0000FE0F\U0000200D]+', '', s
+        )
+        # Remove markdown bold/italic
+        s = re.sub(r'\*+', '', s)
+        s = re.sub(r'_+', '', s)
+        # Remove bullet markers
+        s = re.sub(r'^[\s•\-–—]+', '', s)
+        s = s.strip()
+        if s:
+            cleaned.append(s)
+
+    return cleaned
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# TTS Engine
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TTSEngine:
+    """Streaming Piper TTS with aplay playback and interrupt support."""
+
+    def __init__(self) -> None:
+        self._piper_path: str | None = None
+        self._aplay_path: str | None = None
+        self._model_path: str | None = None
+        self._speaker: int = 0
+        self._rate: float = 1.0
+        self._playing: asyncio.subprocess.Process | None = None
+        self._speaking: bool = False
+        self._stop_requested: bool = False
+        self._speak_task: asyncio.Task | None = None
+
+    # ── Init (lazy) ─────────────────────────────────────────────────────
+
+    def _ensure_init(self) -> bool:
+        """Discover Piper and aplay binaries. Returns True if ready."""
+        if self._piper_path is not None:
+            return bool(self._piper_path and self._aplay_path)
+
+        from bantz.config import config
+
+        # Find piper
+        piper = shutil.which("piper")
+        if not piper:
+            # Check common locations
+            for p in [
+                Path.home() / ".local" / "bin" / "piper",
+                Path("/usr/local/bin/piper"),
+                Path("/usr/bin/piper"),
+            ]:
+                if p.exists():
+                    piper = str(p)
+                    break
+
+        # Find aplay
+        aplay = shutil.which("aplay")
+        if not aplay:
+            for p in [Path("/usr/bin/aplay"), Path("/usr/local/bin/aplay")]:
+                if p.exists():
+                    aplay = str(p)
+                    break
+
+        if not piper:
+            log.warning("TTS: piper binary not found — audio disabled")
+            self._piper_path = ""
+            self._aplay_path = ""
+            return False
+
+        if not aplay:
+            log.warning("TTS: aplay binary not found — audio disabled")
+            self._piper_path = ""
+            self._aplay_path = ""
+            return False
+
+        self._piper_path = piper
+        self._aplay_path = aplay
+
+        # Resolve model path
+        model = config.tts_model_path
+        if not model:
+            # Auto-discover: check ~/.local/share/piper-voices/
+            model_name = config.tts_model
+            search_dirs = [
+                Path.home() / ".local" / "share" / "piper-voices",
+                Path.home() / ".local" / "share" / "piper" / "voices",
+                Path.home() / ".local" / "share" / "piper",
+                Path("/usr/share/piper-voices"),
+            ]
+            for d in search_dirs:
+                candidate = d / f"{model_name}.onnx"
+                if candidate.exists():
+                    model = str(candidate)
+                    break
+                # Try nested: en_US-lessac-medium/en_US-lessac-medium.onnx
+                candidate2 = d / model_name / f"{model_name}.onnx"
+                if candidate2.exists():
+                    model = str(candidate2)
+                    break
+
+        if not model or not Path(model).exists():
+            log.warning(
+                "TTS: voice model not found (expected %s) — run: "
+                "piper --download-dir ~/.local/share/piper-voices "
+                "--model %s --update-voices",
+                config.tts_model, config.tts_model,
+            )
+            self._piper_path = ""
+            return False
+
+        self._model_path = model
+        self._speaker = config.tts_speaker
+        self._rate = config.tts_rate
+        log.info("TTS: ready — piper=%s model=%s", piper, model)
+        return True
+
+    # ── Public API ──────────────────────────────────────────────────────
+
+    def available(self) -> bool:
+        """Check if TTS is available (Piper + aplay + model found)."""
+        from bantz.config import config
+        if not config.tts_enabled:
+            return False
+        return self._ensure_init()
+
+    @property
+    def is_speaking(self) -> bool:
+        return self._speaking
+
+    async def speak(self, text: str) -> None:
+        """Speak text with streaming sentence-by-sentence pipeline.
+
+        Synthesizes the next sentence while playing the current one.
+        Can be interrupted at any time via stop().
+        """
+        if not self.available():
+            return
+
+        self._stop_requested = False
+        self._speaking = True
+        try:
+            sentences = split_sentences(text)
+            if not sentences:
+                return
+
+            log.info("TTS: speaking %d sentences", len(sentences))
+
+            # Pre-synthesize first sentence
+            next_wav: bytes | None = await self._synthesize(sentences[0])
+
+            for i, sentence in enumerate(sentences):
+                if self._stop_requested:
+                    log.info("TTS: stop requested, aborting at sentence %d/%d", i + 1, len(sentences))
+                    break
+
+                # Use pre-synthesized wav for current sentence
+                current_wav = next_wav
+
+                # Start synthesizing next sentence in background
+                synth_task: asyncio.Task | None = None
+                if i + 1 < len(sentences):
+                    synth_task = asyncio.create_task(
+                        self._synthesize(sentences[i + 1])
+                    )
+
+                # Play current sentence
+                if current_wav:
+                    await self._play(current_wav)
+
+                # Collect next sentence's wav
+                if synth_task:
+                    next_wav = await synth_task
+                else:
+                    next_wav = None
+
+        except asyncio.CancelledError:
+            log.info("TTS: speak task cancelled")
+            self._kill_playback()
+        except Exception as exc:
+            log.error("TTS: speak error — %s", exc)
+        finally:
+            self._speaking = False
+            self._playing = None
+
+    async def speak_background(self, text: str) -> None:
+        """Speak in background (fire-and-forget, interruptible)."""
+        if self._speak_task and not self._speak_task.done():
+            self.stop()
+            # Give previous task a moment to clean up
+            await asyncio.sleep(0.1)
+        self._speak_task = asyncio.create_task(self.speak(text))
+
+    def stop(self) -> None:
+        """Immediately stop all TTS playback ("Sessiz ol Bantz!")."""
+        self._stop_requested = True
+        self._kill_playback()
+        if self._speak_task and not self._speak_task.done():
+            self._speak_task.cancel()
+        log.info("TTS: stopped by user")
+
+    # ── Internal: Synthesis ─────────────────────────────────────────────
+
+    async def _synthesize(self, sentence: str) -> bytes | None:
+        """Synthesize a single sentence via Piper → raw WAV bytes."""
+        if not sentence or not self._piper_path or not self._model_path:
+            return None
+
+        cmd = [
+            self._piper_path,
+            "--model", self._model_path,
+            "--output-raw",
+        ]
+        if self._speaker > 0:
+            cmd.extend(["--speaker", str(self._speaker)])
+        if self._rate != 1.0:
+            cmd.extend(["--length-scale", str(1.0 / self._rate)])
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(input=sentence.encode("utf-8")),
+                timeout=30.0,
+            )
+            if proc.returncode != 0:
+                log.warning("TTS: piper failed — %s", stderr.decode(errors="replace")[:200])
+                return None
+            return stdout
+        except asyncio.TimeoutError:
+            log.warning("TTS: piper synthesis timed out for: %s", sentence[:50])
+            return None
+        except Exception as exc:
+            log.warning("TTS: synthesis error — %s", exc)
+            return None
+
+    # ── Internal: Playback ──────────────────────────────────────────────
+
+    async def _play(self, wav_data: bytes) -> None:
+        """Play raw WAV data via aplay (16-bit, 22050 Hz mono for Piper)."""
+        if not wav_data or not self._aplay_path:
+            return
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                self._aplay_path,
+                "-r", "22050",
+                "-f", "S16_LE",
+                "-t", "raw",
+                "-c", "1",
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            self._playing = proc
+            await proc.communicate(input=wav_data)
+            self._playing = None
+        except asyncio.CancelledError:
+            self._kill_playback()
+            raise
+        except Exception as exc:
+            log.warning("TTS: playback error — %s", exc)
+            self._playing = None
+
+    def _kill_playback(self) -> None:
+        """Send SIGTERM to the active aplay process."""
+        proc = self._playing
+        if proc and proc.returncode is None:
+            try:
+                proc.send_signal(signal.SIGTERM)
+            except (ProcessLookupError, OSError):
+                pass
+            self._playing = None
+
+    # ── Diagnostics ─────────────────────────────────────────────────────
+
+    def stats(self) -> dict:
+        return {
+            "available": self.available(),
+            "speaking": self._speaking,
+            "piper": self._piper_path or "not found",
+            "aplay": self._aplay_path or "not found",
+            "model": self._model_path or "not found",
+        }
+
+    def status_line(self) -> str:
+        if not self._ensure_init():
+            return "tts=unavailable"
+        state = "speaking" if self._speaking else "idle"
+        return f"tts={state} model={Path(self._model_path or '').stem}"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Module singleton
+# ═══════════════════════════════════════════════════════════════════════════
+
+tts_engine = TTSEngine()

--- a/src/bantz/config.py
+++ b/src/bantz/config.py
@@ -141,6 +141,14 @@ class Config(BaseSettings):
     notification_icon: str = Field("", alias="BANTZ_NOTIFICATION_ICON")
     notification_sound: bool = Field(False, alias="BANTZ_NOTIFICATION_SOUND")
 
+    # ── TTS / Audio Briefing (#131) ──────────────────────────────────────
+    tts_enabled: bool = Field(False, alias="BANTZ_TTS_ENABLED")
+    tts_model: str = Field("en_US-lessac-medium", alias="BANTZ_TTS_MODEL")
+    tts_model_path: str = Field("", alias="BANTZ_TTS_MODEL_PATH")
+    tts_speaker: int = Field(0, alias="BANTZ_TTS_SPEAKER")
+    tts_rate: float = Field(1.0, alias="BANTZ_TTS_RATE")
+    tts_auto_briefing: bool = Field(True, alias="BANTZ_TTS_AUTO_BRIEFING")
+
     @property
     def db_path(self) -> Path:
         base = (

--- a/src/bantz/core/brain.py
+++ b/src/bantz/core/brain.py
@@ -565,6 +565,13 @@ class Brain:
                 return {"tool": "reminder", "args": {"action": "snooze"}}
             return {"tool": "reminder", "args": {"action": "add", "intent": orig}}
 
+        # TTS stop (#131) — "shut up" / "sessiz ol" / "stop talking"
+        if re.search(
+            r"shut\s*up|be\s+quiet|stop\s+talk|sessiz\s+ol|sus\s+bantz|kapat\s+sesi",
+            both,
+        ):
+            return {"tool": "_tts_stop", "args": {}}
+
         # Briefing
         if any(k in both for k in ("good morning", "morning briefing", "daily briefing",
                                     "what's today", "what do i have today")):
@@ -1000,10 +1007,27 @@ class Brain:
 
         quick = self._quick_route(user_input, en_input)
 
+        if quick and quick["tool"] == "_tts_stop":
+            from bantz.agent.tts import tts_engine
+            if tts_engine.is_speaking:
+                tts_engine.stop()
+                text = "🔇 Stopped."
+            else:
+                text = "I'm not speaking right now."
+            data_layer.conversations.add("assistant", text, tool_used="tts")
+            return BrainResult(response=text, tool_used="tts")
+
         if quick and quick["tool"] == "_briefing":
             from bantz.core.briefing import briefing as _briefing
             text = await _briefing.generate()
             data_layer.conversations.add("assistant", text, tool_used="briefing")
+            # Speak via TTS if available (#131)
+            try:
+                from bantz.agent.tts import tts_engine
+                if tts_engine.available():
+                    await tts_engine.speak_background(text)
+            except Exception:
+                pass
             return BrainResult(response=text, tool_used="briefing")
 
         if quick and quick["tool"] == "_maintenance":

--- a/tests/test_job_scheduler.py
+++ b/tests/test_job_scheduler.py
@@ -677,7 +677,7 @@ class TestJobRegistry:
     def test_all_registrations_present(self):
         from bantz.agent.job_scheduler import _JOB_REGISTRY
         expected = {"maintenance", "reflection", "overnight_poll",
-                    "briefing_prep", "reminder_check"}
+                    "briefing_prep", "reminder_check", "briefing_watcher"}
         assert set(_JOB_REGISTRY.keys()) == expected
 
     def test_registry_entries_are_callable(self):

--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -1,0 +1,834 @@
+"""
+Tests for bantz.agent.tts — Streaming TTS Pipeline (#131).
+
+Coverage:
+  - Sentence splitting: basic, edge cases, emoji/markdown removal
+  - TTSEngine: init, available, speak, stop, synthesis, playback
+  - Briefing watcher: IDLE→active transition detection
+  - Brain integration: quick_route for TTS stop, briefing with TTS
+  - Config: TTS-related fields
+"""
+from __future__ import annotations
+
+import asyncio
+import signal
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
+
+import pytest
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 1. Sentence splitting
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestSplitSentences:
+    """Test the sentence splitter used for TTS chunking."""
+
+    def _split(self, text: str) -> list[str]:
+        from bantz.agent.tts import split_sentences
+        return split_sentences(text)
+
+    def test_basic_split(self):
+        result = self._split("Hello world. How are you? Fine thanks!")
+        assert len(result) >= 2
+        assert "Hello world" in result[0]
+
+    def test_empty(self):
+        assert self._split("") == []
+        assert self._split("   ") == []
+
+    def test_single_sentence(self):
+        result = self._split("Just one sentence here.")
+        assert len(result) == 1
+        assert "Just one sentence here" in result[0]
+
+    def test_newline_split(self):
+        result = self._split("Line one.\nLine two.\nLine three.")
+        assert len(result) >= 2
+
+    def test_emoji_removal(self):
+        result = self._split("🌤️ Weather is sunny. 📅 Calendar has 3 events.")
+        for s in result:
+            assert "🌤️" not in s
+            assert "📅" not in s
+
+    def test_markdown_removal(self):
+        result = self._split("**Bold text** and *italic* here.")
+        for s in result:
+            assert "**" not in s
+            assert "*" not in s or s.count("*") == 0
+
+    def test_bullet_removal(self):
+        result = self._split("• Item one.\n• Item two.\n- Item three.")
+        for s in result:
+            assert not s.startswith("•")
+            assert not s.startswith("-")
+
+    def test_short_merge(self):
+        """Very short fragments should be merged with their predecessor."""
+        result = self._split("OK. Yes. Good. This is a longer sentence here.")
+        # "OK", "Yes", "Good" are <10 chars, should be merged
+        assert len(result) <= 2
+
+    def test_briefing_like_text(self):
+        text = (
+            "🌤️ Weather: Sunny, 22°C.\n"
+            "📅 Calendar: 3 events today.\n"
+            "📧 Gmail: 2 new emails.\n"
+            "No urgent items."
+        )
+        result = self._split(text)
+        assert len(result) >= 2
+        assert all(isinstance(s, str) for s in result)
+        assert all(len(s) > 0 for s in result)
+
+    def test_mixed_punctuation(self):
+        result = self._split("Hello; goodbye: see you! Done?")
+        assert len(result) >= 2
+
+    def test_colon_split(self):
+        result = self._split("Weather: sunny and warm. Calendar: meeting at 10.")
+        assert len(result) >= 2
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 2. TTSEngine unit tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestTTSEngine:
+    """Test TTSEngine initialization, availability, and lifecycle."""
+
+    def _make_engine(self):
+        from bantz.agent.tts import TTSEngine
+        return TTSEngine()
+
+    def test_initial_state(self):
+        eng = self._make_engine()
+        assert eng.is_speaking is False
+        assert eng._piper_path is None
+        assert eng._aplay_path is None
+
+    def test_available_when_disabled(self):
+        eng = self._make_engine()
+        with patch("bantz.config.config") as mock_cfg:
+            mock_cfg.tts_enabled = False
+            assert eng.available() is False
+
+    def test_available_no_piper(self):
+        eng = self._make_engine()
+        with patch("bantz.config.config") as mock_cfg, \
+             patch("shutil.which", return_value=None), \
+             patch("pathlib.Path.exists", return_value=False):
+            mock_cfg.tts_enabled = True
+            assert eng.available() is False
+
+    def test_ensure_init_finds_piper(self):
+        """When piper and aplay exist and model is found."""
+        eng = self._make_engine()
+
+        mock_cfg = MagicMock()
+        mock_cfg.tts_enabled = True
+        mock_cfg.tts_model = "en_US-lessac-medium"
+        mock_cfg.tts_model_path = "/tmp/fake_model.onnx"
+        mock_cfg.tts_speaker = 0
+        mock_cfg.tts_rate = 1.0
+
+        with patch("bantz.agent.tts.shutil.which") as mock_which, \
+             patch("bantz.config.config", mock_cfg), \
+             patch("pathlib.Path.exists", return_value=True):
+            mock_which.side_effect = lambda cmd: {
+                "piper": "/usr/bin/piper",
+                "aplay": "/usr/bin/aplay",
+            }.get(cmd)
+
+            result = eng._ensure_init()
+            assert result is True
+            assert eng._piper_path == "/usr/bin/piper"
+            assert eng._aplay_path == "/usr/bin/aplay"
+
+    def test_ensure_init_cached(self):
+        """Second call to _ensure_init uses cached values."""
+        eng = self._make_engine()
+        eng._piper_path = "/usr/bin/piper"
+        eng._aplay_path = "/usr/bin/aplay"
+        eng._model_path = "/fake/model.onnx"
+        # Should return True without calling shutil.which
+        with patch("shutil.which") as mock_which:
+            result = eng._ensure_init()
+            assert result is True
+            mock_which.assert_not_called()
+
+    def test_ensure_init_cached_negative(self):
+        """Cached negative result (empty string)."""
+        eng = self._make_engine()
+        eng._piper_path = ""
+        eng._aplay_path = ""
+        assert eng._ensure_init() is False
+
+    def test_stop_not_speaking(self):
+        """stop() when not speaking should not crash."""
+        eng = self._make_engine()
+        eng.stop()  # Should not raise
+        assert eng._stop_requested is True
+
+    def test_stop_kills_playback(self):
+        eng = self._make_engine()
+        mock_proc = MagicMock()
+        mock_proc.returncode = None
+        eng._playing = mock_proc
+        eng._speaking = True
+
+        eng.stop()
+
+        mock_proc.send_signal.assert_called_once_with(signal.SIGTERM)
+        assert eng._stop_requested is True
+
+    def test_kill_playback_already_exited(self):
+        """Kill playback when process already exited."""
+        eng = self._make_engine()
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0  # Already exited
+        eng._playing = mock_proc
+
+        eng._kill_playback()
+        # Should not send signal since returncode is set
+        mock_proc.send_signal.assert_not_called()
+
+    def test_kill_playback_none(self):
+        eng = self._make_engine()
+        eng._playing = None
+        eng._kill_playback()  # Should not crash
+
+    def test_stats(self):
+        eng = self._make_engine()
+        with patch.object(eng, "available", return_value=False):
+            s = eng.stats()
+            assert "available" in s
+            assert "speaking" in s
+            assert s["available"] is False
+
+    def test_status_line_unavailable(self):
+        eng = self._make_engine()
+        eng._piper_path = ""
+        eng._aplay_path = ""
+        assert "unavailable" in eng.status_line()
+
+    def test_status_line_ready(self):
+        eng = self._make_engine()
+        eng._piper_path = "/usr/bin/piper"
+        eng._aplay_path = "/usr/bin/aplay"
+        eng._model_path = "/fake/en_US-lessac-medium.onnx"
+        eng._speaking = False
+        line = eng.status_line()
+        assert "idle" in line
+        assert "lessac" in line
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 3. Async speak / synthesis / playback
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestTTSAsync:
+    """Async tests for speak, synthesize, play."""
+
+    def _make_engine(self):
+        from bantz.agent.tts import TTSEngine
+        eng = TTSEngine()
+        eng._piper_path = "/usr/bin/piper"
+        eng._aplay_path = "/usr/bin/aplay"
+        eng._model_path = "/fake/model.onnx"
+        eng._speaker = 0
+        eng._rate = 1.0
+        return eng
+
+    @pytest.mark.asyncio
+    async def test_speak_not_available(self):
+        from bantz.agent.tts import TTSEngine
+        eng = TTSEngine()
+        with patch.object(eng, "available", return_value=False):
+            await eng.speak("Hello world")
+            assert eng.is_speaking is False
+
+    @pytest.mark.asyncio
+    async def test_speak_empty_text(self):
+        eng = self._make_engine()
+        with patch.object(eng, "available", return_value=True):
+            await eng.speak("")
+            assert eng.is_speaking is False
+
+    @pytest.mark.asyncio
+    async def test_speak_calls_synthesize_and_play(self):
+        eng = self._make_engine()
+        fake_wav = b"\x00" * 100
+
+        with patch.object(eng, "available", return_value=True), \
+             patch.object(eng, "_synthesize", new_callable=AsyncMock, return_value=fake_wav), \
+             patch.object(eng, "_play", new_callable=AsyncMock):
+            await eng.speak("Hello world.")
+            eng._synthesize.assert_called()
+            eng._play.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_speak_stop_mid_stream(self):
+        eng = self._make_engine()
+
+        call_count = 0
+
+        async def fake_synth(s):
+            return b"\x00" * 50
+
+        async def fake_play(wav):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                eng._stop_requested = True  # Simulate stop during first play
+
+        with patch.object(eng, "available", return_value=True), \
+             patch.object(eng, "_synthesize", side_effect=fake_synth), \
+             patch.object(eng, "_play", side_effect=fake_play):
+            await eng.speak("First sentence. Second sentence. Third sentence.")
+            # Should have stopped after first play
+            assert call_count <= 2
+
+    @pytest.mark.asyncio
+    async def test_synthesize_success(self):
+        eng = self._make_engine()
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"wavdata", b""))
+        mock_proc.returncode = 0
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            result = await eng._synthesize("Hello world")
+            assert result == b"wavdata"
+
+    @pytest.mark.asyncio
+    async def test_synthesize_failure(self):
+        eng = self._make_engine()
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"", b"error"))
+        mock_proc.returncode = 1
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            result = await eng._synthesize("Hello world")
+            assert result is None
+
+    @pytest.mark.asyncio
+    async def test_synthesize_timeout(self):
+        eng = self._make_engine()
+
+        async def slow_comm(*a, **kw):
+            await asyncio.sleep(100)
+            return b"", b""
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate = slow_comm
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc), \
+             patch("asyncio.wait_for", side_effect=asyncio.TimeoutError):
+            result = await eng._synthesize("Hello")
+            assert result is None
+
+    @pytest.mark.asyncio
+    async def test_synthesize_empty_sentence(self):
+        eng = self._make_engine()
+        result = await eng._synthesize("")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_play_success(self):
+        eng = self._make_engine()
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+        mock_proc.returncode = 0
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            await eng._play(b"\x00" * 100)
+            assert eng._playing is None
+
+    @pytest.mark.asyncio
+    async def test_play_empty(self):
+        eng = self._make_engine()
+        await eng._play(b"")  # Should not crash
+
+    @pytest.mark.asyncio
+    async def test_speak_background(self):
+        eng = self._make_engine()
+        with patch.object(eng, "speak", new_callable=AsyncMock):
+            await eng.speak_background("Hello")
+            assert eng._speak_task is not None
+
+    @pytest.mark.asyncio
+    async def test_speak_background_replaces_previous(self):
+        eng = self._make_engine()
+
+        # Create a mock task that's not done
+        old_task = MagicMock()
+        old_task.done.return_value = False
+        eng._speak_task = old_task
+
+        with patch.object(eng, "speak", new_callable=AsyncMock), \
+             patch.object(eng, "stop"):
+            await eng.speak_background("New text")
+            eng.stop.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_synthesize_with_rate(self):
+        eng = self._make_engine()
+        eng._rate = 1.5
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"wav", b""))
+        mock_proc.returncode = 0
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+            await eng._synthesize("Hello")
+            # Check that --length-scale was passed
+            call_args = mock_exec.call_args[0]
+            assert "--length-scale" in call_args
+
+    @pytest.mark.asyncio
+    async def test_synthesize_with_speaker(self):
+        eng = self._make_engine()
+        eng._speaker = 2
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"wav", b""))
+        mock_proc.returncode = 0
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+            await eng._synthesize("Hello")
+            call_args = mock_exec.call_args[0]
+            assert "--speaker" in call_args
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 4. Briefing watcher
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestBriefingWatcher:
+    """Test IDLE→active transition detection for auto-briefing."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_globals(self):
+        """Reset module-level state between tests."""
+        import bantz.agent.job_scheduler as js
+        js._last_activity = "idle"
+        js._briefing_spoken_today = ""
+        yield
+        js._last_activity = "idle"
+        js._briefing_spoken_today = ""
+
+    @pytest.mark.asyncio
+    async def test_watcher_disabled_tts(self):
+        """Watcher does nothing when TTS is disabled."""
+        from bantz.agent.job_scheduler import _job_briefing_watcher
+        with patch("bantz.config.config") as mock_cfg:
+            mock_cfg.tts_enabled = False
+            await _job_briefing_watcher()
+            # Should return without doing anything
+
+    @pytest.mark.asyncio
+    async def test_watcher_already_spoken_today(self):
+        """Watcher skips if already spoken today."""
+        import bantz.agent.job_scheduler as js
+        from datetime import datetime as dt
+        js._briefing_spoken_today = dt.now().date().isoformat()
+
+        with patch("bantz.config.config") as mock_cfg:
+            mock_cfg.tts_enabled = True
+            mock_cfg.tts_auto_briefing = True
+            await js._job_briefing_watcher()
+            # Should noop since already spoken today
+
+    @pytest.mark.asyncio
+    async def test_watcher_before_prep_hour(self):
+        """Watcher skips if before briefing_prep_hour."""
+        from bantz.agent.job_scheduler import _job_briefing_watcher
+        from datetime import datetime as dt
+
+        with patch("bantz.config.config") as mock_cfg, \
+             patch("bantz.agent.job_scheduler.datetime") as mock_dt:
+            mock_cfg.tts_enabled = True
+            mock_cfg.tts_auto_briefing = True
+            mock_cfg.briefing_prep_hour = 6
+
+            # Simulate 4 AM
+            fake_now = dt(2025, 1, 15, 4, 0, 0)
+            mock_dt.now.return_value = fake_now
+
+            await _job_briefing_watcher()
+            # Should skip because 4 AM < 6 AM
+
+    @pytest.mark.asyncio
+    async def test_watcher_idle_to_active_triggers(self):
+        """IDLE → CODING transition triggers TTS briefing."""
+        import bantz.agent.job_scheduler as js
+        from datetime import datetime as dt
+
+        js._last_activity = "idle"
+
+        mock_cfg = MagicMock()
+        mock_cfg.tts_enabled = True
+        mock_cfg.tts_auto_briefing = True
+        mock_cfg.briefing_prep_hour = 6
+
+        fake_now = dt(2025, 1, 15, 9, 0, 0)
+
+        mock_detector = MagicMock()
+        mock_activity = MagicMock()
+        mock_activity.value = "coding"
+        mock_activity.__ne__ = lambda self, other: True  # != Activity.IDLE
+        mock_detector.get_activity_category.return_value = mock_activity
+
+        mock_tts = MagicMock()
+        mock_tts.speak_background = AsyncMock()
+
+        with patch("bantz.config.config", mock_cfg), \
+             patch("bantz.agent.job_scheduler.datetime") as mock_dt, \
+             patch("bantz.agent.job_scheduler.check_briefing_trigger", return_value="Good morning!"), \
+             patch("bantz.agent.app_detector.app_detector", mock_detector), \
+             patch("bantz.agent.tts.tts_engine", mock_tts), \
+             patch("bantz.agent.notifier.notifier", MagicMock(enabled=False)):
+            mock_dt.now.return_value = fake_now
+
+            await js._job_briefing_watcher()
+
+            mock_tts.speak_background.assert_called_once_with("Good morning!")
+            assert js._briefing_spoken_today == "2025-01-15"
+
+    @pytest.mark.asyncio
+    async def test_watcher_no_briefing_ready(self):
+        """IDLE → active but no briefing cached: should not speak."""
+        import bantz.agent.job_scheduler as js
+        from datetime import datetime as dt
+
+        js._last_activity = "idle"
+
+        mock_cfg = MagicMock()
+        mock_cfg.tts_enabled = True
+        mock_cfg.tts_auto_briefing = True
+        mock_cfg.briefing_prep_hour = 6
+
+        fake_now = dt(2025, 1, 15, 9, 0, 0)
+
+        mock_detector = MagicMock()
+        mock_activity = MagicMock()
+        mock_activity.value = "coding"
+        mock_activity.__ne__ = lambda self, other: True
+        mock_detector.get_activity_category.return_value = mock_activity
+
+        with patch("bantz.config.config", mock_cfg), \
+             patch("bantz.agent.job_scheduler.datetime") as mock_dt, \
+             patch("bantz.agent.job_scheduler.check_briefing_trigger", return_value=None), \
+             patch("bantz.agent.app_detector.app_detector", mock_detector):
+            mock_dt.now.return_value = fake_now
+
+            await js._job_briefing_watcher()
+
+            # No briefing spoken
+            assert js._briefing_spoken_today == ""
+
+    @pytest.mark.asyncio
+    async def test_watcher_active_to_active_no_trigger(self):
+        """CODING → BROWSING should NOT trigger briefing."""
+        import bantz.agent.job_scheduler as js
+        from datetime import datetime as dt
+
+        js._last_activity = "coding"  # Not idle
+
+        mock_cfg = MagicMock()
+        mock_cfg.tts_enabled = True
+        mock_cfg.tts_auto_briefing = True
+        mock_cfg.briefing_prep_hour = 6
+
+        fake_now = dt(2025, 1, 15, 9, 0, 0)
+
+        mock_detector = MagicMock()
+        mock_activity = MagicMock()
+        mock_activity.value = "browsing"
+        mock_activity.__ne__ = lambda self, other: True
+        mock_detector.get_activity_category.return_value = mock_activity
+
+        with patch("bantz.config.config", mock_cfg), \
+             patch("bantz.agent.job_scheduler.datetime") as mock_dt, \
+             patch("bantz.agent.app_detector.app_detector", mock_detector):
+            mock_dt.now.return_value = fake_now
+
+            await js._job_briefing_watcher()
+            assert js._briefing_spoken_today == ""
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 5. Brain quick_route integration
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestBrainTTSRoutes:
+    """Test quick_route patterns for TTS control."""
+
+    def _qr(self, text: str):
+        from bantz.core.brain import Brain
+        return Brain._quick_route(text, text.lower())
+
+    def test_shut_up(self):
+        assert self._qr("shut up")["tool"] == "_tts_stop"
+
+    def test_be_quiet(self):
+        assert self._qr("be quiet")["tool"] == "_tts_stop"
+
+    def test_stop_talking(self):
+        assert self._qr("stop talking")["tool"] == "_tts_stop"
+
+    def test_sessiz_ol(self):
+        assert self._qr("sessiz ol")["tool"] == "_tts_stop"
+
+    def test_sus_bantz(self):
+        assert self._qr("sus bantz")["tool"] == "_tts_stop"
+
+    def test_kapat_sesi(self):
+        assert self._qr("kapat sesi")["tool"] == "_tts_stop"
+
+    def test_briefing_still_works(self):
+        """Ensure briefing route still works."""
+        assert self._qr("good morning")["tool"] == "_briefing"
+
+    def test_unrelated_not_tts(self):
+        """Normal conversation should not trigger TTS stop."""
+        r = self._qr("what's the weather like?")
+        assert r is None or r["tool"] != "_tts_stop"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 6. Brain process — TTS stop handler
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestBrainTTSStopHandler:
+    """Test process() handling of _tts_stop route."""
+
+    def _make_brain(self):
+        from bantz.core.brain import Brain
+        b = Brain.__new__(Brain)
+        b._bridge = False
+        b._memory_ready = True
+        b._graph_ready = True
+        b._last_messages = []
+        b._last_events = []
+        b._last_draft = None
+        b._pending_intervention = None
+        return b
+
+    @pytest.mark.asyncio
+    async def test_stop_when_speaking(self):
+        b = self._make_brain()
+
+        mock_tts = MagicMock()
+        mock_tts.is_speaking = True
+
+        mock_conv = MagicMock()
+
+        with patch("bantz.core.brain.data_layer") as mock_dl, \
+             patch("bantz.agent.tts.tts_engine", mock_tts), \
+             patch.object(b, "_to_en", new_callable=AsyncMock, return_value="shut up"), \
+             patch.object(b, "_ensure_memory"), \
+             patch.object(b, "_ensure_graph", new_callable=AsyncMock), \
+             patch.object(b, "_check_intervention_queue", new_callable=AsyncMock, return_value=None), \
+             patch("bantz.core.brain.time_ctx") as mock_tc:
+            mock_tc.snapshot.return_value = MagicMock()
+            mock_dl.conversations = mock_conv
+
+            result = await b.process("shut up")
+            assert "Stopped" in result.response or "🔇" in result.response
+            mock_tts.stop.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_stop_when_not_speaking(self):
+        b = self._make_brain()
+
+        mock_tts = MagicMock()
+        mock_tts.is_speaking = False
+
+        mock_conv = MagicMock()
+
+        with patch("bantz.core.brain.data_layer") as mock_dl, \
+             patch("bantz.agent.tts.tts_engine", mock_tts), \
+             patch.object(b, "_to_en", new_callable=AsyncMock, return_value="shut up"), \
+             patch.object(b, "_ensure_memory"), \
+             patch.object(b, "_ensure_graph", new_callable=AsyncMock), \
+             patch.object(b, "_check_intervention_queue", new_callable=AsyncMock, return_value=None), \
+             patch("bantz.core.brain.time_ctx") as mock_tc:
+            mock_tc.snapshot.return_value = MagicMock()
+            mock_dl.conversations = mock_conv
+
+            result = await b.process("shut up")
+            assert "not speaking" in result.response.lower()
+            mock_tts.stop.assert_not_called()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 7. Brain process — Briefing with TTS
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestBrainBriefingWithTTS:
+    """Test that briefing trigger also speaks via TTS."""
+
+    def _make_brain(self):
+        from bantz.core.brain import Brain
+        b = Brain.__new__(Brain)
+        b._bridge = False
+        b._memory_ready = True
+        b._graph_ready = True
+        b._last_messages = []
+        b._last_events = []
+        b._last_draft = None
+        b._pending_intervention = None
+        return b
+
+    @pytest.mark.asyncio
+    async def test_briefing_triggers_tts(self):
+        b = self._make_brain()
+
+        mock_briefing = AsyncMock()
+        mock_briefing.generate = AsyncMock(return_value="Good morning! Weather is sunny.")
+
+        mock_tts = MagicMock()
+        mock_tts.available.return_value = True
+        mock_tts.speak_background = AsyncMock()
+
+        mock_conv = MagicMock()
+
+        with patch("bantz.core.brain.data_layer") as mock_dl, \
+             patch("bantz.core.briefing.briefing", mock_briefing), \
+             patch("bantz.agent.tts.tts_engine", mock_tts), \
+             patch.object(b, "_to_en", new_callable=AsyncMock, return_value="good morning"), \
+             patch.object(b, "_ensure_memory"), \
+             patch.object(b, "_ensure_graph", new_callable=AsyncMock), \
+             patch.object(b, "_check_intervention_queue", new_callable=AsyncMock, return_value=None), \
+             patch("bantz.core.brain.time_ctx") as mock_tc:
+            mock_tc.snapshot.return_value = MagicMock()
+            mock_dl.conversations = mock_conv
+
+            result = await b.process("good morning")
+            assert "sunny" in result.response.lower() or "Good morning" in result.response
+            mock_tts.speak_background.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_briefing_no_tts_when_unavailable(self):
+        b = self._make_brain()
+
+        mock_briefing = AsyncMock()
+        mock_briefing.generate = AsyncMock(return_value="Morning briefing text")
+
+        mock_tts = MagicMock()
+        mock_tts.available.return_value = False
+        mock_tts.speak_background = AsyncMock()
+
+        mock_conv = MagicMock()
+
+        with patch("bantz.core.brain.data_layer") as mock_dl, \
+             patch("bantz.core.briefing.briefing", mock_briefing), \
+             patch("bantz.agent.tts.tts_engine", mock_tts), \
+             patch.object(b, "_to_en", new_callable=AsyncMock, return_value="good morning"), \
+             patch.object(b, "_ensure_memory"), \
+             patch.object(b, "_ensure_graph", new_callable=AsyncMock), \
+             patch.object(b, "_check_intervention_queue", new_callable=AsyncMock, return_value=None), \
+             patch("bantz.core.brain.time_ctx") as mock_tc:
+            mock_tc.snapshot.return_value = MagicMock()
+            mock_dl.conversations = mock_conv
+
+            result = await b.process("good morning")
+            assert result.response == "Morning briefing text"
+            mock_tts.speak_background.assert_not_called()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 8. Config fields
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestTTSConfig:
+    """Test TTS configuration fields."""
+
+    def test_default_values(self):
+        from bantz.config import Config
+        cfg = Config()
+        assert cfg.tts_enabled is False
+        assert cfg.tts_model == "en_US-lessac-medium"
+        assert cfg.tts_model_path == ""
+        assert cfg.tts_speaker == 0
+        assert cfg.tts_rate == 1.0
+        assert cfg.tts_auto_briefing is True
+
+    def test_env_override(self):
+        from bantz.config import Config
+        cfg = Config(
+            BANTZ_TTS_ENABLED="true",
+            BANTZ_TTS_MODEL="en_GB-alba-medium",
+            BANTZ_TTS_SPEAKER="2",
+            BANTZ_TTS_RATE="1.5",
+        )
+        assert cfg.tts_enabled is True
+        assert cfg.tts_model == "en_GB-alba-medium"
+        assert cfg.tts_speaker == 2
+        assert cfg.tts_rate == 1.5
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 9. JobScheduler briefing watcher registration
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestBriefingWatcherRegistration:
+    """Test that the briefing watcher job is registered when TTS is enabled."""
+
+    def test_register_when_tts_enabled(self):
+        from bantz.agent.job_scheduler import JobScheduler
+        js = JobScheduler()
+        mock_scheduler = MagicMock()
+        js._scheduler = mock_scheduler
+        js._started = True
+
+        with patch("bantz.config.config") as mock_cfg:
+            mock_cfg.tts_enabled = True
+            js._register_briefing_watcher()
+            mock_scheduler.add_job.assert_called_once()
+            call_kwargs = mock_scheduler.add_job.call_args
+            assert call_kwargs[1]["id"] == "briefing_watcher"
+
+    def test_no_register_when_tts_disabled(self):
+        from bantz.agent.job_scheduler import JobScheduler
+        js = JobScheduler()
+        mock_scheduler = MagicMock()
+        js._scheduler = mock_scheduler
+        js._started = True
+
+        with patch("bantz.config.config") as mock_cfg:
+            mock_cfg.tts_enabled = False
+            js._register_briefing_watcher()
+            mock_scheduler.add_job.assert_not_called()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 10. Module singleton
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestTTSSingleton:
+    """Test the module-level tts_engine singleton."""
+
+    def test_singleton_exists(self):
+        from bantz.agent.tts import tts_engine
+        assert tts_engine is not None
+
+    def test_singleton_is_tts_engine(self):
+        from bantz.agent.tts import tts_engine, TTSEngine
+        assert isinstance(tts_engine, TTSEngine)


### PR DESCRIPTION
## Issue #131 — Audio Morning Briefing with Local TTS

### What
Streaming sentence-by-sentence TTS pipeline using Piper + aplay for audio morning briefings.

### Architecture
```
text → split_sentences() → Queue<str>
                              ↓
    synthesize(sentence N+1) while play(sentence N)
                              ↓
    Piper subprocess → raw WAV → aplay subprocess
                              ↓
    stop() → SIGTERM to aplay → instant silence
```

### Changes

**New: `src/bantz/agent/tts.py`** — Streaming TTS engine
- `split_sentences(text)`: sentence splitter with emoji/markdown cleanup
- `TTSEngine`: lazy-init Piper/aplay discovery, async speak/stop
- Producer-consumer pipeline: synthesize next while playing current
- `stop()` sends SIGTERM to active aplay for instant silence
- Graceful fallback: if Piper/aplay/model missing → log warning, skip

**Modified: `src/bantz/agent/job_scheduler.py`** — IDLE→active trigger
- New `_job_briefing_watcher()`: 10s interval APScheduler job
- Polls AppDetector for IDLE→non-IDLE transitions
- On transition after briefing_prep_hour → reads cached briefing → TTS
- One-shot per day (KV store cleared after reading)

**Modified: `src/bantz/core/brain.py`** — Quick-routes
- `_tts_stop` route: 'shut up' / 'sessiz ol' / 'be quiet' → instant stop
- Briefing handler now also speaks via TTS when available

**Modified: `src/bantz/config.py`** — TTS config fields
- `tts_enabled`, `tts_model`, `tts_model_path`, `tts_speaker`, `tts_rate`, `tts_auto_briefing`

### User's 4 improvement points
1. ✅ **AppDetector trigger**: IDLE→non-IDLE transition (not dbus/loginctl)
2. ✅ **Streaming pipeline**: sentence-by-sentence Piper→aplay queue
3. ✅ **Interrupt**: 'sessiz ol bantz' / 'shut up' → SIGTERM to aplay
4. ✅ **English first**: en_US-lessac-medium Piper model (Turkish deferred)

### Tests
62 new tests in `test_tts.py` — **1099 total (was 1037)**

Closes #131