### PR TITLE
fix(brain,router,telegram): 3-bug fix — identity, routing, live streaming

### DIFF
--- a/src/bantz/core/brain.py
+++ b/src/bantz/core/brain.py
@@ -1653,8 +1653,10 @@ class Brain:
         persona_state = _persona_hint()
         deep_memory = await self._deep_memory_context(en_input)
         remote_hint = (
-            "\nYou are receiving this message via remote telegraph. "
-            "Ma'am is not at the machine. Assist her from afar."
+            "\n[Remote Telegraph Mode: You are conversing directly WITH "
+            "ma'am via telegraph. She is away from her physical machine, "
+            "but SHE is the one writing to you right now. Address her "
+            "directly and recognize her as your employer.]"
         ) if getattr(self, "_is_remote", False) else ""
 
         # One-shot RLHF context injection (#180)
@@ -1703,8 +1705,10 @@ class Brain:
         persona_state = _persona_hint()
         deep_memory = await self._deep_memory_context(en_input)
         remote_hint = (
-            "\nYou are receiving this message via remote telegraph. "
-            "Ma'am is not at the machine. Assist her from afar."
+            "\n[Remote Telegraph Mode: You are conversing directly WITH "
+            "ma'am via telegraph. She is away from her physical machine, "
+            "but SHE is the one writing to you right now. Address her "
+            "directly and recognize her as your employer.]"
         ) if getattr(self, "_is_remote", False) else ""
 
         # One-shot RLHF context injection (#180)

--- a/src/bantz/core/intent.py
+++ b/src/bantz/core/intent.py
@@ -76,6 +76,18 @@ CRITICAL:
   historical figure, or topic — route to web_search. Do NOT use chat for factual lookups.
 - "do your search", "can you find", "look it up" → web_search.
 
+ANTI-FALSE-POSITIVE RULES (critical — read carefully):
+- If the user uses slang, idioms, conversational filler, or if you are NOT 100%%
+  sure a specific tool is EXPLICITLY requested, you MUST default to "chat".
+- Never guess a tool. When in doubt, just chat.
+- Phrases like "what does X stand for", "you got me wrong", "never mind",
+  "forget it", "that's not what I meant" are CONVERSATIONAL — route to "chat".
+- Only route to a tool when the user's intent is UNAMBIGUOUS and EXPLICIT.
+- Do NOT pattern-match individual words (e.g. "stand" ≠ web_search,
+  "wrong" ≠ calendar). Look at the FULL sentence meaning.
+- Emotional or corrective statements ("bud you got me wrong", "that's bad",
+  "come on man") are ALWAYS "chat" — never trigger any tool.
+
 Return ONLY valid JSON — no markdown fences, no explanation outside the JSON:
 
 {{"chain":[{{"step":"intent","thought":"..."}},{{"step":"tool","thought":"..."}},{{"step":"params","thought":"..."}}],"route":"tool","tool_name":"<name>","tool_args":{{...}},"risk_level":"safe|moderate|destructive","confidence":0.95}}

--- a/src/bantz/interface/telegram_bot.py
+++ b/src/bantz/interface/telegram_bot.py
@@ -86,6 +86,9 @@ PLACEHOLDER_MESSAGES: list[str] = [
     "📟 The wires are humming with your enquiry. Just a moment...",
 ]
 
+# ── Throttled streaming config (#181 follow-up) ──────────────────────────────
+_STREAM_INTERVAL: float = 2.0  # seconds between edit_text updates
+
 
 def _authorized(func: Callable[..., Coroutine]) -> Callable[..., Coroutine]:
     """Decorator: silently drop messages from non-whitelisted users (#178)."""
@@ -161,6 +164,36 @@ async def _safe_edit(placeholder, text: str) -> bool:
             return True
         except Exception:
             return False
+
+
+async def _stream_to_placeholder(placeholder, stream, *, interval: float = _STREAM_INTERVAL) -> str:
+    """Consume *stream*, updating *placeholder* every *interval* seconds.
+
+    Returns the full accumulated response text.  The placeholder is edited
+    with the latest accumulated text at each tick, so the user can watch
+    the response being generated live without hitting Telegram rate limits.
+    """
+    parts: list[str] = []
+    last_edit = 0.0
+    last_text = ""
+
+    async for chunk in stream:
+        parts.append(chunk)
+        now = asyncio.get_event_loop().time()
+        if now - last_edit >= interval:
+            current = "".join(parts).strip()
+            if current and current != last_text:
+                try:
+                    await placeholder.edit_text(current + " ▍")
+                except Exception:
+                    try:
+                        await placeholder.edit_text(current + " ▍", parse_mode=None)
+                    except Exception:
+                        pass  # skip this tick, retry next
+                last_text = current
+                last_edit = now
+
+    return "".join(parts)
 
 
 # ── Command Handlers ─────────────────────────────────────────────────────────
