### PR TITLE
fix: planner tool-chaining best practices + clearer example

### DIFF
--- a/src/bantz/agent/planner.py
+++ b/src/bantz/agent/planner.py
@@ -53,6 +53,11 @@ CRITICAL TOOL RULES:
 - If a step requires summarizing, analyzing, or modifying text from a previous step, you MUST use the `process_text` tool. Put your exact instructions (e.g., "Summarize the following: {{step_1_output}}") in the "instruction" param.
 - When the user wants a THOROUGH research report (not just snippets), use `web_search` first, then `read_url` to fetch the full article text from the best URL, then `process_text` to summarize.
 
+TOOL USAGE BEST PRACTICES:
+- For `web_search`: Keep queries SHORT and broad (e.g., "Google quantum computer study", NOT "Search for the article titled Google Quantum Computer Makes Breakthrough in Quantum Error Correction"). The search engine works best with concise keywords.
+- For `read_url`: The parameter MUST be a valid HTTP/HTTPS URL. Do NOT pass natural language or search queries to this tool. You get this URL from `{{step_N_output}}` of a previous `web_search` step.
+- Keep plans as SHORT as possible. A complete deep reading workflow should only be 3 or 4 steps: `web_search` -> `read_url` -> `process_text` -> `filesystem`.
+
 RULES:
 1. Each step must use exactly ONE tool.
 2. Steps execute in order. Later steps can reference output of earlier steps.
@@ -71,10 +76,10 @@ OUTPUT FORMAT (return a JSON array of objects):
 
 EXAMPLES:
 
-User: "Search for 3 articles about quantum computing, summarize them, and save to a file"
+User: "Search for articles about quantum computing, summarize the best one, and save to a file"
 [
-  {{"step": 1, "tool": "web_search", "params": {{"query": "quantum computing articles 2024"}}, "description": "Search for quantum computing articles", "depends_on": null}},
-  {{"step": 2, "tool": "read_url", "params": {{"url": "{{step_1_output}}"}}, "description": "Read the full text from the best search result", "depends_on": 1}},
+  {{"step": 1, "tool": "web_search", "params": {{"query": "quantum computing breakthroughs"}}, "description": "Search for quantum computing articles (returns a list of URLs)", "depends_on": null}},
+  {{"step": 2, "tool": "read_url", "params": {{"url": "{{step_1_output}}"}}, "description": "Fetch the full article text from the URL returned by web_search", "depends_on": 1}},
   {{"step": 3, "tool": "process_text", "params": {{"instruction": "Summarize the following article into a concise report. Preserve any source URLs at the bottom: {{step_2_output}}"}}, "description": "Summarize the full article text", "depends_on": 2}},
   {{"step": 4, "tool": "filesystem", "params": {{"action": "create_folder_and_file", "folder_path": "~/Desktop/research", "file_name": "quantum_computing_summary.txt", "content": "{{step_3_output}}"}}, "description": "Save the summary to a file", "depends_on": 3}}
 ]

--- a/tests/agent/test_planner.py
+++ b/tests/agent/test_planner.py
@@ -795,6 +795,44 @@ class TestPlannerPrompt:
                 f"Example uses non-canonical placeholder: {p}"
             )
 
+    def test_prompt_has_tool_usage_best_practices(self):
+        """Prompt must contain TOOL USAGE BEST PRACTICES section."""
+        from bantz.agent.planner import PLANNER_SYSTEM
+        assert "TOOL USAGE BEST PRACTICES" in PLANNER_SYSTEM
+
+    def test_best_practices_web_search_short_queries(self):
+        """Best practices must instruct short/broad web_search queries."""
+        from bantz.agent.planner import PLANNER_SYSTEM
+        idx = PLANNER_SYSTEM.index("TOOL USAGE BEST PRACTICES")
+        block = PLANNER_SYSTEM[idx:]
+        assert "web_search" in block
+        assert "SHORT" in block or "short" in block
+        assert "broad" in block.lower()
+
+    def test_best_practices_read_url_requires_http(self):
+        """Best practices must state read_url needs a valid HTTP/HTTPS URL."""
+        from bantz.agent.planner import PLANNER_SYSTEM
+        idx = PLANNER_SYSTEM.index("TOOL USAGE BEST PRACTICES")
+        block = PLANNER_SYSTEM[idx:]
+        assert "read_url" in block
+        assert "HTTP" in block or "http" in block.lower()
+        assert "natural language" in block.lower() or "Do NOT pass" in block
+
+    def test_best_practices_short_plans(self):
+        """Best practices must recommend 3-4 step deep reading workflow."""
+        from bantz.agent.planner import PLANNER_SYSTEM
+        idx = PLANNER_SYSTEM.index("TOOL USAGE BEST PRACTICES")
+        block = PLANNER_SYSTEM[idx:]
+        assert "3 or 4 steps" in block or "3 or 4" in block
+
+    def test_example_shows_url_data_flow(self):
+        """Example description must show that read_url receives URL from web_search."""
+        from bantz.agent.planner import PLANNER_SYSTEM
+        idx = PLANNER_SYSTEM.index("EXAMPLES:")
+        block = PLANNER_SYSTEM[idx:]
+        # read_url description should mention it gets URL from a previous step
+        assert "URL returned" in block or "url returned" in block.lower()
+
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # 9. PlanStep parsing edge cases


### PR DESCRIPTION
## Summary

Fixes incorrect tool chaining where the LLM passes natural language into `read_url` parameters and writes overly specific `web_search` queries.

### Changes to `PLANNER_SYSTEM`

**New section — TOOL USAGE BEST PRACTICES:**
- **`web_search`**: Keep queries SHORT and broad (keywords, not full sentences). E.g. `"Google quantum computer study"` not `"Search for the article titled Google Quantum Computer Makes Breakthrough..."`
- **`read_url`**: Parameter MUST be a valid HTTP/HTTPS URL. Do NOT pass natural language — get the URL from `{step_N_output}` of a previous `web_search` step.
- **Plan length**: Keep to 3-4 steps max for deep reading workflows (`web_search` → `read_url` → `process_text` → `filesystem`).

**Updated example:**
- Shorter, broader query: `"quantum computing breakthroughs"`
- Descriptions now explicitly show data flow: *"returns a list of URLs"*, *"Fetch the full article text from the URL returned by web_search"*

### Tests: 2305 → 2310 (+5)
- `test_prompt_has_tool_usage_best_practices`
- `test_best_practices_web_search_short_queries`
- `test_best_practices_read_url_requires_http`
- `test_best_practices_short_plans`
- `test_example_shows_url_data_flow`