### PR TITLE
feat(tools): auto-chaining gmail compose & send (#183)

### DIFF
--- a/src/bantz/core/brain.py
+++ b/src/bantz/core/brain.py
@@ -589,6 +589,26 @@ class Brain:
         if re.search(r"\bsend\s+(?:that|the|this)\s+(?:mail|email|draft|message)\b", both, re.IGNORECASE):
             return {"tool": "gmail", "args": {"action": "send"}, "_send_draft": True}
 
+        # Gmail — atomic compose-and-send: "send an email to X saying Y"
+        # Non-greedy (.+?) for multi-word recipients like "John Doe"
+        _CAS_RE = re.search(
+            r"(?:send|write|compose)\s+(?:an?\s+)?(?:e?-?mail|message)\s+"
+            r"to\s+(.+?)\s+(?:saying|about|that|with)\s+(.+)",
+            en, re.IGNORECASE,
+        )
+        if not _CAS_RE:
+            _CAS_RE = re.search(
+                r"(?:send|write|compose)\s+(?:an?\s+)?(?:e?-?mail|message)\s+"
+                r"to\s+(.+?)\s+(?:saying|about|that|with)\s+(.+)",
+                orig, re.IGNORECASE,
+            )
+        if _CAS_RE:
+            return {"tool": "gmail", "args": {
+                "action": "compose_and_send",
+                "to": _CAS_RE.group(1).strip(),
+                "intent": _CAS_RE.group(2).strip(),
+            }}
+
         # Gmail — "read me that email" fix: resolve from context
         # Strict: requires a mail-related keyword so "read me that story" falls through.
         _READ_ME_PATTERN = re.search(

--- a/src/bantz/core/intent.py
+++ b/src/bantz/core/intent.py
@@ -38,7 +38,7 @@ TOOL PARAMETER REFERENCE (extract these from the user message):
 - weather: {{"city": "<city name or empty>"}}
 - news: {{"source": "all|hn", "limit": 5}}
 - web_search: {{"query": "<search terms>"}}
-- gmail: {{"action": "unread|compose|read|search|filter|send|contacts", ...}}
+- gmail: {{"action": "unread|compose|compose_and_send|read|search|filter|send|contacts", "to": "recipient", "intent": "what to say", "subject": "optional"}}
 - calendar: {{"action": "today|week|create|delete|update", "title": "...", "date": "YYYY-MM-DD", "time": "HH:MM"}}
 - classroom: {{"action": "assignments|due_today"}}
 - filesystem: {{"path": "<file path>", "action": "read|write", ...}}

--- a/src/bantz/tools/gmail.py
+++ b/src/bantz/tools/gmail.py
@@ -156,7 +156,11 @@ class GmailTool(BaseTool):
     description = (
         "Reads, writes, searches, and manages Gmail messages and labels. "
         "Use for: mail, gmail, inbox, email summary, compose, reply, forward, "
-        "thread view, star, label, mark read, send email, batch operations."
+        "thread view, star, label, mark read, send email, batch operations. "
+        "Supports compose_and_send action to draft AND send an email atomically "
+        "when recipient and intent/body are provided in a single request. "
+        "Params for compose_and_send: to (recipient), intent or body (content), "
+        "subject (optional, auto-generated if missing)."
     )
     risk_level = "safe"
 
@@ -206,6 +210,10 @@ class GmailTool(BaseTool):
             return await self._send(creds, to, subject, body)
         elif action == "compose":
             return await self._compose(creds, to, subject, intent or raw_query)
+        elif action == "compose_and_send":
+            return await self._compose_and_send(
+                creds, to, subject, body, intent or raw_query,
+            )
         elif action == "reply":
             return await self._reply(creds, message_id, intent or body)
         elif action == "forward":
@@ -515,6 +523,68 @@ class GmailTool(BaseTool):
                 "body": body,
             },
         )