@@ -467,10 +500,7 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
 
         # Collect response: prefer stream if available
         if result.stream:
-            parts: list[str] = []
-            async for chunk in result.stream:
-                parts.append(chunk)
-            response = "".join(parts)
+            response = await _stream_to_placeholder(placeholder, result.stream)
         else:
             response = result.response
 

--- a/tests/core/test_brain_integrations.py
+++ b/tests/core/test_brain_integrations.py
@@ -946,3 +946,51 @@ class TestAmbientProcessHandlers:
              patch.dict("sys.modules", {"bantz.agent.ambient": MagicMock(ambient_analyzer=mock_analyzer)}):
             result = _run(b.process("ambient status"))
         assert "waiting" in result.response.lower() or "no ambient" in result.response.lower()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Remote Telegraph Identity Fix (third-person schizophrenia bug)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestRemoteHintIdentity:
+    """remote_hint must identify the Telegram user AS ma'am, not a stranger."""
+
+    def test_remote_hint_says_directly_with_maam(self):
+        """The hint must say 'directly WITH ma'am', not 'Ma'am is not at the machine'."""
+        import inspect
+        from bantz.core.brain import Brain
+        src = inspect.getsource(Brain._chat)
+        assert "directly WITH" in src or "directly with" in src.lower()
+
+    def test_remote_hint_no_stranger_phrasing(self):
+        """The hint must NOT say 'Ma'am is not at the machine'."""
+        import inspect
+        from bantz.core.brain import Brain
+        src_chat = inspect.getsource(Brain._chat)
+        src_stream = inspect.getsource(Brain._chat_stream)
+        assert "not at the machine" not in src_chat
+        assert "not at the machine" not in src_stream
+
+    def test_remote_hint_says_employer(self):
+        """The hint must tell Bantz to recognize ma'am as employer."""
+        import inspect
+        from bantz.core.brain import Brain
+        src = inspect.getsource(Brain._chat)
+        assert "employer" in src
+
+    def test_remote_hint_address_directly(self):
+        """The hint must instruct Bantz to address her directly."""
+        import inspect
+        from bantz.core.brain import Brain
+        src = inspect.getsource(Brain._chat)
+        assert "Address her" in src
+        assert "directly" in src
+
+    def test_remote_hint_consistent_in_stream(self):
+        """_chat_stream must have the same identity-aware hint."""
+        import inspect
+        from bantz.core.brain import Brain
+        src = inspect.getsource(Brain._chat_stream)
+        assert "directly WITH" in src or "directly with" in src.lower()
+        assert "employer" in src

--- a/tests/core/test_router.py
+++ b/tests/core/test_router.py
@@ -387,3 +387,61 @@ class TestQuickRouteAudit:
         section = src[idx:idx + 600]
         assert "_SIZE_KW" in section and "_DISK_CTX" in section, \
             "Disk routing must use two-gate (size + context) pattern"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# CoT Anti-False-Positive Rules (fix for tool routing schizophrenia)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestCOTAntifalsePositive:
