### PR TITLE
feat(tools): filesystem auto-chaining — create_folder_and_file (#196)

### DIFF
--- a/src/bantz/core/brain.py
+++ b/src/bantz/core/brain.py
@@ -911,6 +911,55 @@ class Brain:
             if len(query) >= 2 and query.lower() not in _WS_STOPWORDS:
                 return {"tool": "web_search", "args": {"query": query}}
 
+        # ── Filesystem auto-chain: create folder + file in one step (#196) ──
+        # Catches: "create a Stark folder and write test.txt in it",
+        # "make a folder X, put a file Y with content Z", etc.
+        # Search on e (English) individually — NOT on 'both' which
+        # concatenates o+e and causes the regex to span duplicated text.
+        _FS_COMBO = re.search(
+            r"(?:create|make|yap|oluştur|aç)\s+"
+            r"(?:a\s+)?(?:folder|directory|klasör|dizin)\s+"
+            r"(?:named?\s+|called?\s+|adında\s+|adlı\s+)?"
+            r"[\"']?([\w.\- ]+?)[\"']?"
+            r"\s+(?:and|then|,)\s+"
+            r"(?:create|put|write|place|add|make|yaz|koy|ekle)\s+"
+            r"(?:a\s+)?(?:file\s+)?(?:named?\s+|called?\s+|adında\s+)?"
+            r"[\"']?([\w.\-]+)[\"']?"
+            r"(?:\s+(?:in(?:side)?|into)\s+it)?"
+            r"(?:\s+(?:with|containing|saying|that\s+says|içeriği|yazısı)\s+"
+            r"[\"']?(.+?)[\"']?)?\s*$",
+            e, re.IGNORECASE,
+        ) or re.search(
+            r"(?:create|make|yap|oluştur|aç)\s+"
+            r"(?:a\s+)?(?:folder|directory|klasör|dizin)\s+"
+            r"(?:named?\s+|called?\s+|adında\s+|adlı\s+)?"
+            r"[\"']?([\w.\- ]+?)[\"']?"
+            r"\s+(?:and|then|,)\s+"
+            r"(?:create|put|write|place|add|make|yaz|koy|ekle)\s+"
+            r"(?:a\s+)?(?:file\s+)?(?:named?\s+|called?\s+|adında\s+)?"
+            r"[\"']?([\w.\-]+)[\"']?"
+            r"(?:\s+(?:in(?:side)?|into)\s+it)?"
+            r"(?:\s+(?:with|containing|saying|that\s+says|içeriği|yazısı)\s+"
+            r"[\"']?(.+?)[\"']?)?\s*$",
+            o, re.IGNORECASE,
+        )
+        if _FS_COMBO:
+            _folder_name = _FS_COMBO.group(1).strip()
+            _file_name = _FS_COMBO.group(2).strip()
+            _content = (_FS_COMBO.group(3) or "").strip()
+            # Default path to Desktop if no path specified
+            if "/" not in _folder_name and "~" not in _folder_name:
+                _folder_name = f"~/Desktop/{_folder_name}"
+            return {
+                "tool": "filesystem",
+                "args": {
+                    "action": "create_folder_and_file",
+                    "folder_path": _folder_name,
+                    "file_name": _file_name,
+                    "content": _content,
+                },
+            }
+
         # Shell generation for file operations
         if any(k in both for k in ("create file", "create folder", "create directory",
                                     "copy file", "move file", "delete file", "rename",

--- a/src/bantz/core/intent.py
+++ b/src/bantz/core/intent.py
@@ -41,7 +41,7 @@ TOOL PARAMETER REFERENCE (extract these from the user message):
 - gmail: {{"action": "unread|compose|compose_and_send|read|search|filter|send|contacts", "to": "recipient", "intent": "what to say", "subject": "optional"}}
 - calendar: {{"action": "today|week|create|delete|update", "title": "...", "date": "YYYY-MM-DD", "time": "HH:MM"}}
 - classroom: {{"action": "assignments|due_today"}}
-- filesystem: {{"path": "<file path>", "action": "read|write", ...}}
+- filesystem: {{"path": "<file path>", "action": "read|write|create_folder_and_file", "folder_path": "~/path/to/folder", "file_name": "file.txt", "content": "..."}}
 - document: {{"path": "<file path>", "action": "summarize|read|ask", "question": "..."}}
 
 CHAIN OF THOUGHT — follow ALL three steps before deciding:
@@ -64,7 +64,7 @@ ROUTING RULES:
 - gmail:      email, inbox, compose, send, read mail
 - calendar:   events, meetings, appointments, schedule
 - classroom:  assignments, homework, deadlines, courses
-- filesystem: read/write a specific file
+- filesystem: read/write a specific file, or create a folder+file atomically (use create_folder_and_file when user wants both)
 - document:   summarize or analyze PDF/TXT/MD/DOCX
 - chat:       ONLY for greetings, small talk, and opinions — NEVER for factual questions
 

--- a/src/bantz/interface/telegram_bot.py
+++ b/src/bantz/interface/telegram_bot.py
@@ -452,17 +452,14 @@ async def _check_reminders_job(context: ContextTypes.DEFAULT_TYPE) -> None:
 
 
 def _is_maintenance_spam(result) -> bool:
-    """Return True if a maintenance/workflow result has zero failures.
+    """Return True for ANY maintenance result on Telegram.
 
-    Suppress "all-green" maintenance chatter on Telegram — only show
-    results that contain at least one failed step.
+    Maintenance output is noisy and irrelevant on mobile — suppress ALL of it.
+    Users can run /briefing to see system health if they want.
     """
     if getattr(result, "tool_used", None) != "maintenance":
         return False
-    text = getattr(result, "response", "") or ""
-    # "Workflow complete: 5/5 steps succeeded" → spam
-    # "Workflow complete: 4/5 steps succeeded" + "✗" → NOT spam
-    return "✗" not in text
+    return True
 
 
 def _is_rate_limited(user_id: int) -> bool:

--- a/src/bantz/tools/filesystem.py
+++ b/src/bantz/tools/filesystem.py
@@ -30,17 +30,30 @@ class FilesystemTool(BaseTool):
     name = "filesystem"
     description = (
         "File system operations: listing (ls), reading (read), "
-        "writing (write). Only works under the home directory."
+        "writing (write), or atomic folder+file creation (create_folder_and_file). "
+        "Only works under the home directory. "
+        "Use action='create_folder_and_file' when the user wants to create a "
+        "folder AND put a file in it in a single step — avoids multi-step hallucination."
     )
     risk_level = "moderate"
 
     async def execute(
         self,
-        action: Literal["ls", "read", "write"] = "ls",
+        action: Literal["ls", "read", "write", "create_folder_and_file"] = "ls",
         path: str = "~",
         content: str = "",
+        folder_path: str = "",
+        file_name: str = "",
         **kwargs: Any,
     ) -> ToolResult:
+
+        # ── Atomic folder+file creation shortcut ──────────────────────
+        if action == "create_folder_and_file":
+            return await self._create_folder_and_file(
+                folder_path=folder_path,
+                file_name=file_name,
+                content=content,
+            )
 
         p = _safe_path(path)
         if p is None:
@@ -127,6 +140,72 @@ class FilesystemTool(BaseTool):
             )
         except PermissionError:
             return ToolResult(success=False, output="", error=f"Permission denied: {p}")
+
+    # ── create_folder_and_file (atomic combo — #196) ─────────────────────
+
+    async def _create_folder_and_file(
+        self, folder_path: str, file_name: str, content: str,
+    ) -> ToolResult:
+        """Create a directory AND write a file inside it in one atomic step.
+
+        This avoids multi-step hallucination where the LLM claims success
+        without actually calling the tools sequentially.
+        """
+        if not folder_path:
+            return ToolResult(
+                success=False, output="",
+                error="Missing folder_path — where should I create the folder?",
+            )
+        if not file_name:
+            return ToolResult(
+                success=False, output="",
+                error="Missing file_name — what should the file be called?",
+            )
+
+        folder = _safe_path(folder_path)
+        if folder is None:
+            return ToolResult(
+                success=False, output="",
+                error=f"Security: '{folder_path}' is outside the home directory or invalid.",
+            )
+
+        file_path = folder / file_name
+        # Validate the final file path is also under SAFE_ROOT
+        if _safe_path(str(file_path)) is None:
+            return ToolResult(
+                success=False, output="",
+                error=f"Security: '{file_path}' is outside the home directory.",
+            )
+
+        try:
+            folder.mkdir(parents=True, exist_ok=True)
+        except PermissionError:
+            return ToolResult(
+                success=False, output="",
+                error=f"Permission denied: cannot create '{folder}'.",
+            )
+
+        file_content = content or ""
+        try:
+            file_path.write_text(file_content, encoding="utf-8")
+        except PermissionError:
+            return ToolResult(
+                success=False, output="",
+                error=f"Permission denied: cannot write '{file_path}'.",
+            )
+
+        return ToolResult(
+            success=True,
+            output=(
+                f"✓ Created folder: {folder}\n"
+                f"✓ Created file: {file_path}  ({len(file_content)} characters)"
+            ),
+            data={
+                "folder_path": str(folder),
+                "file_path": str(file_path),
+                "bytes_written": len(file_content.encode()),
+            },
+        )
 
 
 registry.register(FilesystemTool())

--- a/tests/interface/test_telegram_llm.py
+++ b/tests/interface/test_telegram_llm.py
@@ -1133,7 +1133,7 @@ class TestMessageLock:
 
 
 class TestMaintenanceSpamFilter:
-    """All-green maintenance results must be suppressed on Telegram."""
+    """ALL maintenance results must be suppressed on Telegram."""
 
     def test_all_green_maintenance_is_spam(self):
         """A maintenance result with zero failures → spam."""
@@ -1144,14 +1144,14 @@ class TestMaintenanceSpamFilter:
         )
         assert _is_maintenance_spam(result) is True
 
-    def test_maintenance_with_failure_not_spam(self):
-        """A maintenance result with ≥1 failure → NOT spam."""
+    def test_maintenance_with_failure_also_spam(self):
+        """A maintenance result with failures → ALSO spam (all maintenance suppressed)."""
         from bantz.interface.telegram_bot import _is_maintenance_spam
         result = FakeBrainResult(
             response="Workflow complete: 2/3 steps succeeded.\n✓ [a] ok\n✗ [b] fail\n✓ [c] ok",
             tool_used="maintenance",
         )
-        assert _is_maintenance_spam(result) is False
+        assert _is_maintenance_spam(result) is True
 
     def test_non_maintenance_never_spam(self):
         """Non-maintenance tool results are never spam."""
@@ -1198,8 +1198,8 @@ class TestMaintenanceSpamFilter:
             mod._ALLOWED = original
 
     @pytest.mark.asyncio
-    async def test_handle_message_shows_failed_maintenance(self):
-        """handle_message must show maintenance results that contain failures."""
+    async def test_handle_message_suppresses_failed_maintenance(self):
+        """handle_message must ALSO suppress maintenance results with failures."""
         import bantz.interface.telegram_bot as mod
         original = mod._ALLOWED
         mod._rate_log.clear()
@@ -1220,11 +1220,9 @@ class TestMaintenanceSpamFilter:
                 with patch.dict("sys.modules", {"bantz.core.brain": MagicMock(brain=mock_brain)}):
                     await mod.handle_message(update, ctx)
 
-            # Placeholder should be edited with the failure result
+            # Placeholder should be deleted — ALL maintenance suppressed
             placeholder = update.message.reply_text.return_value
-            placeholder.delete.assert_not_awaited()
-            edit_args = placeholder.edit_text.call_args_list[-1][0][0]
-            assert "✗" in edit_args
+            placeholder.delete.assert_awaited_once()
         finally:
             mod._ALLOWED = original
 

--- a/tests/tools/test_filesystem_autochain.py
+++ b/tests/tools/test_filesystem_autochain.py
@@ -1,0 +1,283 @@
+"""Tests for Issue #196 — Filesystem Auto-Chaining (create_folder_and_file).
+
+The "Stark Folder Fix": LLM used to hallucinate success for multi-step
+filesystem ops (mkdir → write_file) without calling any tools.  Now a
+single atomic action does both in one shot.
+
+Covers:
+  1. Atomic folder+file creation (happy path)
+  2. Missing parameter handling (folder_path, file_name)
+  3. Security boundary (outside home dir)
+  4. Empty content (allowed — creates empty file)
+  5. Nested subfolder creation (mkdir -p behaviour)
+  6. Quick-route regex matching for English + Turkish patterns
+  7. COT_SYSTEM filesystem schema includes create_folder_and_file
+  8. Tool description advertises create_folder_and_file
+"""
+from __future__ import annotations
+
+import asyncio
+import re
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _run(coro):
+    """Sync wrapper for async tests."""
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 1. Atomic folder+file creation
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestCreateFolderAndFile:
+    """The core atomic operation: create dir + write file in one step."""
+
+    @pytest.mark.asyncio
+    async def test_creates_folder_and_file(self, tmp_path):
+        """Happy path: folder is created, file is written, paths returned."""
+        from bantz.tools.filesystem import FilesystemTool, SAFE_ROOT
+        tool = FilesystemTool()
+        folder = str(tmp_path / "Stark")
+        with patch("bantz.tools.filesystem.SAFE_ROOT", tmp_path):
+            result = await tool.execute(
+                action="create_folder_and_file",
+                folder_path=folder,
+                file_name="notes.txt",
+                content="Winter is coming.",
+            )
+        assert result.success is True
+        assert "✓ Created folder" in result.output
+        assert "✓ Created file" in result.output
+        assert (tmp_path / "Stark" / "notes.txt").exists()
+        assert (tmp_path / "Stark" / "notes.txt").read_text() == "Winter is coming."
+        assert result.data["folder_path"] == folder
+        assert result.data["file_path"] == str(Path(folder) / "notes.txt")
+
+    @pytest.mark.asyncio
+    async def test_creates_nested_subfolders(self, tmp_path):
+        """mkdir -p behaviour: creates intermediate directories."""
+        from bantz.tools.filesystem import FilesystemTool
+        tool = FilesystemTool()
+        deep = str(tmp_path / "level1" / "level2" / "level3")
+        with patch("bantz.tools.filesystem.SAFE_ROOT", tmp_path):
+            result = await tool.execute(
+                action="create_folder_and_file",
+                folder_path=deep,
+                file_name="deep.txt",
+                content="Hello from the deep.",
+            )
+        assert result.success is True
+        assert (tmp_path / "level1" / "level2" / "level3" / "deep.txt").exists()
+
+    @pytest.mark.asyncio
+    async def test_empty_content_creates_empty_file(self, tmp_path):
+        """Content can be empty — creates a 0-byte file."""
+        from bantz.tools.filesystem import FilesystemTool
+        tool = FilesystemTool()
+        folder = str(tmp_path / "EmptyTest")
+        with patch("bantz.tools.filesystem.SAFE_ROOT", tmp_path):
+            result = await tool.execute(
+                action="create_folder_and_file",
+                folder_path=folder,
+                file_name="blank.txt",
+                content="",
+            )
+        assert result.success is True
+        assert (tmp_path / "EmptyTest" / "blank.txt").read_text() == ""
+        assert result.data["bytes_written"] == 0
+
+    @pytest.mark.asyncio
+    async def test_existing_folder_no_error(self, tmp_path):
+        """If the folder already exists, it should NOT fail (exist_ok=True)."""
+        from bantz.tools.filesystem import FilesystemTool
+        tool = FilesystemTool()
+        folder = tmp_path / "Existing"
+        folder.mkdir()
+        with patch("bantz.tools.filesystem.SAFE_ROOT", tmp_path):
+            result = await tool.execute(
+                action="create_folder_and_file",
+                folder_path=str(folder),
+                file_name="new.txt",
+                content="Added to existing folder.",
+            )
+        assert result.success is True
+        assert (folder / "new.txt").read_text() == "Added to existing folder."
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 2. Missing parameter handling
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestMissingParams:
+    """Graceful error messages when required params are omitted."""
+
+    @pytest.mark.asyncio
+    async def test_missing_folder_path(self, tmp_path):
+        """Missing folder_path → clear error."""
+        from bantz.tools.filesystem import FilesystemTool
+        tool = FilesystemTool()
+        with patch("bantz.tools.filesystem.SAFE_ROOT", tmp_path):
+            result = await tool.execute(
+                action="create_folder_and_file",
+                folder_path="",
+                file_name="test.txt",
+                content="data",
+            )
+        assert result.success is False
+        assert "folder_path" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_missing_file_name(self, tmp_path):
+        """Missing file_name → clear error."""
+        from bantz.tools.filesystem import FilesystemTool
+        tool = FilesystemTool()
+        with patch("bantz.tools.filesystem.SAFE_ROOT", tmp_path):
+            result = await tool.execute(
+                action="create_folder_and_file",
+                folder_path=str(tmp_path / "Foo"),
+                file_name="",
+                content="data",
+            )
+        assert result.success is False
+        assert "file_name" in result.error.lower()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 3. Security boundary
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestSecurityBoundary:
+    """Paths outside SAFE_ROOT must be rejected."""
+
+    @pytest.mark.asyncio
+    async def test_outside_home_rejected(self, tmp_path):
+        """Folder path outside SAFE_ROOT → security error."""
+        from bantz.tools.filesystem import FilesystemTool
+        tool = FilesystemTool()
+        with patch("bantz.tools.filesystem.SAFE_ROOT", tmp_path):
+            result = await tool.execute(
+                action="create_folder_and_file",
+                folder_path="/etc/evil",
+                file_name="pwned.txt",
+                content="bad",
+            )
+        assert result.success is False
+        assert "security" in result.error.lower() or "outside" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_traversal_attack_rejected(self, tmp_path):
+        """Path traversal (../../) must be caught."""
+        from bantz.tools.filesystem import FilesystemTool
+        tool = FilesystemTool()
+        with patch("bantz.tools.filesystem.SAFE_ROOT", tmp_path):
+            result = await tool.execute(
+                action="create_folder_and_file",
+                folder_path=str(tmp_path / ".." / ".." / "tmp" / "evil"),
+                file_name="escape.txt",
+                content="nope",
+            )
+        assert result.success is False
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 4. Quick-route regex matching
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestQuickRouteFilesystem:
+    """_quick_route must catch folder+file creation patterns."""
+
+    def _route(self, text: str) -> dict | None:
+        from bantz.core.brain import Brain
+        return Brain._quick_route(text, text)
+
+    def test_create_stark_folder_and_file(self):
+        """'create a folder named Stark and write notes.txt in it'"""
+        r = self._route("create a folder named Stark and write notes.txt in it")
+        assert r is not None
+        assert r["tool"] == "filesystem"
+        assert r["args"]["action"] == "create_folder_and_file"
+        assert "stark" in r["args"]["folder_path"].lower()
+        assert r["args"]["file_name"] == "notes.txt"
+
+    def test_make_folder_and_put_file(self):
+        """'make a folder called Projects and put readme.md in it with hello world'"""
+        r = self._route("make a folder called Projects and put readme.md in it with hello world")
+        assert r is not None
+        assert r["tool"] == "filesystem"
+        assert "projects" in r["args"]["folder_path"].lower()
+        assert r["args"]["file_name"] == "readme.md"
+        assert "hello world" in r["args"]["content"]
+
+    def test_create_directory_then_create_file(self):
+        """'create a directory named reports then create notes.txt'"""
+        r = self._route("create a directory named reports then create notes.txt")
+        assert r is not None
+        assert r["tool"] == "filesystem"
+        assert "reports" in r["args"]["folder_path"].lower()
+        assert r["args"]["file_name"] == "notes.txt"
+
+    def test_create_folder_with_content(self):
+        """'create a folder named test and write data.txt in it with some test data'"""
+        r = self._route("create a folder named test and write data.txt in it with some test data")
+        assert r is not None
+        assert r["args"]["content"] == "some test data"
+
+    def test_default_desktop_path(self):
+        """When no path specified, folder should default to ~/Desktop/."""
+        r = self._route("create a folder named Stark and write test.txt in it")
+        assert r is not None
+        assert "~/Desktop/" in r["args"]["folder_path"]
+
+    def test_no_match_for_simple_create_folder(self):
+        """'create a folder named X' (without file) should NOT match combo regex."""
+        r = self._route("create a folder named TestOnly")
+        # Should NOT match the combo regex — falls through to _generate
+        if r is not None:
+            assert r["tool"] != "filesystem" or r["args"].get("action") != "create_folder_and_file"
+
+    def test_no_match_for_email_create(self):
+        """'create a mail ...' must NOT match filesystem combo."""
+        r = self._route("create a folder and write a mail to john")
+        # Should NOT be filesystem
+        if r is not None and r["tool"] == "filesystem":
+            assert r["args"].get("action") != "create_folder_and_file"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 5. Schema / description / COT
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestSchemaAndCOT:
+    """Tool schema and COT_SYSTEM must advertise create_folder_and_file."""
+
+    def test_tool_description_mentions_create_folder_and_file(self):
+        """FilesystemTool.description must mention create_folder_and_file."""
+        from bantz.tools.filesystem import FilesystemTool
+        tool = FilesystemTool()
+        assert "create_folder_and_file" in tool.description
+
+    def test_cot_system_includes_create_folder_and_file(self):
+        """COT_SYSTEM must list create_folder_and_file as a filesystem action."""
+        from bantz.core.intent import COT_SYSTEM
+        assert "create_folder_and_file" in COT_SYSTEM
+
+    def test_cot_system_includes_folder_path_param(self):
+        """COT_SYSTEM filesystem section must mention folder_path parameter."""
+        from bantz.core.intent import COT_SYSTEM
+        assert "folder_path" in COT_SYSTEM
+
+    def test_cot_system_includes_file_name_param(self):
+        """COT_SYSTEM filesystem section must mention file_name parameter."""
+        from bantz.core.intent import COT_SYSTEM
+        assert "file_name" in COT_SYSTEM


### PR DESCRIPTION
## The Stark Folder Fix

LLM used to hallucinate success for multi-step filesystem ops (mkdir → write) without calling any tools. Session logs #99/#100 showed Bantz claiming "I created the folder, ma'am" without ever calling the filesystem tool.

Now a single atomic `create_folder_and_file` action handles both steps in one shot — no multi-step reasoning required.

### Changes

**filesystem.py:**
- New action `create_folder_and_file` (folder_path, file_name, content)
- mkdir -p behaviour, SAFE_ROOT security checks, empty content allowed
- Updated tool description to advertise the new action

**brain.py (_quick_route):**
- Regex fast-path: "create a folder named X and write Y in it"
- English + Turkish support
- Defaults to ~/Desktop/ when no path specified

**intent.py (COT_SYSTEM):**
- filesystem params now include create_folder_and_file + folder_path + file_name

**telegram_bot.py:**
- Strengthened maintenance spam filter: ALL maintenance output suppressed on Telegram

### Tests
19 new tests in `test_filesystem_autochain.py`
2216 total, 0 failures