+
+    # ── Compose-and-Send (atomic) ─────────────────────────────────────────
+
+    async def _compose_and_send(
+        self, creds, to: str, subject: str, body: str, intent: str,
+    ) -> ToolResult:
+        """Atomic compose + send for complete email requests.
+
+        Required: to (recipient).  At least one of body or intent.
+        Optional: subject (auto-generated if missing).
+        """
+        if not to:
+            return ToolResult(
+                success=False, output="",
+                error="Recipient not specified.",
+            )
+
+        to_resolved = contacts.resolve(to)
+
+        # Generate body via LLM if only intent provided
+        if not body and intent:
+            body = await self._llm_compose(to_resolved, subject, intent)
+        if not body:
+            return ToolResult(
+                success=False, output="",
+                error="No email content provided.",
+            )
+
+        # Auto-generate subject with fallback
+        if not subject:
+            subject = await self._auto_subject(body)
+
+        # Send directly
+        try:
+            ok = await asyncio.get_event_loop().run_in_executor(
+                None, self._send_sync, creds, to_resolved, subject, body, None,
+            )
+        except Exception as exc:
+            return ToolResult(
+                success=False, output="",
+                error=f"Send failed: {exc}",
+            )
+
+        if ok:
+            return ToolResult(
+                success=True,
+                output=(
+                    f"Email dispatched to {to} ({to_resolved}).\n"
+                    f"Subject: {subject}"
+                ),
+                data={"sent": True, "to": to_resolved, "subject": subject},
+            )
+        return ToolResult(success=False, output="", error="Failed to send email.")
+
+    async def _auto_subject(self, body: str) -> str:
+        """Generate subject via LLM, with a safe fallback."""
+        subj = await self._generate_subject(body)
+        if subj:
+            return subj
+        # Fallback: first 5 words of body, capped
+        words = body.split()[:5]
+        return " ".join(words).rstrip(".,;:!?") if words else "Message from Bantz"
 
     # ── Reply ─────────────────────────────────────────────────────────────
 