+    """COT_SYSTEM must include anti-false-positive routing rules."""
+
+    def test_cot_has_doubt_chat_rule(self):
+        """Router must default to chat when in doubt."""
+        from bantz.core.intent import COT_SYSTEM
+        lower = COT_SYSTEM.lower()
+        assert "when in doubt" in lower
+        assert "chat" in lower
+
+    def test_cot_has_slang_idiom_rule(self):
+        """Router must handle slang/idioms as conversational."""
+        from bantz.core.intent import COT_SYSTEM
+        lower = COT_SYSTEM.lower()
+        assert "slang" in lower
+        assert "idiom" in lower
+
+    def test_cot_has_never_guess_rule(self):
+        """Router must never guess a tool."""
+        from bantz.core.intent import COT_SYSTEM
+        lower = COT_SYSTEM.lower()
+        assert "never guess" in lower
+
+    def test_cot_has_full_sentence_rule(self):
+        """Router must look at full sentence meaning, not individual words."""
+        from bantz.core.intent import COT_SYSTEM
+        lower = COT_SYSTEM.lower()
+        assert "full sentence" in lower
+
+    def test_cot_has_emotional_rule(self):
+        """Emotional/corrective statements must route to chat."""
+        from bantz.core.intent import COT_SYSTEM
+        lower = COT_SYSTEM.lower()
+        assert "emotional" in lower or "corrective" in lower
+
+    def test_cot_has_stand_for_example(self):
+        """The 'stand for' false positive should be explicitly mentioned."""
+        from bantz.core.intent import COT_SYSTEM
+        assert "stand" in COT_SYSTEM.lower()
+
+    def test_cot_has_conversational_examples(self):
+        """Phrases like 'got me wrong' should be listed as conversational."""
+        from bantz.core.intent import COT_SYSTEM
+        lower = COT_SYSTEM.lower()
+        assert "got me wrong" in lower
+
+    def test_cot_has_unambiguous_rule(self):
+        """Only unambiguous and explicit intents should trigger tools."""
+        from bantz.core.intent import COT_SYSTEM
+        lower = COT_SYSTEM.lower()
+        assert "unambiguous" in lower

--- a/tests/interface/test_telegram_llm.py
+++ b/tests/interface/test_telegram_llm.py
@@ -295,10 +295,11 @@ class TestHandleMessage:
                     await mod.handle_message(update, ctx)
 
             # Response should have been edited into the placeholder (#181)
+            # With throttled streaming, the final edit is via _safe_edit
             placeholder = update.message.reply_text.return_value
-            placeholder.edit_text.assert_awaited_once()
-            edited_text = placeholder.edit_text.call_args[0][0]
-            assert edited_text == "Good day, ma'am."
+            # Last edit_text call should contain the full response
+            final_edit = placeholder.edit_text.call_args_list[-1][0][0]
+            assert "Good day, ma'am." in final_edit
         finally:
             mod._ALLOWED = original_allowed
 
@@ -855,9 +856,9 @@ class TestProgressIndicators:
                     await mod.handle_message(update, ctx)
 
             placeholder = update.message.reply_text.return_value
-            placeholder.edit_text.assert_awaited_once()
-            edited = placeholder.edit_text.call_args[0][0]
-            assert edited == "Good evening, ma'am."
+            # Final edit should contain the full text
+            final_edit = placeholder.edit_text.call_args_list[-1][0][0]
+            assert "Good evening, ma'am." in final_edit
         finally:
             mod._ALLOWED = original
 
