### PR TITLE
feat(agent): Plan-and-Solve Multi-Step Decomposition (#187)

### DIFF
--- a/src/bantz/agent/executor.py
+++ b/src/bantz/agent/executor.py
@@ -1,0 +1,185 @@
+"""
+Bantz v3 — Plan-and-Solve Executor (#187)
+
+"The Butler Carries Out His Itinerary"
+
+Executes a list of PlanSteps sequentially, passing context from one step
+to the next.  If a step fails, the executor notes it and continues with
+remaining steps (graceful degradation).
+
+Usage:
+    from bantz.agent.executor import plan_executor
+    result = await plan_executor.run(steps, tool_registry)
+"""
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from bantz.tools import registry, ToolResult
+
+log = logging.getLogger("bantz.executor")
+
+
+@dataclass
+class StepResult:
+    """Result of executing a single plan step."""
+    step_number: int
+    tool: str
+    description: str
+    success: bool
+    output: str
+    error: str = ""
+
+
+@dataclass
+class PlanExecutionResult:
+    """Aggregate result of executing an entire plan."""
+    step_results: list[StepResult] = field(default_factory=list)
+    aborted: bool = False
+
+    @property
+    def succeeded(self) -> int:
+        return sum(1 for s in self.step_results if s.success)
+
+    @property
+    def total(self) -> int:
+        return len(self.step_results)
+
+    @property
+    def all_success(self) -> bool:
+        return self.succeeded == self.total and self.total > 0
+
+    def summary(self) -> str:
+        """A butler-style completion summary."""
+        if not self.step_results:
+            return "I'm afraid the itinerary was empty — nothing to do."
+
+        lines: list[str] = []
+        for sr in self.step_results:
+            icon = "✓" if sr.success else "✗"
+            short = sr.output[:200].replace("\n", " ") if sr.output else sr.error[:200]
+            lines.append(f"  {icon} Step {sr.step_number}: {sr.description}")
+            if short:
+                lines.append(f"    → {short}")
+
+        ok, total = self.succeeded, self.total
+        if ok == total:
+            header = f"Very good — all {total} tasks completed successfully."
+        elif ok == 0:
+            header = f"I regret to report that all {total} tasks encountered difficulties."
+        else:
+            header = f"I have completed {ok} of {total} tasks. Some required improvisation."
+
+        return header + "\n" + "\n".join(lines)
+
+
+class PlanExecutor:
+    """Runs plan steps sequentially, threading context between them."""
+
+    async def run(
+        self,
+        steps: list[Any],  # list[PlanStep] from planner.py
+        *,
+        on_step_start: Any = None,  # optional callback(step_number, description)
+    ) -> PlanExecutionResult:
+        """Execute all steps in order.
+
+        - Output from step N is stored and injected into step N+1 when
+          step N+1 declares ``depends_on: N``.
+        - If a step fails, execution continues with remaining steps.
+        - ``on_step_start`` is an optional async callback for progress updates.
+        """
+        result = PlanExecutionResult()
+        context_store: dict[int, str] = {}  # step_number → output text
+
+        for plan_step in steps:
+            step_num = plan_step.step
+            tool_name = plan_step.tool
+            params = dict(plan_step.params)  # shallow copy
+            description = plan_step.description
+            depends = plan_step.depends_on
+
+            # Progress callback
+            if on_step_start is not None:
+                try:
+                    await on_step_start(step_num, description)
+                except Exception:
+                    pass
+
+            # Inject dependency context
+            if depends is not None and depends in context_store:
+                prev_output = context_store[depends]
+                params = self._inject_context(params, prev_output)
+
+            # Look up tool
+            tool = registry.get(tool_name)
+            if not tool:
+                sr = StepResult(
+                    step_number=step_num,
+                    tool=tool_name,
+                    description=description,
+                    success=False,
+                    output="",
+                    error=f"Tool '{tool_name}' not found in registry.",
+                )
+                result.step_results.append(sr)
+                log.warning("Plan step %d: tool '%s' not found", step_num, tool_name)
+                continue
+
+            # Execute
+            try:
+                tool_result: ToolResult = await tool.execute(**params)
+                sr = StepResult(
+                    step_number=step_num,
+                    tool=tool_name,
+                    description=description,
+                    success=tool_result.success,
+                    output=tool_result.output,
+                    error=tool_result.error,
+                )
+                if tool_result.success:
+                    context_store[step_num] = tool_result.output[:2000]
+                    log.info("Plan step %d [%s]: success", step_num, tool_name)
+                else:
+                    log.warning("Plan step %d [%s]: failed — %s",
+                                step_num, tool_name, tool_result.error)
+            except Exception as exc:
+                sr = StepResult(
+                    step_number=step_num,
+                    tool=tool_name,
+                    description=description,
+                    success=False,
+                    output="",
+                    error=str(exc),
+                )
+                log.warning("Plan step %d [%s]: exception — %s",
+                            step_num, tool_name, exc)
+
+            result.step_results.append(sr)
+
+        return result
+
+    @staticmethod
+    def _inject_context(params: dict, prev_output: str) -> dict:
+        """Replace {step_N_output} placeholders and add context key."""
+        # Replace any placeholder references in string values
+        for key, val in params.items():
+            if isinstance(val, str) and re.search(r"\{step_\d+_output\}", val):
+                params[key] = re.sub(r"\{step_\d+_output\}", prev_output[:1500], val)
+
+        # Also provide as explicit "content" for filesystem writes
+        # if content is a placeholder or empty and we have prior output
+        if "content" in params:
+            c = params["content"]
+            if not c or (isinstance(c, str) and "{step_" in c):
+                params["content"] = prev_output[:2000]
+
+        return params
+
+
+# ── Singleton ────────────────────────────────────────────────────────────────
+
+plan_executor = PlanExecutor()

--- a/src/bantz/agent/planner.py
+++ b/src/bantz/agent/planner.py
@@ -1,0 +1,265 @@
+"""
+Bantz v3 — Plan-and-Solve Multi-Step Decomposition (#187)
+
+"The Butler's Itinerary"
+
+When the user gives a complex, multi-step command (e.g. "Find 3 articles
+about AI, summarize them, and save to a file in the Research folder"),
+the PlannerAgent uses the LLM to break it down into a structured JSON
+array of steps — an "itinerary" — that the Executor runs sequentially.
+
+Usage:
+    from bantz.agent.planner import planner_agent
+    steps = await planner_agent.decompose(en_input, tool_schemas)
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from bantz.llm.ollama import ollama
+
+log = logging.getLogger("bantz.planner")
+
+# ── System prompt — enforces 1920s Butler persona + valid JSON output ────────
+
+PLANNER_SYSTEM = """\
+You are Bantz, a 1920s-era English butler who is also a meticulous planner.
+The user has given you a complex request that requires MULTIPLE steps.
+
+Your task: break the request into a numbered list of discrete steps.
+Each step uses exactly ONE tool from the available set.
+
+AVAILABLE TOOLS: {tool_names}
+
+TOOL REFERENCE:
+- web_search: search the internet for information. Params: {{"query": "..."}}
+- filesystem: read/write/create files and folders. Params: {{"action": "write|read|create_folder_and_file", "path": "...", "content": "...", "folder_path": "...", "file_name": "..."}}
+- shell: run a bash command. Params: {{"command": "..."}}
+- gmail: send/read email. Params: {{"action": "compose_and_send|unread|search", "to": "...", "intent": "...", "subject": "..."}}
+- calendar: manage events. Params: {{"action": "create|today|week", "title": "...", "date": "...", "time": "..."}}
+- weather: check weather. Params: {{"city": "..."}}
+- news: get headlines. Params: {{"source": "all|hn"}}
+- system: check CPU/RAM/disk. Params: {{"metric": "all|cpu|ram|disk"}}
+- document: summarize/read a document. Params: {{"path": "...", "action": "summarize|read|ask", "question": "..."}}
+
+RULES:
+1. Each step must use exactly ONE tool.
+2. Steps execute in order. Later steps can reference output of earlier steps.
+3. If a step needs the output of a previous step, note it in "depends_on".
+4. Keep it minimal — don't add unnecessary steps.
+5. For file writing, default to ~/Desktop/ if no path is specified.
+6. Return ONLY a valid JSON array. No markdown fences. No explanation.
+
+OUTPUT FORMAT (return a JSON array of objects):
+[
+  {{"step": 1, "tool": "<tool_name>", "params": {{...}}, "description": "Brief description", "depends_on": null}},
+  {{"step": 2, "tool": "<tool_name>", "params": {{...}}, "description": "Brief description", "depends_on": 1}},
+  ...
+]
+
+EXAMPLES:
+
+User: "Search for 3 articles about quantum computing and save a summary to a file"
+[
+  {{"step": 1, "tool": "web_search", "params": {{"query": "quantum computing articles 2024"}}, "description": "Search for quantum computing articles", "depends_on": null}},
+  {{"step": 2, "tool": "filesystem", "params": {{"action": "create_folder_and_file", "folder_path": "~/Desktop/research", "file_name": "quantum_computing_summary.txt", "content": "{{step_1_output}}"}}, "description": "Save the search results to a file", "depends_on": 1}}
+]
+
+User: "Check my emails, then check the weather in Istanbul, and tell me what's on my calendar"
+[
+  {{"step": 1, "tool": "gmail", "params": {{"action": "unread"}}, "description": "Check unread emails", "depends_on": null}},
+  {{"step": 2, "tool": "weather", "params": {{"city": "Istanbul"}}, "description": "Check weather in Istanbul", "depends_on": null}},
+  {{"step": 3, "tool": "calendar", "params": {{"action": "today"}}, "description": "Check today's calendar", "depends_on": null}}
+]\
+"""
+
+# ── Complexity detection heuristics ──────────────────────────────────────────
+
+# Conjunctions / sequence markers that hint at multi-step intent
+_MULTI_STEP_MARKERS = re.compile(
+    r"""
+    \b(?:then|after\s+that|next|also|additionally|finally|afterwards)\b
+    | \b(?:and\s+(?:then|also|afterwards))\b
+    | \b(?:first|second|third)\b.*\b(?:then|next|after)\b
+    """,
+    re.VERBOSE | re.IGNORECASE,
+)
+
+# Tool-indicating keywords — grouped by tool for counting distinct tools
+_TOOL_KEYWORDS: dict[str, list[str]] = {
+    "web_search": ["search", "find", "look up", "google", "articles", "research"],
+    "gmail": ["email", "mail", "inbox", "compose", "send mail"],
+    "calendar": ["calendar", "event", "meeting", "schedule", "appointment"],
+    "filesystem": ["save", "file", "folder", "write to", "create file", "create folder"],
+    "weather": ["weather", "temperature", "forecast"],
+    "news": ["news", "headlines"],
+    "system": ["cpu", "ram", "memory", "disk", "system status"],
+    "shell": ["run command", "terminal", "bash"],
+    "document": ["summarize", "pdf", "document", "analyze"],
+}
+
+
+@dataclass
+class PlanStep:
+    """A single step in the butler's itinerary."""
+    step: int
+    tool: str
+    params: dict[str, Any] = field(default_factory=dict)
+    description: str = ""
+    depends_on: int | None = None
+
+
+class PlannerAgent:
+    """Decomposes complex user requests into structured step arrays."""
+
+    def is_complex(self, en_input: str) -> bool:
+        """Heuristic check: does this input likely need multi-step planning?
+
+        Returns True if:
+        - Input has sequence markers (then, after that, next...)
+        - Input references 2+ distinct tool categories
+        - Input is long (>15 words) with multiple verb phrases
+        """
+        text = en_input.lower()
+
+        # Check for explicit sequence markers
+        if _MULTI_STEP_MARKERS.search(text):
+            # Also needs at least 2 different tool intents
+            distinct = self._count_distinct_tools(text)
+            if distinct >= 2:
+                return True
+
+        # Even without markers, 2+ distinct tool intents in a long sentence
+        distinct = self._count_distinct_tools(text)
+        word_count = len(text.split())
+        if distinct >= 2 and word_count >= 8:
+            return True
+
+        # Very explicit multi-step: numbered instructions
+        if re.search(r"\b(?:1\.|step\s*1|first)\b", text) and \
+           re.search(r"\b(?:2\.|step\s*2|second|then)\b", text):
+            return True
+
+        return False
+
+    @staticmethod
+    def _count_distinct_tools(text: str) -> int:
+        """Count how many distinct tool categories are mentioned."""
+        found: set[str] = set()
+        for tool_name, keywords in _TOOL_KEYWORDS.items():
+            for kw in keywords:
+                if kw in text:
+                    found.add(tool_name)
+                    break
+        return len(found)
+
+    async def decompose(
+        self,
+        en_input: str,
+        tool_names: list[str],
+    ) -> list[PlanStep]:
+        """Use the LLM to decompose a complex request into plan steps.
+
+        Args:
+            en_input: User request (in English).
+            tool_names: Available tool names from the registry.
+
+        Returns:
+            List of PlanStep objects. Empty list if decomposition fails.
+        """
+        prompt = PLANNER_SYSTEM.format(tool_names=", ".join(tool_names))
+
+        raw = await ollama.chat([
+            {"role": "system", "content": prompt},
+            {"role": "user", "content": en_input},
+        ])
+
+        try:
+            steps_data = self._parse_steps(raw)
+        except (json.JSONDecodeError, ValueError) as exc:
+            log.warning("Planner decomposition failed (attempt 1): %s", exc)
+            # Retry with correction
+            try:
+                raw2 = await ollama.chat([
+                    {"role": "system", "content": prompt},
+                    {"role": "user", "content": en_input},
+                    {"role": "assistant", "content": raw},
+                    {"role": "user", "content": (
+                        "That was not valid JSON. Return ONLY a JSON array of step "
+                        "objects. No markdown. No explanation."
+                    )},
+                ])
+                steps_data = self._parse_steps(raw2)
+            except Exception as exc2:
+                log.warning("Planner decomposition failed (attempt 2): %s", exc2)
+                return []
+
+        # Convert raw dicts to PlanStep objects
+        steps: list[PlanStep] = []
+        for i, s in enumerate(steps_data, 1):
+            steps.append(PlanStep(
+                step=s.get("step", i),
+                tool=s.get("tool", ""),
+                params=s.get("params", {}),
+                description=s.get("description", ""),
+                depends_on=s.get("depends_on"),
+            ))
+
+        # Validate: each step must reference a known tool
+        valid_steps = [s for s in steps if s.tool in tool_names]
+        if len(valid_steps) < len(steps):
+            dropped = len(steps) - len(valid_steps)
+            log.warning("Planner dropped %d steps with unknown tools", dropped)
+
+        return valid_steps
+
+    @staticmethod
+    def _parse_steps(raw: str) -> list[dict]:
+        """Extract a JSON array from the LLM response."""
+        text = raw.strip().strip("`")
+        text = re.sub(r"^```(?:json)?\s*", "", text)
+        text = re.sub(r"\s*```$", "", text)
+
+        # Try to find a JSON array
+        m = re.search(r"\[.*\]", text, re.DOTALL)
+        if m:
+            result = json.loads(m.group())
+        else:
+            result = json.loads(text)
+
+        if not isinstance(result, list):
+            raise ValueError(f"Expected JSON array, got {type(result).__name__}")
+        if len(result) == 0:
+            raise ValueError("Empty step array")
+        return result
+
+    def format_itinerary(self, steps: list[PlanStep]) -> str:
+        """Format the plan as a butler-style announcement for the user.
+
+        Returns a persona-appropriate message like:
+        'Allow me a moment to draft an itinerary for this endeavor, ma'am.
+         Here is my plan:
+           1. Search for quantum computing articles
+           2. Save the results to a file'
+        """
+        if not steps:
+            return ""
+        lines = [
+            "Allow me a moment to draft an itinerary for this endeavor.",
+            "Here is my plan:",
+        ]
+        for s in steps:
+            dep = f" (using results from step {s.depends_on})" if s.depends_on else ""
+            lines.append(f"  {s.step}. {s.description}{dep}")
+        lines.append("")
+        lines.append("Commencing forthwith.")
+        return "\n".join(lines)
+
+
+# ── Singleton ────────────────────────────────────────────────────────────────
+
+planner_agent = PlannerAgent()

--- a/src/bantz/core/brain.py
+++ b/src/bantz/core/brain.py
@@ -1229,6 +1229,39 @@ class Brain:
         params.setdefault("content", "")
         return params
 
+    async def _execute_plan(
+        self, user_input: str, en_input: str, tc: dict,
+    ) -> BrainResult | None:
+        """Decompose a complex request into steps, then execute them.
+
+        Returns BrainResult on success, or None if decomposition fails
+        (so caller can fall through to normal routing).
+        """
+        from bantz.agent.planner import planner_agent
+        from bantz.agent.executor import plan_executor
+
+        tool_names = registry.names()
+        steps = await planner_agent.decompose(en_input, tool_names)
+        if not steps or len(steps) < 2:
+            # Not genuinely multi-step — fall through to normal routing
+            return None
+
+        # Announce the itinerary to the user
+        itinerary = planner_agent.format_itinerary(steps)
+        log.info("Plan-and-Solve itinerary:\n%s", itinerary)
+
+        # Execute all steps
+        exec_result = await plan_executor.run(steps)
+
+        # Combine itinerary + execution summary
+        resp = itinerary + "\n\n" + exec_result.summary()
+
+        data_layer.conversations.add("assistant", resp, tool_used="planner")
+        await self._graph_store(user_input, resp, "planner")
+        self._fire_embeddings()
+
+        return BrainResult(response=resp, tool_used="planner")
+
     async def _handle_location(self) -> str:
         """Handle 'where am i' queries — show GPS/location info."""
         from bantz.core.location import location_service
@@ -1380,6 +1413,18 @@ class Brain:
             await self._graph_store(user_input, resp, "workflow")
             self._fire_embeddings()
             return BrainResult(response=resp, tool_used="workflow")
+
+        # ── Plan-and-Solve: LLM-based multi-step decomposition (#187) ────
+        # If workflow engine didn't fire (regex-based), check if the
+        # planner detects a complex multi-tool request via heuristics.
+        try:
+            from bantz.agent.planner import planner_agent
+            if planner_agent.is_complex(en_input):
+                plan_result = await self._execute_plan(user_input, en_input, tc)
+                if plan_result is not None:
+                    return plan_result
+        except Exception as exc:
+            log.debug("Planner check failed: %s — falling through", exc)
 
         quick = self._quick_route(user_input, en_input)
 

--- a/tests/agent/test_planner.py
+++ b/tests/agent/test_planner.py
@@ -1,0 +1,622 @@
+"""Tests for Issue #187 — Plan-and-Solve Multi-Step Decomposition.
+
+"The Butler's Itinerary": Complex multi-step commands are decomposed
+by the LLM into a structured step array and executed sequentially.
+
+Covers:
+  1. PlannerAgent — complexity detection heuristics
+  2. PlannerAgent — LLM decomposition (mocked Ollama)
+  3. PlannerAgent — itinerary formatting (Butler persona)
+  4. PlanExecutor — sequential execution with context passing
+  5. PlanExecutor — graceful failure handling
+  6. PlanExecutor — dependency injection between steps
+  7. Brain integration — complex requests route to planner
+  8. Brain integration — simple requests bypass planner
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bantz.tools import ToolResult
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 1. PlannerAgent — complexity detection
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestComplexityDetection:
+    """PlannerAgent.is_complex must detect multi-step requests."""
+
+    def _agent(self):
+        from bantz.agent.planner import PlannerAgent
+        return PlannerAgent()
+
+    def test_search_and_save_is_complex(self):
+        """'Search X and then save to a file' → complex."""
+        assert self._agent().is_complex(
+            "search for quantum computing articles and then save to a file"
+        ) is True
+
+    def test_email_then_calendar_is_complex(self):
+        """'Check email then check my calendar' → complex."""
+        assert self._agent().is_complex(
+            "check my email then check my calendar for today"
+        ) is True
+
+    def test_search_and_write_file(self):
+        """'Find articles about X and save a summary file' → complex."""
+        assert self._agent().is_complex(
+            "find articles about machine learning and save a summary to a file"
+        ) is True
+
+    def test_numbered_steps_complex(self):
+        """'First search X, then save to file' → complex."""
+        assert self._agent().is_complex(
+            "first search for AI news, then write the results to a file"
+        ) is True
+
+    def test_simple_greeting_not_complex(self):
+        """'Hello, how are you?' → NOT complex."""
+        assert self._agent().is_complex("hello how are you") is False
+
+    def test_single_tool_not_complex(self):
+        """'What's the weather in Istanbul?' → NOT complex."""
+        assert self._agent().is_complex("what is the weather in istanbul") is False
+
+    def test_simple_email_not_complex(self):
+        """'Check my email' → NOT complex."""
+        assert self._agent().is_complex("check my email") is False
+
+    def test_simple_file_op_not_complex(self):
+        """'Create a folder named test' → NOT complex."""
+        assert self._agent().is_complex("create a folder named test") is False
+
+    def test_short_ambiguous_not_complex(self):
+        """'Tell me about it' → NOT complex."""
+        assert self._agent().is_complex("tell me about it") is False
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 2. PlannerAgent — LLM decomposition (mocked)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestDecomposition:
+    """PlannerAgent.decompose uses the LLM to generate plan steps."""
+
+    @pytest.mark.asyncio
+    async def test_decomposes_search_and_save(self):
+        """Search + save file decomposes into 2 steps."""
+        from bantz.agent.planner import PlannerAgent
+
+        llm_response = json.dumps([
+            {"step": 1, "tool": "web_search", "params": {"query": "AI news"},
+             "description": "Search for AI articles", "depends_on": None},
+            {"step": 2, "tool": "filesystem", "params": {
+                "action": "write", "path": "~/Desktop/ai.txt",
+                "content": "{step_1_output}"},
+             "description": "Save results to file", "depends_on": 1},
+        ])
+
+        agent = PlannerAgent()
+        with patch("bantz.agent.planner.ollama") as mock_llm:
+            mock_llm.chat = AsyncMock(return_value=llm_response)
+            steps = await agent.decompose(
+                "search for AI news and save to a file",
+                ["web_search", "filesystem", "gmail", "shell"],
+            )
+
+        assert len(steps) == 2
+        assert steps[0].tool == "web_search"
+        assert steps[0].step == 1
+        assert steps[1].tool == "filesystem"
+        assert steps[1].depends_on == 1
+
+    @pytest.mark.asyncio
+    async def test_decomposes_three_steps(self):
+        """Email + weather + calendar → 3 independent steps."""
+        from bantz.agent.planner import PlannerAgent
+
+        llm_response = json.dumps([
+            {"step": 1, "tool": "gmail", "params": {"action": "unread"},
+             "description": "Check unread emails", "depends_on": None},
+            {"step": 2, "tool": "weather", "params": {"city": "Istanbul"},
+             "description": "Check weather in Istanbul", "depends_on": None},
+            {"step": 3, "tool": "calendar", "params": {"action": "today"},
+             "description": "Check today's calendar", "depends_on": None},
+        ])
+
+        agent = PlannerAgent()
+        with patch("bantz.agent.planner.ollama") as mock_llm:
+            mock_llm.chat = AsyncMock(return_value=llm_response)
+            steps = await agent.decompose(
+                "check my email, check the weather, and show my calendar",
+                ["gmail", "weather", "calendar", "web_search", "filesystem"],
+            )
+
+        assert len(steps) == 3
+        assert {s.tool for s in steps} == {"gmail", "weather", "calendar"}
+
+    @pytest.mark.asyncio
+    async def test_filters_unknown_tools(self):
+        """Steps with unknown tool names are dropped."""
+        from bantz.agent.planner import PlannerAgent
+
+        llm_response = json.dumps([
+            {"step": 1, "tool": "web_search", "params": {"query": "test"},
+             "description": "Search", "depends_on": None},
+            {"step": 2, "tool": "magic_wand", "params": {},
+             "description": "Cast spell", "depends_on": None},
+        ])
+
+        agent = PlannerAgent()
+        with patch("bantz.agent.planner.ollama") as mock_llm:
+            mock_llm.chat = AsyncMock(return_value=llm_response)
+            steps = await agent.decompose("test", ["web_search", "filesystem"])
+
+        assert len(steps) == 1
+        assert steps[0].tool == "web_search"
+
+    @pytest.mark.asyncio
+    async def test_handles_markdown_fenced_json(self):
+        """LLM wraps response in ```json fences → still parsed."""
+        from bantz.agent.planner import PlannerAgent
+
+        llm_response = '```json\n[{"step": 1, "tool": "weather", "params": {"city": "London"}, "description": "Check weather", "depends_on": null}]\n```'
+
+        agent = PlannerAgent()
+        with patch("bantz.agent.planner.ollama") as mock_llm:
+            mock_llm.chat = AsyncMock(return_value=llm_response)
+            steps = await agent.decompose("check weather", ["weather"])
+
+        assert len(steps) == 1
+        assert steps[0].tool == "weather"
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_garbage(self):
+        """LLM returns garbage → empty list, no crash."""
+        from bantz.agent.planner import PlannerAgent
+
+        agent = PlannerAgent()
+        with patch("bantz.agent.planner.ollama") as mock_llm:
+            mock_llm.chat = AsyncMock(return_value="I'm just a butler, I can't do that.")
+            steps = await agent.decompose("do something", ["web_search"])
+
+        assert steps == []
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 3. PlannerAgent — itinerary formatting
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestItineraryFormatting:
+    """format_itinerary must produce butler-style announcements."""
+
+    def test_formats_two_step_plan(self):
+        from bantz.agent.planner import PlannerAgent, PlanStep
+
+        steps = [
+            PlanStep(step=1, tool="web_search", params={"query": "AI"},
+                     description="Search for AI articles"),
+            PlanStep(step=2, tool="filesystem", params={"action": "write"},
+                     description="Save results to a file", depends_on=1),
+        ]
+        text = PlannerAgent().format_itinerary(steps)
+        assert "itinerary" in text.lower()
+        assert "1. Search for AI articles" in text
+        assert "2. Save results to a file" in text
+        assert "Commencing forthwith" in text
+
+    def test_shows_dependency(self):
+        from bantz.agent.planner import PlannerAgent, PlanStep
+
+        steps = [
+            PlanStep(step=1, tool="web_search", description="Search"),
+            PlanStep(step=2, tool="filesystem", description="Save", depends_on=1),
+        ]
+        text = PlannerAgent().format_itinerary(steps)
+        assert "results from step 1" in text
+
+    def test_empty_plan_returns_empty(self):
+        from bantz.agent.planner import PlannerAgent
+        assert PlannerAgent().format_itinerary([]) == ""
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 4. PlanExecutor — sequential execution
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestPlanExecutor:
+    """PlanExecutor.run executes steps and tracks results."""
+
+    @pytest.mark.asyncio
+    async def test_executes_two_steps_sequentially(self):
+        """Two independent steps both succeed → summary says 2/2."""
+        from bantz.agent.planner import PlanStep
+        from bantz.agent.executor import PlanExecutor
+
+        steps = [
+            PlanStep(step=1, tool="weather", params={"city": "London"},
+                     description="Check London weather"),
+            PlanStep(step=2, tool="news", params={"source": "all"},
+                     description="Get headlines"),
+        ]
+
+        mock_weather = AsyncMock(return_value=ToolResult(
+            success=True, output="London: 15°C, cloudy"))
+        mock_news = AsyncMock(return_value=ToolResult(
+            success=True, output="Top stories: AI, Tech"))
+
+        executor = PlanExecutor()
+        with patch("bantz.agent.executor.registry") as mock_reg:
+            def _get(name):
+                tools = {
+                    "weather": MagicMock(execute=mock_weather),
+                    "news": MagicMock(execute=mock_news),
+                }
+                return tools.get(name)
+            mock_reg.get = _get
+
+            result = await executor.run(steps)
+
+        assert result.all_success is True
+        assert result.succeeded == 2
+        assert result.total == 2
+        assert "2" in result.summary()
+
+    @pytest.mark.asyncio
+    async def test_handles_step_failure_gracefully(self):
+        """One step fails → execution continues, summary shows partial."""
+        from bantz.agent.planner import PlanStep
+        from bantz.agent.executor import PlanExecutor
+
+        steps = [
+            PlanStep(step=1, tool="web_search",
+                     params={"query": "test"}, description="Search"),
+            PlanStep(step=2, tool="weather",
+                     params={"city": "Paris"}, description="Weather"),
+        ]
+
+        mock_search = AsyncMock(return_value=ToolResult(
+            success=False, output="", error="Connection timeout"))
+        mock_weather = AsyncMock(return_value=ToolResult(
+            success=True, output="Paris: 20°C"))
+
+        executor = PlanExecutor()
+        with patch("bantz.agent.executor.registry") as mock_reg:
+            def _get(name):
+                tools = {
+                    "web_search": MagicMock(execute=mock_search),
+                    "weather": MagicMock(execute=mock_weather),
+                }
+                return tools.get(name)
+            mock_reg.get = _get
+
+            result = await executor.run(steps)
+
+        assert result.succeeded == 1
+        assert result.total == 2
+        assert result.all_success is False
+        assert "1 of 2" in result.summary()
+
+    @pytest.mark.asyncio
+    async def test_unknown_tool_doesnt_crash(self):
+        """Step references unknown tool → noted as failure, doesn't crash."""
+        from bantz.agent.planner import PlanStep
+        from bantz.agent.executor import PlanExecutor
+
+        steps = [
+            PlanStep(step=1, tool="nonexistent", params={},
+                     description="Do something"),
+        ]
+
+        executor = PlanExecutor()
+        with patch("bantz.agent.executor.registry") as mock_reg:
+            mock_reg.get = MagicMock(return_value=None)
+            result = await executor.run(steps)
+
+        assert result.succeeded == 0
+        assert result.total == 1
+        assert "not found" in result.step_results[0].error
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 5. PlanExecutor — context passing between steps
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestContextPassing:
+    """Output from step N must be available to step N+1 when depends_on."""
+
+    @pytest.mark.asyncio
+    async def test_step2_receives_step1_output(self):
+        """Step 2 depends on step 1 → step 1 output injected into step 2 params."""
+        from bantz.agent.planner import PlanStep
+        from bantz.agent.executor import PlanExecutor
+
+        search_output = "Article: Quantum computing is the future of..."
+
+        steps = [
+            PlanStep(step=1, tool="web_search",
+                     params={"query": "quantum computing"},
+                     description="Search"),
+            PlanStep(step=2, tool="filesystem",
+                     params={"action": "write", "path": "~/Desktop/q.txt",
+                             "content": "{step_1_output}"},
+                     description="Save results", depends_on=1),
+        ]
+
+        captured_params: dict = {}
+
+        async def mock_fs_execute(**kwargs):
+            captured_params.update(kwargs)
+            return ToolResult(success=True, output="File written")
+
+        mock_search = AsyncMock(return_value=ToolResult(
+            success=True, output=search_output))
+        mock_fs = MagicMock()
+        mock_fs.execute = mock_fs_execute
+
+        executor = PlanExecutor()
+        with patch("bantz.agent.executor.registry") as mock_reg:
+            def _get(name):
+                tools = {"web_search": MagicMock(execute=mock_search),
+                         "filesystem": mock_fs}
+                return tools.get(name)
+            mock_reg.get = _get
+
+            result = await executor.run(steps)
+
+        assert result.all_success is True
+        # The content should have been replaced with step 1 output
+        assert "quantum computing" in captured_params.get("content", "").lower()
+
+    @pytest.mark.asyncio
+    async def test_independent_steps_no_context_leak(self):
+        """Steps without depends_on don't get injected context."""
+        from bantz.agent.planner import PlanStep
+        from bantz.agent.executor import PlanExecutor
+
+        steps = [
+            PlanStep(step=1, tool="weather",
+                     params={"city": "Tokyo"}, description="Weather"),
+            PlanStep(step=2, tool="news",
+                     params={"source": "hn"}, description="News"),
+        ]
+
+        captured: list[dict] = []
+
+        async def mock_execute(**kwargs):
+            captured.append(dict(kwargs))
+            return ToolResult(success=True, output="OK")
+
+        executor = PlanExecutor()
+        with patch("bantz.agent.executor.registry") as mock_reg:
+            mock_tool = MagicMock()
+            mock_tool.execute = mock_execute
+            mock_reg.get = MagicMock(return_value=mock_tool)
+
+            result = await executor.run(steps)
+
+        # Step 2 params should NOT have step 1 output injected
+        assert "content" not in captured[1]  # news has no content key
+
+    @pytest.mark.asyncio
+    async def test_inject_context_replaces_placeholder(self):
+        """_inject_context replaces {step_N_output} placeholders in params."""
+        from bantz.agent.executor import PlanExecutor
+
+        params = {"content": "{step_1_output}", "path": "~/file.txt"}
+        result = PlanExecutor._inject_context(params, "Hello World")
+        assert result["content"] == "Hello World"
+        assert result["path"] == "~/file.txt"  # unchanged
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 6. PlanExecutor — result summary formatting
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestExecutionSummary:
+    """PlanExecutionResult.summary must produce butler-style summaries."""
+
+    def test_all_success_summary(self):
+        from bantz.agent.executor import PlanExecutionResult, StepResult
+
+        result = PlanExecutionResult(step_results=[
+            StepResult(step_number=1, tool="weather", description="Check weather",
+                       success=True, output="London: 15°C"),
+            StepResult(step_number=2, tool="news", description="Get news",
+                       success=True, output="Headlines here"),
+        ])
+        s = result.summary()
+        assert "all 2 tasks completed" in s.lower()
+        assert "✓" in s
+
+    def test_partial_failure_summary(self):
+        from bantz.agent.executor import PlanExecutionResult, StepResult
+
+        result = PlanExecutionResult(step_results=[
+            StepResult(step_number=1, tool="web_search", description="Search",
+                       success=True, output="Results"),
+            StepResult(step_number=2, tool="filesystem", description="Save",
+                       success=False, output="", error="Permission denied"),
+        ])
+        s = result.summary()
+        assert "1 of 2" in s
+        assert "✗" in s
+
+    def test_empty_result(self):
+        from bantz.agent.executor import PlanExecutionResult
+
+        result = PlanExecutionResult()
+        assert "empty" in result.summary().lower()
+
+    def test_all_failed_summary(self):
+        from bantz.agent.executor import PlanExecutionResult, StepResult
+
+        result = PlanExecutionResult(step_results=[
+            StepResult(step_number=1, tool="web_search", description="Search",
+                       success=False, output="", error="Timeout"),
+        ])
+        s = result.summary()
+        assert "difficulties" in s.lower() or "regret" in s.lower()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 7. Brain integration — _execute_plan routing
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestBrainPlannerIntegration:
+    """Brain.process routes complex requests to the planner."""
+
+    @pytest.mark.asyncio
+    async def test_complex_request_uses_planner(self):
+        """Multi-tool request triggers planner path."""
+        from bantz.agent.planner import PlanStep
+
+        plan_steps = [
+            PlanStep(step=1, tool="web_search",
+                     params={"query": "AI news"}, description="Search"),
+            PlanStep(step=2, tool="filesystem",
+                     params={"action": "write", "path": "~/Desktop/ai.txt",
+                             "content": "{step_1_output}"},
+                     description="Save to file", depends_on=1),
+        ]
+
+        from bantz.agent.executor import PlanExecutionResult, StepResult
+        exec_result = PlanExecutionResult(step_results=[
+            StepResult(step_number=1, tool="web_search",
+                       description="Search", success=True, output="AI stuff"),
+            StepResult(step_number=2, tool="filesystem",
+                       description="Save to file", success=True,
+                       output="File written"),
+        ])
+
+        with patch("bantz.agent.planner.planner_agent") as mock_planner, \
+             patch("bantz.agent.executor.plan_executor") as mock_executor, \
+             patch("bantz.core.brain.data_layer") as mock_dal, \
+             patch("bantz.core.brain.ollama") as mock_ollama, \
+             patch("bantz.core.brain.cot_route") as mock_cot:
+
+            mock_planner.is_complex = MagicMock(return_value=True)
+            mock_planner.decompose = AsyncMock(return_value=plan_steps)
+            mock_planner.format_itinerary = MagicMock(
+                return_value="Allow me a moment...\n1. Search\n2. Save")
+            mock_executor.run = AsyncMock(return_value=exec_result)
+            mock_dal.conversations = MagicMock()
+            mock_dal.init = MagicMock()
+            mock_ollama.chat = AsyncMock(return_value="")
+
+            from bantz.core.brain import Brain
+            brain = Brain.__new__(Brain)
+            brain._memory_ready = True
+            brain._graph_ready = True
+            brain._feedback_ctx = ""
+            brain._last_messages = []
+            brain._last_events = []
+            brain._last_draft = None
+            brain._is_remote = False
+            brain._bridge = None
+            brain._to_en = AsyncMock(return_value="search for AI news and save to a file")
+            brain._graph_store = AsyncMock()
+            brain._fire_embeddings = MagicMock()
+
+            # Mock workflow_engine to not detect anything
+            with patch("bantz.core.workflow.workflow_engine") as mock_wf:
+                mock_wf.detect = MagicMock(return_value=None)
+
+                result = await brain.process(
+                    "search for AI news and save to a file")
+
+            assert result.tool_used == "planner"
+            assert "allow me a moment" in result.response.lower()
+            assert "completed successfully" in result.response.lower()
+
+    @pytest.mark.asyncio
+    async def test_simple_request_bypasses_planner(self):
+        """Simple single-tool request should NOT trigger planner."""
+        from bantz.agent.planner import PlannerAgent
+
+        agent = PlannerAgent()
+        assert agent.is_complex("what is the weather in istanbul") is False
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 8. PLANNER_SYSTEM prompt validation
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestPlannerPrompt:
+    """The planner system prompt must contain required elements."""
+
+    def test_prompt_mentions_butler(self):
+        from bantz.agent.planner import PLANNER_SYSTEM
+        assert "butler" in PLANNER_SYSTEM.lower()
+
+    def test_prompt_mentions_json(self):
+        from bantz.agent.planner import PLANNER_SYSTEM
+        assert "JSON" in PLANNER_SYSTEM
+
+    def test_prompt_has_tool_reference(self):
+        from bantz.agent.planner import PLANNER_SYSTEM
+        assert "web_search" in PLANNER_SYSTEM
+        assert "filesystem" in PLANNER_SYSTEM
+        assert "gmail" in PLANNER_SYSTEM
+
+    def test_prompt_has_depends_on(self):
+        from bantz.agent.planner import PLANNER_SYSTEM
+        assert "depends_on" in PLANNER_SYSTEM
+
+    def test_prompt_has_examples(self):
+        from bantz.agent.planner import PLANNER_SYSTEM
+        assert "quantum computing" in PLANNER_SYSTEM.lower()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 9. PlanStep parsing edge cases
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestPlanStepParsing:
+    """Edge cases in _parse_steps."""
+
+    def test_parse_valid_array(self):
+        from bantz.agent.planner import PlannerAgent
+        data = PlannerAgent._parse_steps(
+            '[{"step": 1, "tool": "weather", "params": {"city": "X"}, "description": "Y", "depends_on": null}]'
+        )
+        assert len(data) == 1
+        assert data[0]["tool"] == "weather"
+
+    def test_parse_strips_fences(self):
+        from bantz.agent.planner import PlannerAgent
+        data = PlannerAgent._parse_steps(
+            '```json\n[{"step": 1, "tool": "a", "params": {}, "description": "", "depends_on": null}]\n```'
+        )
+        assert len(data) == 1
+
+    def test_parse_rejects_non_array(self):
+        from bantz.agent.planner import PlannerAgent
+        with pytest.raises(ValueError, match="Expected JSON array"):
+            PlannerAgent._parse_steps('{"not": "an array"}')
+
+    def test_parse_rejects_empty_array(self):
+        from bantz.agent.planner import PlannerAgent
+        with pytest.raises(ValueError, match="Empty"):
+            PlannerAgent._parse_steps('[]')
+
+    def test_parse_rejects_garbage(self):
+        from bantz.agent.planner import PlannerAgent
+        with pytest.raises(Exception):
+            PlannerAgent._parse_steps("I'm just a butler, I can't do that.")


### PR DESCRIPTION
## Issue #187: The Butler's Itinerary

Gives Bantz true autonomous agent capabilities for complex multi-step commands.

**Before**: 'Search for AI articles and save to a file' → single tool attempt → hallucinated or partial result.
**After**: Structured plan → sequential execution → context passed between steps.

### Architecture

```
User: 'Find articles about AI and save them to a file in Research folder'
  ↓ is_complex() → True (web_search + filesystem keywords + sequence marker)
  ↓ decompose() → LLM generates JSON step array
  ↓ format_itinerary() → Butler announces plan to user
  ↓ executor.run() → Steps execute sequentially, context flows
  ✓ Combined itinerary + execution summary returned

Plan announcement:
  'Allow me a moment to draft an itinerary for this endeavor.
   Here is my plan:
     1. Search for AI articles
     2. Save the results to a file (using results from step 1)
   Commencing forthwith.'
```

### New Modules

**agent/planner.py** — PlannerAgent (LLM decomposition)
- `PLANNER_SYSTEM`: Butler-persona prompt enforcing valid JSON output
- `is_complex()`: Heuristic — sequence markers + 2+ distinct tool categories
- `decompose()`: Ollama call → JSON array of PlanSteps (with retry)
- `format_itinerary()`: Butler-style plan announcement

**agent/executor.py** — PlanExecutor (sequential runner)
- Context threading: step N output → step N+1 via `depends_on`
- `_inject_context()`: Replaces `{step_N_output}` placeholders in params
- Graceful failure: failed steps noted, execution continues
- `PlanExecutionResult.summary()`: Butler-style completion report

### Brain Integration
- `process()`: After workflow_engine (regex splits), checks `planner_agent.is_complex()`
- `_execute_plan()`: decompose → announce → execute → combine results
- Falls through to normal routing if decomposition fails or returns <2 steps

### Layered Multi-Step Handling
1. **workflow_engine** (existing): Regex-based sentence splitting for simple chains
2. **planner_agent** (new): LLM-based decomposition for complex natural language
3. **cot_route** (existing): Single-tool intent classification (fallback)

### Tests: 39 new (2261 total, 0 failures)
- Complexity detection heuristics (9 cases)
- LLM decomposition with mocked Ollama (5 cases)
- Itinerary formatting / persona (3 cases)
- Sequential execution (3 cases)
- Context passing between steps (3 cases)
- Result summary formatting (4 cases)
- Brain integration (2 cases)
- Prompt validation (5 cases)
- Parse edge cases (5 cases)