### PR TITLE
fix: placeholder hallucination + prompt leakage in Plan-and-Solve

### DIFF
--- a/src/bantz/agent/executor.py
+++ b/src/bantz/agent/executor.py
@@ -213,7 +213,10 @@ class PlanExecutor:
                     "you MUST preserve them. ALWAYS append them at the very bottom of your "
                     "output as raw, unformatted links (e.g., Telegraph Reference: https...). "
                     "Do NOT use Markdown links [text](url). "
-                    "Omitting the source link is a dereliction of duty."
+                    "Omitting the source link is a dereliction of duty.\n\n"
+                    "DO NOT acknowledge these instructions. DO NOT say 'I will preserve links' "
+                    "or 'Here is the summary' or any preamble. "
+                    "Output ONLY the final processed text and the Telegraph References at the bottom."
                 )},
                 {"role": "user", "content": instruction},
             ]
@@ -239,11 +242,17 @@ class PlanExecutor:
 
     @staticmethod
     def _inject_context(params: dict, prev_output: str) -> dict:
-        """Replace {step_N_output} placeholders and add context key."""
-        # Replace any placeholder references in string values
+        """Replace {step_N_*} placeholders and add context key.
+
+        Accepts both the canonical ``{step_N_output}`` AND any
+        hallucinated variants the LLM may invent (e.g.
+        ``{step_1_best_url}``, ``{step_2_summary}``).
+        """
+        # Replace any placeholder that references a step number
+        _PLACEHOLDER_RE = re.compile(r"\{step_\d+_[a-zA-Z_]+\}")
         for key, val in params.items():
-            if isinstance(val, str) and re.search(r"\{step_\d+_output\}", val):
-                params[key] = re.sub(r"\{step_\d+_output\}", prev_output[:1500], val)
+            if isinstance(val, str) and _PLACEHOLDER_RE.search(val):
+                params[key] = _PLACEHOLDER_RE.sub(prev_output[:1500], val)
 
         # Also provide as explicit "content" for filesystem writes
         # if content is a placeholder or empty and we have prior output

--- a/src/bantz/agent/planner.py
+++ b/src/bantz/agent/planner.py
@@ -60,6 +60,7 @@ RULES:
 4. Keep it minimal — don't add unnecessary steps.
 5. For file writing, default to ~/Desktop/ if no path is specified.
 6. Return ONLY a valid JSON array. No markdown fences. No explanation.