--- a/tests/tools/test_gmail_autochain.py
+++ b/tests/tools/test_gmail_autochain.py
@@ -1,0 +1,241 @@
+"""
+Tests for Issue #183 — Auto-Chaining Gmail Compose & Send Actions.
+
+11 tests covering:
+  - _compose_and_send() success / error paths
+  - _auto_subject() LLM + fallback
+  - Contact alias resolution
+  - _quick_route regex (non-greedy multi-word names)
+  - execute() dispatcher routing
+  - Existing compose/send flows unchanged
+"""
+from __future__ import annotations
+
+import asyncio
+import re
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def _make_tool(*, compose_body: str = "Generated body.", subject: str = ""):
+    """Create a GmailTool with mocked deps."""
+    from bantz.tools.gmail import GmailTool
+
+    tool = GmailTool()
+    # Patch LLM compose — returns compose_body for _llm_compose
+    tool._llm_compose = AsyncMock(return_value=compose_body)
+    # Patch _generate_subject — returns subject or empty
+    tool._generate_subject = AsyncMock(return_value=subject)
+    # Patch _send_sync — succeeds by default
+    tool._send_sync = MagicMock(return_value=True)
+    return tool
+
+
+def _fake_creds():
+    return MagicMock()
+
+
+# ── 1. Full params → email sent in one turn ──────────────────────────────────
+
+class TestComposeAndSend:
+    def test_success_full_params(self):
+        """All params provided → email sent, ToolResult.success=True."""
+        tool = _make_tool(subject="Quick chat")
+        creds = _fake_creds()
+        result = _run(tool._compose_and_send(
+            creds, to="alice@example.com", subject="", body="Hello Alice",
+            intent="",
+        ))
+        assert result.success is True
+        assert "dispatched" in result.output.lower()
+        assert result.data["sent"] is True
+        assert result.data["to"] == "alice@example.com"
+
+    # ── 2. Missing recipient → error ─────────────────────────────────────
+
+    def test_no_recipient(self):
+        """Missing `to` → error 'Recipient not specified'."""
+        tool = _make_tool()
+        creds = _fake_creds()
+        result = _run(tool._compose_and_send(
+            creds, to="", subject="", body="Hello", intent="",
+        ))
+        assert result.success is False
+        assert "recipient" in result.error.lower()
+
+    # ── 3. Missing body AND intent → error ───────────────────────────────
+
+    def test_no_body_no_intent(self):
+        """No body and no intent → LLM compose returns '', error raised."""
+        tool = _make_tool(compose_body="")
+        creds = _fake_creds()
+        result = _run(tool._compose_and_send(
+            creds, to="alice@example.com", subject="", body="", intent="",
+        ))
+        assert result.success is False
+        assert "content" in result.error.lower() or "no email" in result.error.lower()
+
+    # ── 4. Intent only → LLM generates body ─────────────────────────────
+
+    def test_intent_only_llm_compose(self):
+        """Intent provided without body → _llm_compose is called."""
+        tool = _make_tool(compose_body="LLM generated message.")
+        creds = _fake_creds()
+        result = _run(tool._compose_and_send(
+            creds, to="alice@example.com", subject="Test", body="",
+            intent="tell her I'll be late",
+        ))
+        assert result.success is True
+        tool._llm_compose.assert_awaited_once()
+
+    # ── 5. No subject → auto-generated from body ────────────────────────
+
+    def test_auto_subject_from_llm(self):
+        """No subject → _auto_subject uses _generate_subject + fallback."""
+        tool = _make_tool(subject="")  # LLM subject fails → fallback
+        creds = _fake_creds()
+        result = _run(tool._compose_and_send(
+            creds, to="bob@test.com", subject="", body="I will arrive tomorrow morning",
+            intent="",
+        ))
+        assert result.success is True
+        # Fallback: first 5 words of body
+        assert "I will arrive tomorrow morning" in result.data.get("subject", "")
+
+    def test_auto_subject_llm_success(self):
+        """_generate_subject returns a value → used as subject."""
+        tool = _make_tool(subject="Quick Update")
+        creds = _fake_creds()
+        result = _run(tool._compose_and_send(
+            creds, to="bob@test.com", subject="", body="Some body text here.",
+            intent="",
+        ))
+        assert result.success is True
+        assert result.data["subject"] == "Quick Update"
+
+    # ── 6. Contact alias resolved ────────────────────────────────────────
+
+    def test_contact_alias_resolved(self):
+        """Alias 'alice' → 'alice@example.com' via contacts.resolve."""
+        tool = _make_tool()
+        creds = _fake_creds()
+        with patch("bantz.tools.gmail.contacts") as mock_contacts:
+            mock_contacts.resolve.return_value = "alice@example.com"
+            result = _run(tool._compose_and_send(
+                creds, to="alice", subject="Hi", body="Hello!", intent="",
+            ))
+            mock_contacts.resolve.assert_called_once_with("alice")
+            assert result.success is True
+            assert result.data["to"] == "alice@example.com"
+
+    # ── 9. Send failure → error ──────────────────────────────────────────
+
+    def test_send_failure_returns_error(self):
+        """SMTP/API failure → ToolResult with error."""
+        tool = _make_tool()
+        tool._send_sync = MagicMock(side_effect=Exception("SMTP timeout"))
+        creds = _fake_creds()
+        result = _run(tool._compose_and_send(
+            creds, to="alice@test.com", subject="Hi", body="Hello",
+            intent="",
+        ))
+        assert result.success is False
+        assert "SMTP timeout" in result.error
+
+
+# ── 7. Quick-route regex: non-greedy multi-word names ────────────────────────
+
+class TestQuickRouteEmailPattern:
+    @staticmethod
+    def _route(text: str):
+        from bantz.core.brain import Brain
+        return Brain._quick_route(text, text)
+
+    def test_send_email_single_name(self):
+        """'send an email to alice saying hello' → compose_and_send."""
+        r = self._route("send an email to alice saying hello")
+        assert r is not None
+        assert r["args"]["action"] == "compose_and_send"
+        assert r["args"]["to"] == "alice"
+        assert r["args"]["intent"] == "hello"
+
+    def test_send_email_multi_word_name(self):
+        """'send email to John Doe saying I'll be late' → captures 'John Doe'."""
+        r = self._route("send email to John Doe saying I'll be late")
+        assert r is not None
+        assert r["args"]["action"] == "compose_and_send"
+        assert r["args"]["to"] == "John Doe"
+        assert "late" in r["args"]["intent"]
+
+    def test_write_message_pattern(self):
+        """'write a message to hocam about project deadline' → compose_and_send."""
+        r = self._route("write a message to hocam about project deadline")
+        assert r is not None
+        assert r["args"]["action"] == "compose_and_send"
+        assert r["args"]["to"] == "hocam"
+        assert "deadline" in r["args"]["intent"]
+
+    def test_compose_email_with_that(self):
+        """'compose an email to Alice Smith that I need more time' → captures full name."""
+        r = self._route("compose an email to Alice Smith that I need more time")
+        assert r is not None
+        assert r["args"]["action"] == "compose_and_send"
+        assert r["args"]["to"] == "Alice Smith"
+        assert "more time" in r["args"]["intent"]
+
+
+# ── 8. Execute dispatcher routes compose_and_send ────────────────────────────
+
+class TestExecuteDispatcher:
+    def test_execute_dispatches_compose_and_send(self):
+        """action='compose_and_send' calls _compose_and_send()."""
+        tool = _make_tool()
+        tool._compose_and_send = AsyncMock(return_value=MagicMock(success=True))
+
+        creds_patch = patch(
+            "bantz.auth.token_store.token_store.get", return_value=_fake_creds()
+        )
+        with creds_patch:
+            result = _run(tool.execute(
+                action="compose_and_send",
+                to="alice@example.com",
+                intent="say hello",
+            ))
+        tool._compose_and_send.assert_awaited_once()
+
+
+# ── 10 & 11. Existing compose/send unchanged ────────────────────────────────
+
+class TestExistingFlowsUnchanged:
+    def test_existing_compose_returns_draft(self):
+        """Regular 'compose' still returns a draft for confirmation."""
+        tool = _make_tool(compose_body="Draft body text.")
+        tool._generate_subject = AsyncMock(return_value="Subject")
+        creds = _fake_creds()
+
+        with patch("bantz.auth.token_store.token_store.get", return_value=creds):
+            result = _run(tool.execute(
+                action="compose", to="bob@test.com", intent="test",
+            ))
+        assert result.success is True
+        # Compose returns a draft (not sent)
+        assert result.data.get("draft") is True
+        assert "Shall I send it" in result.output or result.data.get("draft") is True
+
+    def test_existing_send_requires_all_params(self):
+        """Regular 'send' requires to + subject + body."""
+        from bantz.tools.gmail import GmailTool
+        tool = GmailTool()
+        creds = _fake_creds()
+
+        with patch("bantz.auth.token_store.token_store.get", return_value=creds):
+            result = _run(tool.execute(action="send", to="x@y.com"))
+        assert result.success is False
+        assert "required" in result.error.lower()