@@ -964,3 +965,110 @@ class TestSafeEdit:
         ph.edit_text = AsyncMock(side_effect=Exception("total failure"))
         result = await _safe_edit(ph, "test")
         assert result is False
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 14. Throttled Streaming (#181 follow-up)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestThrottledStreaming:
+    """Tests for _stream_to_placeholder live-update behaviour."""
+
+    @pytest.mark.asyncio
+    async def test_returns_full_text(self):
+        """_stream_to_placeholder must return the complete accumulated text."""
+        from bantz.interface.telegram_bot import _stream_to_placeholder
+
+        async def gen():
+            for tok in ["Good ", "morning, ", "ma'am."]:
+                yield tok
+
+        ph = AsyncMock()
+        ph.edit_text = AsyncMock()
+        result = await _stream_to_placeholder(ph, gen(), interval=0)
+        assert result == "Good morning, ma'am."
+
+    @pytest.mark.asyncio
+    async def test_edits_placeholder_during_stream(self):
+        """With interval=0, every chunk should trigger an edit."""
+        from bantz.interface.telegram_bot import _stream_to_placeholder
+
+        async def gen():
+            for tok in ["Hello ", "world"]:
+                yield tok
+
+        ph = AsyncMock()
+        ph.edit_text = AsyncMock()
+        await _stream_to_placeholder(ph, gen(), interval=0)
+        # At least one edit should have occurred
+        assert ph.edit_text.await_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_edit_includes_cursor(self):
+        """Intermediate edits should include the ▍ cursor indicator."""
+        from bantz.interface.telegram_bot import _stream_to_placeholder
+
+        async def gen():
+            for tok in ["Hello ", "world"]:
+                yield tok
+
+        ph = AsyncMock()
+        ph.edit_text = AsyncMock()
+        await _stream_to_placeholder(ph, gen(), interval=0)
+        # At least one intermediate call should have the cursor
+        calls = [c[0][0] for c in ph.edit_text.call_args_list]
+        assert any("▍" in c for c in calls)
+
+    @pytest.mark.asyncio
+    async def test_edit_failure_does_not_crash(self):
+        """If edit_text fails during streaming, it should not abort."""
+        from bantz.interface.telegram_bot import _stream_to_placeholder
+
+        async def gen():
+            for tok in ["One ", "two ", "three"]:
+                yield tok
+
+        ph = AsyncMock()
+        ph.edit_text = AsyncMock(side_effect=Exception("rate limited"))
+        result = await _stream_to_placeholder(ph, gen(), interval=0)
+        assert result == "One two three"
+
+    @pytest.mark.asyncio
+    async def test_stream_interval_constant_exists(self):
+        """_STREAM_INTERVAL constant must exist and be >= 1.0."""
+        from bantz.interface.telegram_bot import _STREAM_INTERVAL
+        assert isinstance(_STREAM_INTERVAL, float)
+        assert _STREAM_INTERVAL >= 1.0
+
+    @pytest.mark.asyncio
+    async def test_handle_message_uses_stream_to_placeholder(self):
+        """handle_message should use _stream_to_placeholder for streams."""
+        import bantz.interface.telegram_bot as mod
+        original = mod._ALLOWED
+        mod._rate_log.clear()
+        try:
+            mod._ALLOWED = None
+            update = _make_update(user_id=111, text="stream live")
+            ctx = _ctx()
+
+            async def fake_stream():
+                for chunk in ["Live ", "stream."]:
+                    yield chunk
+
+            fake_result = FakeBrainResult(response="", stream=fake_stream())
+            mock_brain = MagicMock()
+            mock_brain.process = AsyncMock(return_value=fake_result)
+
+            with patch.object(mod, "config") as mock_cfg:
+                mock_cfg.telegram_llm_mode = True
+                with patch.dict("sys.modules", {"bantz.core.brain": MagicMock(brain=mock_brain)}):
+                    await mod.handle_message(update, ctx)
+
+            # Final edit should have the complete text (no cursor)
+            placeholder = update.message.reply_text.return_value
+            final_edit = placeholder.edit_text.call_args_list[-1][0][0]
+            assert "Live stream." in final_edit
+            assert "▍" not in final_edit  # cursor removed in final edit
+        finally:
+            mod._ALLOWED = original


### PR DESCRIPTION
## Summary

Fixes three critical production bugs observed in Telegram logs.

### 1. Third-Person Schizophrenia Fix (`brain.py`)

**Problem:** `remote_hint` said *"Ma'am is not at the machine"* — Bantz concluded the Telegram user was a stranger and started asking "who are you?"

**Fix:** Changed to:
> `[Remote Telegraph Mode: You are conversing directly WITH ma'am via telegraph. She is away from her physical machine, but SHE is the one writing to you right now. Address her directly and recognize her as your employer.]`

Updated in both `_chat()` and `_chat_stream()` for consistency.

### 2. False-Positive Tool Routing Fix (`intent.py`)

**Problem:** "What does Bantz stand for?" → triggered `web_search` (pattern-matched "stand for"). "Bud you got me wrong" → triggered `calendar` (pattern-matched "wrong").

**Fix:** Added **ANTI-FALSE-POSITIVE RULES** to `COT_SYSTEM` prompt:
- Slang, idioms, conversational filler → MUST default to `chat`
- "Never guess a tool. When in doubt, just chat."
- Full sentence analysis required, not individual word matching
- Explicit examples: "stand for", "got me wrong", "never mind" = conversational
- Emotional/corrective statements always route to `chat`

### 3. Throttled Live Streaming (`telegram_bot.py`)

**Problem:** User waited 10-20s seeing only a placeholder, then got the full response in one shot.

**Fix:** New `_stream_to_placeholder()` helper:
- Accumulates stream chunks from `brain.process()`
- Edits placeholder every 2.0 seconds with accumulated text + cursor (▍)
- User watches Bantz typing live like a real telegraph
- Edit failures silently skipped (retry next tick)
- Final edit via `_safe_edit` removes cursor, shows clean text

### Test Results

**2147 passed** (2128 baseline + 19 new), zero failures.

| Area | New Tests |
|------|-----------|
| Remote Identity | 5 (no stranger phrasing, employer recognition, consistency) |
| Router Anti-FP | 8 (doubt→chat, slang rule, never-guess, full-sentence, etc.) |
| Live Streaming | 6 (full text, cursor, edit failure safety, interval constant) |