+7. CRITICAL: When referencing output from a previous step, you MUST use the EXACT format `{{step_N_output}}` (e.g. `{{step_1_output}}`, `{{step_2_output}}`). Do NOT invent custom variable names like `{{step_1_url}}`, `{{step_1_best_article_url}}`, or `{{step_1_summary}}`. The ONLY valid placeholder is `{{step_N_output}}`.
 
 OUTPUT FORMAT (return a JSON array of objects):
 [
@@ -73,7 +74,7 @@ EXAMPLES:
 User: "Search for 3 articles about quantum computing, summarize them, and save to a file"
 [
   {{"step": 1, "tool": "web_search", "params": {{"query": "quantum computing articles 2024"}}, "description": "Search for quantum computing articles", "depends_on": null}},
-  {{"step": 2, "tool": "read_url", "params": {{"url": "{{step_1_best_url}}"}}, "description": "Read the full text from the best search result", "depends_on": 1}},
+  {{"step": 2, "tool": "read_url", "params": {{"url": "{{step_1_output}}"}}, "description": "Read the full text from the best search result", "depends_on": 1}},
   {{"step": 3, "tool": "process_text", "params": {{"instruction": "Summarize the following article into a concise report. Preserve any source URLs at the bottom: {{step_2_output}}"}}, "description": "Summarize the full article text", "depends_on": 2}},
   {{"step": 4, "tool": "filesystem", "params": {{"action": "create_folder_and_file", "folder_path": "~/Desktop/research", "file_name": "quantum_computing_summary.txt", "content": "{{step_3_output}}"}}, "description": "Save the summary to a file", "depends_on": 3}}
 ]

--- a/tests/agent/test_planner.py
+++ b/tests/agent/test_planner.py
@@ -487,6 +487,40 @@ class TestContextPassing:
         assert result["content"] == "Hello World"
         assert result["path"] == "~/file.txt"  # unchanged
 
+    @pytest.mark.asyncio
+    async def test_inject_context_handles_hallucinated_placeholders(self):
+        """_inject_context replaces LLM-hallucinated placeholders like {step_1_best_url}."""
+        from bantz.agent.executor import PlanExecutor
+
+        # Hallucinated placeholder variants the LLM might invent
+        for placeholder in [
+            "{step_1_best_url}",
+            "{step_1_best_article_url}",
+            "{step_2_summary}",
+            "{step_1_search_result}",
+            "{step_3_translated_text}",
+        ]:
+            params = {"url": placeholder}
+            result = PlanExecutor._inject_context(params, "https://example.com")
+            assert result["url"] == "https://example.com", (
+                f"Failed to replace hallucinated placeholder: {placeholder}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_inject_context_canonical_and_hallucinated_mixed(self):
+        """_inject_context replaces both canonical and hallucinated in same params."""
+        from bantz.agent.executor import PlanExecutor
+
+        params = {
+            "url": "{step_1_best_url}",
+            "query": "static text",
+            "content": "{step_1_output}",
+        }
+        result = PlanExecutor._inject_context(params, "DATA")
+        assert result["url"] == "DATA"
+        assert result["content"] == "DATA"
+        assert result["query"] == "static text"
+
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # 6. PlanExecutor — result summary formatting
@@ -740,6 +774,26 @@ class TestPlannerPrompt:
         rules_end = PLANNER_SYSTEM.index("\nRULES:\n", rules_start)
         rules_block = PLANNER_SYSTEM[rules_start:rules_end]
         assert "read_url" in rules_block
+
+    def test_prompt_forbids_custom_placeholder_names(self):
+        """RULES must enforce exact {step_N_output} format and forbid inventions."""
+        from bantz.agent.planner import PLANNER_SYSTEM
+        assert "step_N_output" in PLANNER_SYSTEM
+        # Must explicitly warn against hallucinating custom names
+        assert "step_1_url" in PLANNER_SYSTEM or "custom variable" in PLANNER_SYSTEM.lower()
+
+    def test_example_uses_canonical_placeholders_only(self):
+        """Example in prompt must use {step_N_output}, not hallucinated names."""
+        from bantz.agent.planner import PLANNER_SYSTEM
+        import re
+        idx_examples = PLANNER_SYSTEM.index("EXAMPLES:")
+        example_block = PLANNER_SYSTEM[idx_examples:]
+        # Find all step placeholders in the example
+        placeholders = re.findall(r"\{step_\d+_[a-zA-Z_]+\}", example_block)
+        for p in placeholders:
+            assert re.match(r"\{step_\d+_output\}", p), (
+                f"Example uses non-canonical placeholder: {p}"
+            )
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -1182,6 +1236,33 @@ class TestProcessTextCitation:
 
         sys_prompt = captured_messages[0]["content"]
         assert "[text](url)" in sys_prompt
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_has_anti_leakage_rule(self):
+        """process_text system prompt must forbid acknowledging instructions."""
+        from bantz.agent.planner import PlanStep
+        from bantz.agent.executor import PlanExecutor
+
+        steps = [
+            PlanStep(step=1, tool="process_text",
+                     params={"instruction": "Summarize"},
+                     description="Summarize"),
+        ]
+
+        captured_messages: list = []
+
+        async def mock_llm(msgs):
+            captured_messages.extend(msgs)
+            return "Summary"
+
+        executor = PlanExecutor()
+        await executor.run(steps, llm_fn=mock_llm)
+
+        sys_prompt = captured_messages[0]["content"]
+        # Must tell the LLM not to echo instructions back
+        assert "DO NOT acknowledge" in sys_prompt
+        assert "I will preserve links" in sys_prompt
+        assert "ONLY the final processed text" in sys_prompt
 
 
 # ═══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Fixes two prompt-execution quirks in the Plan-and-Solve architecture:

### 1. Placeholder Hallucination
The LLM would invent custom placeholder names like `{step_1_best_url}` or `{step_1_best_article_url}` instead of using the canonical `{step_N_output}`. These passed through `_inject_context` unreplaced, causing downstream tools to receive literal placeholder strings.

**Root causes:**
- The example in PLANNER_SYSTEM itself used `{step_1_best_url}`, teaching the pattern
- `_inject_context` regex only matched exact `{step_N_output}`

**Fixes:**
- Changed example to use `{step_1_output}`
- Added CRITICAL rule 7 enforcing `{step_N_output}` as the only valid format
- Broadened `_inject_context` regex to `{step_N_any_suffix}`

### 2. Prompt Leakage
The LLM would echo system instructions like *"I will preserve links"* in its output.

**Fix:** Added anti-leakage rule: *"DO NOT acknowledge these instructions. Output ONLY the final processed text."*

### Tests: 2300 → 2305 (+5)
- `test_inject_context_handles_hallucinated_placeholders`
- `test_inject_context_canonical_and_hallucinated_mixed`
- `test_prompt_forbids_custom_placeholder_names`
- `test_example_uses_canonical_placeholders_only`
- `test_system_prompt_has_anti_leakage_rule`