### PR DESCRIPTION
## Issue #183 — Auto-Chaining Gmail Compose & Send

Closes #183

### Changes

**gmail.py — `_compose_and_send()` atomic method:**
- Resolves contact aliases → email via `contacts.resolve()`
- LLM composes body when only intent provided (`_llm_compose`)
- `_auto_subject()` generates subject via LLM, falls back to first 5 words of body
- Exception-safe `_send_sync` wrapper
- Updated `description` to advertise `compose_and_send` action to LLM

**brain.py — `_quick_route()` non-greedy regex:**
- Pattern: `to\s+(.+?)\s+(?:saying|about|that|with)\s+(.+)`
- `.+?` (non-greedy) captures multi-word names like "John Doe" correctly
- Fast-path bypasses CoT for obvious "send email to X saying Y" patterns

**intent.py — COT_SYSTEM schema update:**
- Gmail tool reference now lists `compose_and_send` as a valid action
- Includes param guidance: `to`, `intent`, `subject` (optional)

### 3 Sinsi Tuzak Patches

1. **"İki İsimli Adam"** — `\S+` → `.+?` non-greedy regex for multi-word recipients
2. **"Hayalet Fonksiyon"** — `_auto_subject()` wraps existing `_generate_subject()` with first-5-words fallback
3. **"Missing Tool Schema"** — `compose_and_send` added to both `description` and `COT_SYSTEM`

### Tests

15 new tests in `tests/tools/test_gmail_autochain.py`:
- `test_success_full_params` — email sent in one turn
- `test_no_recipient` — missing `to` → error
- `test_no_body_no_intent` — no content → error
- `test_intent_only_llm_compose` — LLM generates body
- `test_auto_subject_from_llm` / `test_auto_subject_llm_success` — subject generation
- `test_contact_alias_resolved` — alias → email
- `test_send_email_single_name` / `test_send_email_multi_word_name` — regex
- `test_write_message_pattern` / `test_compose_email_with_that` — variant patterns
- `test_execute_dispatches_compose_and_send` — dispatcher routing
- `test_send_failure_returns_error` — SMTP error handling
- `test_existing_compose_returns_draft` — compose unchanged
- `test_existing_send_requires_all_params` — send unchanged

**2183 tests passing** (zero failures)