### PR TITLE
fix: forbid news tool for research + clarify tool-chaining pipeline

### DIFF
--- a/src/bantz/agent/planner.py
+++ b/src/bantz/agent/planner.py
@@ -52,6 +52,9 @@ CRITICAL TOOL RULES:
 - NEVER use `web_search` or `news` to summarize, rewrite, translate, or analyze text. Those tools are STRICTLY for fetching new external information.
 - If a step requires summarizing, analyzing, or modifying text from a previous step, you MUST use the `process_text` tool. Put your exact instructions (e.g., "Summarize the following: {{step_1_output}}") in the "instruction" param.
 - When the user wants a THOROUGH research report (not just snippets), use `web_search` first, then `read_url` to fetch the full article text from the best URL, then `process_text` to summarize.
+- NEVER use the `news` tool for specific research, reading full articles, or when you need a URL. The `news` tool provides a text-only summary of today's headlines without source links. It is ONLY for general "What's in the news today?" questions.
+- For finding specific articles, news, or topics to read, you MUST use `web_search`. `web_search` returns the raw URLs required for the `read_url` tool.
+- Do NOT invent intermediate steps like "Extract URL from results". Just pass `{{step_N_output}}` from `web_search` directly to `read_url` — the executor handles extraction automatically.
 
 TOOL USAGE BEST PRACTICES:
 - For `web_search`: Keep queries SHORT and broad (e.g., "Google quantum computer study", NOT "Search for the article titled Google Quantum Computer Makes Breakthrough in Quantum Error Correction"). The search engine works best with concise keywords.
@@ -78,9 +81,9 @@ EXAMPLES:
 
 User: "Search for articles about quantum computing, summarize the best one, and save to a file"
 [
-  {{"step": 1, "tool": "web_search", "params": {{"query": "quantum computing breakthroughs"}}, "description": "Search for quantum computing articles (returns a list of URLs)", "depends_on": null}},
-  {{"step": 2, "tool": "read_url", "params": {{"url": "{{step_1_output}}"}}, "description": "Fetch the full article text from the URL returned by web_search", "depends_on": 1}},
-  {{"step": 3, "tool": "process_text", "params": {{"instruction": "Summarize the following article into a concise report. Preserve any source URLs at the bottom: {{step_2_output}}"}}, "description": "Summarize the full article text", "depends_on": 2}},
+  {{"step": 1, "tool": "web_search", "params": {{"query": "quantum computing breakthrough"}}, "description": "Search for quantum computing articles — returns a list of URLs", "depends_on": null}},
+  {{"step": 2, "tool": "read_url", "params": {{"url": "{{step_1_output}}"}}, "description": "Read the full article from the URL returned by step 1", "depends_on": 1}},
+  {{"step": 3, "tool": "process_text", "params": {{"instruction": "Summarize this article in detail, preserving source URLs at the bottom: {{step_2_output}}"}}, "description": "Summarize the article text from step 2", "depends_on": 2}},
   {{"step": 4, "tool": "filesystem", "params": {{"action": "create_folder_and_file", "folder_path": "~/Desktop/research", "file_name": "quantum_computing_summary.txt", "content": "{{step_3_output}}"}}, "description": "Save the summary to a file", "depends_on": 3}}
 ]
 

--- a/tests/agent/test_planner.py
+++ b/tests/agent/test_planner.py
@@ -833,6 +833,48 @@ class TestPlannerPrompt:
         # read_url description should mention it gets URL from a previous step
         assert "URL returned" in block or "url returned" in block.lower()
 
+    def test_news_tool_forbidden_for_research(self):
+        """CRITICAL TOOL RULES must forbid news tool for specific research."""
+        from bantz.agent.planner import PLANNER_SYSTEM
+        rules_start = PLANNER_SYSTEM.index("CRITICAL TOOL RULES")
+        rules_end = PLANNER_SYSTEM.index("\nTOOL USAGE BEST PRACTICES", rules_start)
+        rules_block = PLANNER_SYSTEM[rules_start:rules_end]
+        assert "news" in rules_block
+        assert "text-only" in rules_block.lower() or "without source links" in rules_block.lower()
+
+    def test_web_search_required_for_articles(self):
+        """CRITICAL TOOL RULES must mandate web_search for article finding."""
+        from bantz.agent.planner import PLANNER_SYSTEM
+        rules_start = PLANNER_SYSTEM.index("CRITICAL TOOL RULES")
+        rules_end = PLANNER_SYSTEM.index("\nTOOL USAGE BEST PRACTICES", rules_start)
+        rules_block = PLANNER_SYSTEM[rules_start:rules_end]
+        assert "web_search" in rules_block
+        assert "raw URLs" in rules_block or "URLs required" in rules_block
+
+    def test_no_invented_intermediate_steps(self):
+        """CRITICAL TOOL RULES must forbid inventing 'Extract URL' steps."""
+        from bantz.agent.planner import PLANNER_SYSTEM
+        rules_start = PLANNER_SYSTEM.index("CRITICAL TOOL RULES")
+        rules_end = PLANNER_SYSTEM.index("\nTOOL USAGE BEST PRACTICES", rules_start)
+        rules_block = PLANNER_SYSTEM[rules_start:rules_end]
+        assert "Extract URL" in rules_block or "intermediate steps" in rules_block.lower()
+
+    def test_example_step1_uses_web_search(self):
+        """Example step 1 must use web_search with a concise query."""
+        from bantz.agent.planner import PLANNER_SYSTEM
+        idx = PLANNER_SYSTEM.index("EXAMPLES:")
+        block = PLANNER_SYSTEM[idx:]
+        assert '"tool": "web_search"' in block
+        assert "quantum computing breakthrough" in block.lower()
+
+    def test_example_step3_uses_process_text(self):
+        """Example step 3 must use process_text referencing step_2_output."""
+        from bantz.agent.planner import PLANNER_SYSTEM
+        idx = PLANNER_SYSTEM.index("EXAMPLES:")
+        block = PLANNER_SYSTEM[idx:]
+        assert '"tool": "process_text"' in block
+        assert "step_2_output" in block
+
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # 9. PlanStep parsing edge cases


### PR DESCRIPTION
## Summary

Fixes the pipeline failure where Bantz uses the `news` tool for research tasks, gets text-only headlines (no URLs), then `read_url` and `process_text` cascade-fail because there's nothing to read.

### Problem
1. **Wrong tool**: User says "find me articles about X" → planner picks `news` instead of `web_search`. The `news` tool returns text-only headlines with no source links.
2. **Cascading failure**: Step 2 (`read_url`) receives plain text instead of a URL → fails. Step 3 (`process_text`) has nothing to summarize → produces a hallucinated apology.

### Fix — 3 new CRITICAL TOOL RULES

| Rule | Purpose |
|------|---------|
| `news` is FORBIDDEN for specific research | It only provides text summaries without URLs — only valid for "What's in the news today?" |
| `web_search` is MANDATORY for article finding | It returns the raw URLs that `read_url` needs |
| No invented intermediate steps | Don't add "Extract URL" steps — pass `{step_N_output}` directly from `web_search` to `read_url` |

### Example Updated
Step 1: `web_search` (query: `"quantum computing breakthrough"`)
Step 2: `read_url` (url: `{step_1_output}`)
Step 3: `process_text` (instruction: summarize `{step_2_output}`)
Step 4: `filesystem` (content: `{step_3_output}`)

### Tests: 2310 → 2315 (+5)
- `test_news_tool_forbidden_for_research`
- `test_web_search_required_for_articles`
- `test_no_invented_intermediate_steps`
- `test_example_step1_uses_web_search`
- `test_example_step3_uses_process_text`