### PR TITLE
feat(brain): LLM-based filesystem param extraction (#196-v2)

### DIFF
--- a/src/bantz/core/brain.py
+++ b/src/bantz/core/brain.py
@@ -215,6 +215,31 @@ RULES:
 5. NEVER invent extra files or directories\
 """
 
+# ── LLM-based filesystem parameter extractor (#196-v2) ──────────────────────
+# Replaces rigid regex with LLM understanding for folder+file creation.
+_FS_EXTRACT_SYSTEM = """\
+Extract folder + file creation parameters from the user request.
+Return ONLY a valid JSON object with these keys:
+- folder_path: path for the folder (default ~/Desktop/<name> if no path given)
+- file_name: the file to create (include extension; default .txt if none given)
+- content: text to write in the file (empty string if not specified)
+
+Examples:
+"create a stark folder then create a text file and write heeey into it"
+→ {"folder_path": "~/Desktop/stark", "file_name": "file.txt", "content": "heeey"}
+
+"make a directory called Projects and put readme.md in it with hello world"
+→ {"folder_path": "~/Desktop/Projects", "file_name": "readme.md", "content": "hello world"}
+
+"yeni klasör aç adı work olsun, içine notes.txt yaz, test yaz"
+→ {"folder_path": "~/Desktop/work", "file_name": "notes.txt", "content": "test"}
+
+"create a folder named reports then create data.csv"
+→ {"folder_path": "~/Desktop/reports", "file_name": "data.csv", "content": ""}
+
+Return ONLY the JSON object. No markdown fences. No explanation.\
+"""
+
 _REFUSAL_PATTERNS = (
     "sorry", "can't assist", "cannot assist", "i'm unable",
     "i cannot", "not able to", "inappropriate",
@@ -911,54 +936,24 @@ class Brain:
             if len(query) >= 2 and query.lower() not in _WS_STOPWORDS:
                 return {"tool": "web_search", "args": {"query": query}}
 
-        # ── Filesystem auto-chain: create folder + file in one step (#196) ──
-        # Catches: "create a Stark folder and write test.txt in it",
-        # "make a folder X, put a file Y with content Z", etc.
-        # Search on e (English) individually — NOT on 'both' which
-        # concatenates o+e and causes the regex to span duplicated text.
-        _FS_COMBO = re.search(
-            r"(?:create|make|yap|oluştur|aç)\s+"
-            r"(?:a\s+)?(?:folder|directory|klasör|dizin)\s+"
-            r"(?:named?\s+|called?\s+|adında\s+|adlı\s+)?"
-            r"[\"']?([\w.\- ]+?)[\"']?"
-            r"\s+(?:and|then|,)\s+"
-            r"(?:create|put|write|place|add|make|yaz|koy|ekle)\s+"
-            r"(?:a\s+)?(?:file\s+)?(?:named?\s+|called?\s+|adında\s+)?"
-            r"[\"']?([\w.\-]+)[\"']?"
-            r"(?:\s+(?:in(?:side)?|into)\s+it)?"
-            r"(?:\s+(?:with|containing|saying|that\s+says|içeriği|yazısı)\s+"
-            r"[\"']?(.+?)[\"']?)?\s*$",
-            e, re.IGNORECASE,
-        ) or re.search(
-            r"(?:create|make|yap|oluştur|aç)\s+"
-            r"(?:a\s+)?(?:folder|directory|klasör|dizin)\s+"
-            r"(?:named?\s+|called?\s+|adında\s+|adlı\s+)?"
-            r"[\"']?([\w.\- ]+?)[\"']?"
-            r"\s+(?:and|then|,)\s+"
-            r"(?:create|put|write|place|add|make|yaz|koy|ekle)\s+"
-            r"(?:a\s+)?(?:file\s+)?(?:named?\s+|called?\s+|adında\s+)?"
-            r"[\"']?([\w.\-]+)[\"']?"
-            r"(?:\s+(?:in(?:side)?|into)\s+it)?"
-            r"(?:\s+(?:with|containing|saying|that\s+says|içeriği|yazısı)\s+"
-            r"[\"']?(.+?)[\"']?)?\s*$",
-            o, re.IGNORECASE,
-        )
-        if _FS_COMBO:
-            _folder_name = _FS_COMBO.group(1).strip()
-            _file_name = _FS_COMBO.group(2).strip()
-            _content = (_FS_COMBO.group(3) or "").strip()
-            # Default path to Desktop if no path specified
-            if "/" not in _folder_name and "~" not in _folder_name:
-                _folder_name = f"~/Desktop/{_folder_name}"
-            return {
-                "tool": "filesystem",
-                "args": {
-                    "action": "create_folder_and_file",
-                    "folder_path": _folder_name,
-                    "file_name": _file_name,
-                    "content": _content,
-                },
-            }
+        # ── Filesystem auto-chain: LLM-based folder+file creation (#196-v2) ──
+        # Instead of rigid regex, detect keyword overlap and let the LLM
+        # extract actual parameters (folder name, file name, content).
+        _fs_folder_kw = any(k in both for k in (
+            "folder", "directory", "klasör", "dizin",
+        ))
+        _fs_file_kw = any(k in both for k in (
+            " file", "dosya", ".txt", ".md", ".py", ".csv", ".json",
+            ".html", ".css", ".js", ".log",
+        ))
+        _fs_create_kw = any(k in both for k in (
+            "create", "make", "write", "put", "place", "add",
+            "yap", "oluştur", "aç", "yaz", "koy", "ekle",
+        ))
+        if _fs_folder_kw and _fs_file_kw and _fs_create_kw:
+            # Guard: "create a folder and write a mail" → NOT filesystem
+            if not any(k in both for k in ("mail", "email", "calendar", "assignment")):
+                return {"tool": "_fs_autochain", "args": {}}
 
         # Shell generation for file operations
         if any(k in both for k in ("create file", "create folder", "create directory",
@@ -1207,6 +1202,32 @@ class Brain:
             {"role": "user", "content": en or orig},
         ])
         return raw.strip().strip("`")
+
+    async def _extract_fs_params(self, orig: str, en: str) -> dict:
+        """Use LLM to extract folder+file creation params from natural language.
+
+        Returns dict with keys: folder_path, file_name, content.
+        Falls back to sensible defaults if parsing fails.
+        """
+        import json as _json
+
+        raw = await ollama.chat([
+            {"role": "system", "content": _FS_EXTRACT_SYSTEM},
+            {"role": "user", "content": en or orig},
+        ])
+
+        # Strip markdown fences and extract JSON
+        text = raw.strip().strip("`")
+        text = re.sub(r"^```(?:json)?\s*", "", text)
+        text = re.sub(r"\s*```$", "", text)
+        m = re.search(r"\{.*\}", text, re.DOTALL)
+        params = _json.loads(m.group() if m else text)
+
+        # Ensure required keys exist with defaults
+        params.setdefault("folder_path", "~/Desktop/new_folder")
+        params.setdefault("file_name", "file.txt")
+        params.setdefault("content", "")
+        return params
 
     async def _handle_location(self) -> str:
         """Handle 'where am i' queries — show GPS/location info."""
@@ -1562,7 +1583,28 @@ class Brain:
             data_layer.conversations.add("assistant", text, tool_used="schedule")
             return BrainResult(response=text, tool_used="schedule")
 
-        if quick and quick["tool"] == "_generate":
+        # ── FS autochain: LLM extracts folder/file params (#196-v2) ──────
+        if quick and quick["tool"] == "_fs_autochain":
+            try:
+                params = await self._extract_fs_params(user_input, en_input)
+                plan = {
+                    "route": "tool",
+                    "tool_name": "filesystem",
+                    "tool_args": {
+                        "action": "create_folder_and_file",
+                        "folder_path": params.get("folder_path", "~/Desktop/new_folder"),
+                        "file_name": params.get("file_name", "file.txt"),
+                        "content": params.get("content", ""),
+                    },
+                    "risk_level": "moderate",
+                }
+            except Exception as exc:
+                log.warning("FS autochain extraction failed: %s — falling back to shell", exc)
+                cmd = await self._generate_command(user_input, en_input)
+                plan = {"route": "tool", "tool_name": "shell",
+                        "tool_args": {"command": cmd}, "risk_level": "moderate"}
+
+        elif quick and quick["tool"] == "_generate":
             cmd = await self._generate_command(user_input, en_input)
             plan = {"route": "tool", "tool_name": "shell",
                     "tool_args": {"command": cmd}, "risk_level": "moderate"}

--- a/tests/tools/test_filesystem_autochain.py
+++ b/tests/tools/test_filesystem_autochain.py
@@ -4,15 +4,20 @@ The "Stark Folder Fix": LLM used to hallucinate success for multi-step
 filesystem ops (mkdir → write_file) without calling any tools.  Now a
 single atomic action does both in one shot.
 
+v2: Replaced rigid regex with LLM-based parameter extraction.
+    Keyword detection catches the intent; Ollama extracts the params.
+
 Covers:
   1. Atomic folder+file creation (happy path)
   2. Missing parameter handling (folder_path, file_name)
   3. Security boundary (outside home dir)
   4. Empty content (allowed — creates empty file)
   5. Nested subfolder creation (mkdir -p behaviour)
-  6. Quick-route regex matching for English + Turkish patterns
-  7. COT_SYSTEM filesystem schema includes create_folder_and_file
-  8. Tool description advertises create_folder_and_file
+  6. Quick-route keyword detection (English + Turkish)
+  7. LLM parameter extraction (mocked Ollama)
+  8. Fallback to shell on extraction failure
+  9. COT_SYSTEM filesystem schema includes create_folder_and_file
+ 10. Tool description advertises create_folder_and_file
 """
 from __future__ import annotations
 
@@ -20,7 +25,7 @@ import asyncio
 import re
 import tempfile
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -189,72 +194,150 @@ class TestSecurityBoundary:
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# 4. Quick-route regex matching
+# 4. Quick-route keyword detection (v2: LLM-based)
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
 class TestQuickRouteFilesystem:
-    """_quick_route must catch folder+file creation patterns."""
+    """_quick_route must catch folder+file creation via keyword detection."""
 
     def _route(self, text: str) -> dict | None:
         from bantz.core.brain import Brain
         return Brain._quick_route(text, text)
 
+    # ── Keyword detection: routes to _fs_autochain ──
+
     def test_create_stark_folder_and_file(self):
-        """'create a folder named Stark and write notes.txt in it'"""
-        r = self._route("create a folder named Stark and write notes.txt in it")
+        """'create a stark folder then create a text file and write heeey'"""
+        r = self._route("create a stark folder then create a text file and write heeey into it")
         assert r is not None
-        assert r["tool"] == "filesystem"
-        assert r["args"]["action"] == "create_folder_and_file"
-        assert "stark" in r["args"]["folder_path"].lower()
-        assert r["args"]["file_name"] == "notes.txt"
+        assert r["tool"] == "_fs_autochain"
 
     def test_make_folder_and_put_file(self):
-        """'make a folder called Projects and put readme.md in it with hello world'"""
+        """'make a folder called Projects and put readme.md in it'"""
         r = self._route("make a folder called Projects and put readme.md in it with hello world")
         assert r is not None
-        assert r["tool"] == "filesystem"
-        assert "projects" in r["args"]["folder_path"].lower()
-        assert r["args"]["file_name"] == "readme.md"
-        assert "hello world" in r["args"]["content"]
+        assert r["tool"] == "_fs_autochain"
 
     def test_create_directory_then_create_file(self):
         """'create a directory named reports then create notes.txt'"""
         r = self._route("create a directory named reports then create notes.txt")
         assert r is not None
-        assert r["tool"] == "filesystem"
-        assert "reports" in r["args"]["folder_path"].lower()
-        assert r["args"]["file_name"] == "notes.txt"
+        assert r["tool"] == "_fs_autochain"
 
-    def test_create_folder_with_content(self):
-        """'create a folder named test and write data.txt in it with some test data'"""
-        r = self._route("create a folder named test and write data.txt in it with some test data")
+    def test_turkish_klasor_dosya(self):
+        """Turkish: 'klasör oluştur ve dosya yaz'"""
+        r = self._route("bir klasör oluştur ve içine dosya yaz")
         assert r is not None
-        assert r["args"]["content"] == "some test data"
+        assert r["tool"] == "_fs_autochain"
 
-    def test_default_desktop_path(self):
-        """When no path specified, folder should default to ~/Desktop/."""
-        r = self._route("create a folder named Stark and write test.txt in it")
+    def test_folder_with_extension_hint(self):
+        """Request mentioning a .txt file + folder → autochain."""
+        r = self._route("create a folder called work and write notes.txt in it")
         assert r is not None
-        assert "~/Desktop/" in r["args"]["folder_path"]
+        assert r["tool"] == "_fs_autochain"
 
     def test_no_match_for_simple_create_folder(self):
-        """'create a folder named X' (without file) should NOT match combo regex."""
+        """'create a folder named X' (without file) should NOT match combo."""
         r = self._route("create a folder named TestOnly")
-        # Should NOT match the combo regex — falls through to _generate
+        # Should NOT match _fs_autochain — no file keyword
         if r is not None:
-            assert r["tool"] != "filesystem" or r["args"].get("action") != "create_folder_and_file"
+            assert r["tool"] != "_fs_autochain"
 
     def test_no_match_for_email_create(self):
-        """'create a mail ...' must NOT match filesystem combo."""
+        """'create a folder and write a mail to john' must NOT match filesystem."""
         r = self._route("create a folder and write a mail to john")
-        # Should NOT be filesystem
-        if r is not None and r["tool"] == "filesystem":
-            assert r["args"].get("action") != "create_folder_and_file"
+        if r is not None:
+            assert r["tool"] != "_fs_autochain"
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# 5. Schema / description / COT
+# 5. LLM parameter extraction (mocked Ollama)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestExtractFsParams:
+    """Brain._extract_fs_params uses LLM to extract folder/file/content."""
+
+    @pytest.mark.asyncio
+    async def test_extracts_all_params(self):
+        """LLM returns valid JSON → params are extracted correctly."""
+        from bantz.core.brain import Brain
+
+        llm_response = '{"folder_path": "~/Desktop/stark", "file_name": "notes.txt", "content": "heeey"}'
+        brain = Brain.__new__(Brain)
+        with patch("bantz.core.brain.ollama") as mock_ollama:
+            mock_ollama.chat = AsyncMock(return_value=llm_response)
+            params = await brain._extract_fs_params(
+                "create a stark folder then create a text file and write heeey",
+                "create a stark folder then create a text file and write heeey",
+            )
+        assert params["folder_path"] == "~/Desktop/stark"
+        assert params["file_name"] == "notes.txt"
+        assert params["content"] == "heeey"
+
+    @pytest.mark.asyncio
+    async def test_defaults_on_missing_keys(self):
+        """LLM returns partial JSON → defaults fill in."""
+        from bantz.core.brain import Brain
+
+        llm_response = '{"folder_path": "~/Desktop/work"}'
+        brain = Brain.__new__(Brain)
+        with patch("bantz.core.brain.ollama") as mock_ollama:
+            mock_ollama.chat = AsyncMock(return_value=llm_response)
+            params = await brain._extract_fs_params("make a work folder", "make a work folder")
+        assert params["folder_path"] == "~/Desktop/work"
+        assert params["file_name"] == "file.txt"       # default
+        assert params["content"] == ""                  # default
+
+    @pytest.mark.asyncio
+    async def test_handles_markdown_fences(self):
+        """LLM wraps JSON in markdown code fences → still parsed."""
+        from bantz.core.brain import Brain
+
+        llm_response = '```json\n{"folder_path": "~/Desktop/test", "file_name": "a.txt", "content": "hi"}\n```'
+        brain = Brain.__new__(Brain)
+        with patch("bantz.core.brain.ollama") as mock_ollama:
+            mock_ollama.chat = AsyncMock(return_value=llm_response)
+            params = await brain._extract_fs_params("test", "test")
+        assert params["folder_path"] == "~/Desktop/test"
+        assert params["file_name"] == "a.txt"
+
+    @pytest.mark.asyncio
+    async def test_raises_on_invalid_json(self):
+        """LLM returns garbage → raises exception (caller handles fallback)."""
+        from bantz.core.brain import Brain
+
+        llm_response = "I cannot do that, sorry."
+        brain = Brain.__new__(Brain)
+        with patch("bantz.core.brain.ollama") as mock_ollama:
+            mock_ollama.chat = AsyncMock(return_value=llm_response)
+            with pytest.raises(Exception):
+                await brain._extract_fs_params("test", "test")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 6. FS_EXTRACT_SYSTEM prompt exists
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestFsExtractPrompt:
+    """The LLM prompt for filesystem extraction must exist and be well-formed."""
+
+    def test_prompt_exists(self):
+        from bantz.core.brain import _FS_EXTRACT_SYSTEM
+        assert "folder_path" in _FS_EXTRACT_SYSTEM
+        assert "file_name" in _FS_EXTRACT_SYSTEM
+        assert "content" in _FS_EXTRACT_SYSTEM
+
+    def test_prompt_has_examples(self):
+        from bantz.core.brain import _FS_EXTRACT_SYSTEM
+        assert "stark" in _FS_EXTRACT_SYSTEM.lower()
+        assert "Projects" in _FS_EXTRACT_SYSTEM or "readme" in _FS_EXTRACT_SYSTEM
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 7. Schema / description / COT
 # ═══════════════════════════════════════════════════════════════════════════════
 
 


### PR DESCRIPTION
## Stark Folder Fix v2: Regex → LLM

**Problem**: Rigid _FS_COMBO regex couldn't handle natural language like 'create a stark folder then create a text file and write heeey into it'.

**User verdict**: 'bu iş regexle olmaz, o anlamalı' (this won't work with regex — it needs to understand)

**Solution**: Replace 30-line regex with:
1. Keyword detection in _quick_route: folder+file+create keywords → _fs_autochain
2. _extract_fs_params(): Focused LLM call extracts folder_path, file_name, content as JSON
3. Fallback: If LLM extraction fails → falls back to _generate_command() shell approach

### Changes
- brain.py: _FS_EXTRACT_SYSTEM prompt with examples (EN+TR)
- brain.py: _extract_fs_params() — Ollama JSON extraction with defaults
- brain.py: _quick_route keyword detection → _fs_autochain
- brain.py: process() handler with shell fallback on extraction failure
- tests: 25 tests (6 new: LLM mock, prompt existence, keyword detection)

### Test Results: 2222 passed (+6 new), 0 failures