### PR TITLE
feat(#224): BantzContext dataclass + AsyncDBExecutor

### DIFF
--- a/src/bantz/core/context.py
+++ b/src/bantz/core/context.py
@@ -1,0 +1,124 @@
+"""
+Bantz — BantzContext: request-scoped data carrier (#224)
+
+A plain dataclass that travels through every stage of the brain pipeline
+(translation → routing → tool-execution → finalisation → response).
+
+By **carrying** all intermediate data the context object:
+  - eliminates the need for modules to import each other just to pass data,
+  - breaks the circular-import chains that plague the current God-Object,
+  - gives each future sub-module a clean, typed contract.
+
+This module is intentionally dependency-free — it imports nothing from
+the ``bantz`` package so it can be imported from anywhere without risk.
+
+Closes #224 (Part 1-A of #218).
+"""
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class BantzContext:
+    """Immutable-ish carrier for one request→response cycle.
+
+    Every field has a safe default so callers only need to set the
+    fields relevant to their pipeline stage.  Later stages enrich
+    the same instance as it flows downstream.
+
+    Fields are grouped by pipeline phase — keep this ordering when
+    adding new ones.
+    """
+
+    # ── 1. Input ──────────────────────────────────────────────────────
+    session_id: str = field(default_factory=lambda: uuid.uuid4().hex[:12])
+    user_input: str = ""
+    is_remote: bool = False          # True for Telegram / API callers
+    confirmed: bool = False          # second pass after destructive-confirm
+
+    # ── 2. Translation ────────────────────────────────────────────────
+    en_input: str = ""               # English-translated input (same as user_input when EN)
+    source_lang: str = "en"          # ISO-639-1 code detected by bridge
+
+    # ── 3. Time context ──────────────────────────────────────────────
+    time_context: dict[str, Any] = field(default_factory=dict)
+    # snapshot of time_ctx: {time_segment, day_name, location, prompt_hint, …}
+
+    # ── 4. RLHF / feedback ───────────────────────────────────────────
+    feedback: str | None = None      # "positive" | "negative" | None
+    feedback_hint: str = ""          # one-shot system-prompt injection
+
+    # ── 5. Memory & persona hints ─────────────────────────────────────
+    graph_context: str = ""          # graph memory context string
+    vector_context: str = ""         # semantic-search past messages
+    deep_memory: str = ""            # spontaneous deep memory recall
+    desktop_context: str = ""        # AppDetector workspace snapshot
+    persona_state: str = ""          # persona builder output
+    formality_hint: str = ""         # bonding-meter hint
+    style_hint: str = ""             # response_style + pronoun instruction
+    profile_hint: str = ""           # user profile summary
+
+    # ── 6. Routing / intent ───────────────────────────────────────────
+    route: str = "chat"              # "chat" | "tool"
+    tool_name: str | None = None     # resolved tool name (or internal _tts_stop etc.)
+    tool_args: dict[str, Any] = field(default_factory=dict)
+    risk_level: str = "safe"         # "safe" | "moderate" | "destructive"
+    is_quick_route: bool = False     # True when resolved by regex quick_route
+
+    # ── 7. Execution ──────────────────────────────────────────────────
+    tool_success: bool | None = None # None = not executed yet
+    tool_output: str = ""            # raw ToolResult.output
+    tool_data: dict[str, Any] = field(default_factory=dict)  # ToolResult.data
+
+    # ── 8. Finalisation / response ────────────────────────────────────
+    response: str = ""               # final assistant response text
+    is_streaming: bool = False       # True when response delivered via stream
+    needs_confirm: bool = False      # waiting for destructive-op confirm
+    pending_command: str = ""        # command shown in confirm prompt
+    pending_tool: str = ""           # tool held for confirm
+    pending_args: dict[str, Any] = field(default_factory=dict)
+
+    # ── 9. Timestamps ─────────────────────────────────────────────────
+    created_at: float = field(default_factory=time.time)
+    completed_at: float | None = None
+
+    # ── helpers ───────────────────────────────────────────────────────
+
+    @property
+    def is_tool_call(self) -> bool:
+        """True when routing selected a tool (not plain chat)."""
+        return self.route == "tool" and bool(self.tool_name)
+
+    @property
+    def has_memory(self) -> bool:
+        """True when any memory context was injected."""
+        return bool(self.graph_context or self.vector_context or self.deep_memory)
+
+    @property
+    def elapsed_ms(self) -> float | None:
+        """Wall-clock milliseconds from creation to completion."""
+        if self.completed_at is None:
+            return None
+        return (self.completed_at - self.created_at) * 1000
+
+    def mark_complete(self) -> None:
+        """Stamp ``completed_at`` — call at end of pipeline."""
+        self.completed_at = time.time()
+
+    def as_log_dict(self) -> dict[str, Any]:
+        """Compact dict suitable for structured logging / telemetry."""
+        return {
+            "sid": self.session_id,
+            "input": self.user_input[:80],
+            "lang": self.source_lang,
+            "route": self.route,
+            "tool": self.tool_name,
+            "risk": self.risk_level,
+            "ok": self.tool_success,
+            "stream": self.is_streaming,
+            "ms": round(self.elapsed_ms, 1) if self.elapsed_ms is not None else None,
+        }

--- a/src/bantz/data/async_executor.py
+++ b/src/bantz/data/async_executor.py
@@ -1,0 +1,130 @@
+"""
+Bantz — AsyncDBExecutor: non-blocking DB access for async callers (#224)
+
+Wraps blocking ``SQLitePool.connection()`` calls in a
+``ThreadPoolExecutor`` so that coroutines never stall the
+asyncio event loop.
+
+Architecture notes
+------------------
+* ``max_workers=5`` matches ``SQLitePool``'s 5 pre-created connections.
+  Each worker thread checks out **one** pooled connection, executes the
+  supplied callable, and returns the connection — so the thread count
+  and pool size stay in balance.
+
+* ``run_read`` / ``run_write`` accept a plain ``Callable[[Connection], T]``
+  and return an ``Awaitable[T]``.  The callable runs inside the pool's
+  ``connection()`` context manager on a worker thread.
+
+* Callers do **not** need to touch ``get_pool()`` or manage connections
+  themselves — this executor is the single async bridge.
+
+Closes #224 (Part 1-B of #218).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Callable, TypeVar
+
+from bantz.data.connection_pool import get_pool
+
+log = logging.getLogger("bantz.data.async_executor")
+
+T = TypeVar("T")
+
+# Module-level executor — created once, shared across all callers.
+_executor: ThreadPoolExecutor | None = None
+_MAX_WORKERS = 5  # mirrors SQLitePool's max_connections
+
+
+def _get_executor() -> ThreadPoolExecutor:
+    """Lazy-init the module-level ``ThreadPoolExecutor``."""
+    global _executor
+    if _executor is None:
+        _executor = ThreadPoolExecutor(
+            max_workers=_MAX_WORKERS,
+            thread_name_prefix="bantz-db",
+        )
+        log.info("AsyncDBExecutor ready  workers=%d", _MAX_WORKERS)
+    return _executor
+
+
+# ── public async API ──────────────────────────────────────────────────
+
+
+async def run_read(fn: Callable[..., T], *args: Any, **kwargs: Any) -> T:
+    """Execute *fn(conn, \\*args, \\*\\*kwargs)* on a **read** connection.
+
+    The callable receives an open ``sqlite3.Connection`` as its first
+    argument and must return the desired value.  The connection is
+    automatically returned to the pool after *fn* completes.
+
+    Example::
+
+        rows = await run_read(lambda conn: conn.execute(
+            "SELECT * FROM conversations ORDER BY ts DESC LIMIT 10"
+        ).fetchall())
+    """
+    loop = asyncio.get_running_loop()
+
+    def _work() -> T:
+        with get_pool().connection(write=False) as conn:
+            return fn(conn, *args, **kwargs)
+
+    return await loop.run_in_executor(_get_executor(), _work)
+
+
+async def run_write(fn: Callable[..., T], *args: Any, **kwargs: Any) -> T:
+    """Execute *fn(conn, \\*args, \\*\\*kwargs)* on a **write** connection.
+
+    Acquires the pool's ``_write_lock`` so only one writer at a time.
+    Auto-commits on success, auto-rolls-back on exception.
+
+    Example::
+
+        await run_write(lambda conn: conn.execute(
+            "INSERT INTO conversations(role, content) VALUES (?, ?)",
+            ("user", msg),
+        ))
+    """
+    loop = asyncio.get_running_loop()
+
+    def _work() -> T:
+        with get_pool().connection(write=True) as conn:
+            return fn(conn, *args, **kwargs)
+
+    return await loop.run_in_executor(_get_executor(), _work)
+
+
+async def run_in_db(
+    fn: Callable[..., T],
+    *args: Any,
+    write: bool = False,
+    **kwargs: Any,
+) -> T:
+    """Unified entry point — delegates to :func:`run_read` or :func:`run_write`.
+
+    Parameters
+    ----------
+    fn : callable
+        ``fn(conn, *args, **kwargs)`` — receives an open connection.
+    write : bool
+        Pass ``True`` to acquire the write-lock.
+    """
+    if write:
+        return await run_write(fn, *args, **kwargs)
+    return await run_read(fn, *args, **kwargs)
+
+
+# ── lifecycle ─────────────────────────────────────────────────────────
+
+
+def shutdown(wait: bool = True) -> None:
+    """Shut down the thread-pool.  Called during application teardown."""
+    global _executor
+    if _executor is not None:
+        _executor.shutdown(wait=wait)
+        _executor = None
+        log.info("AsyncDBExecutor shut down")

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -1,0 +1,159 @@
+"""Tests for bantz.core.context — BantzContext dataclass (#224)."""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from bantz.core.context import BantzContext
+
+
+# ── construction & defaults ───────────────────────────────────────────
+
+
+class TestDefaults:
+    def test_default_session_id_is_12_hex(self):
+        ctx = BantzContext()
+        assert len(ctx.session_id) == 12
+        assert ctx.session_id.isalnum()
+
+    def test_two_contexts_have_unique_ids(self):
+        a = BantzContext()
+        b = BantzContext()
+        assert a.session_id != b.session_id
+
+    def test_default_field_values(self):
+        ctx = BantzContext()
+        assert ctx.user_input == ""
+        assert ctx.en_input == ""
+        assert ctx.source_lang == "en"
+        assert ctx.is_remote is False
+        assert ctx.confirmed is False
+        assert ctx.feedback is None
+        assert ctx.route == "chat"
+        assert ctx.tool_name is None
+        assert ctx.tool_args == {}
+        assert ctx.risk_level == "safe"
+        assert ctx.tool_success is None
+        assert ctx.response == ""
+        assert ctx.is_streaming is False
+        assert ctx.needs_confirm is False
+        assert ctx.completed_at is None
+
+    def test_mutable_defaults_are_independent(self):
+        """Each instance must get its own dict/list — no shared mutable default."""
+        a = BantzContext()
+        b = BantzContext()
+        a.tool_args["foo"] = 1
+        assert "foo" not in b.tool_args
+
+    def test_created_at_is_recent(self):
+        before = time.time()
+        ctx = BantzContext()
+        after = time.time()
+        assert before <= ctx.created_at <= after
+
+
+# ── explicit construction ─────────────────────────────────────────────
+
+
+class TestExplicit:
+    def test_set_fields_at_construction(self):
+        ctx = BantzContext(
+            user_input="merhaba",
+            en_input="hello",
+            source_lang="tr",
+            is_remote=True,
+            route="tool",
+            tool_name="weather",
+            tool_args={"city": "Istanbul"},
+            risk_level="safe",
+        )
+        assert ctx.user_input == "merhaba"
+        assert ctx.en_input == "hello"
+        assert ctx.source_lang == "tr"
+        assert ctx.is_remote is True
+        assert ctx.is_tool_call is True
+        assert ctx.tool_args == {"city": "Istanbul"}
+
+    def test_feedback_positive(self):
+        ctx = BantzContext(feedback="positive", feedback_hint="praise")
+        assert ctx.feedback == "positive"
+        assert ctx.feedback_hint == "praise"
+
+    def test_feedback_negative(self):
+        ctx = BantzContext(feedback="negative")
+        assert ctx.feedback == "negative"
+
+
+# ── helper properties ─────────────────────────────────────────────────
+
+
+class TestHelpers:
+    def test_is_tool_call_true(self):
+        ctx = BantzContext(route="tool", tool_name="shell")
+        assert ctx.is_tool_call is True
+
+    def test_is_tool_call_false_when_chat(self):
+        ctx = BantzContext(route="chat", tool_name="shell")
+        assert ctx.is_tool_call is False
+
+    def test_is_tool_call_false_when_no_tool(self):
+        ctx = BantzContext(route="tool", tool_name=None)
+        assert ctx.is_tool_call is False
+
+    def test_has_memory_false_by_default(self):
+        ctx = BantzContext()
+        assert ctx.has_memory is False
+
+    def test_has_memory_with_graph(self):
+        ctx = BantzContext(graph_context="entities…")
+        assert ctx.has_memory is True
+
+    def test_has_memory_with_vector(self):
+        ctx = BantzContext(vector_context="past msgs…")
+        assert ctx.has_memory is True
+
+    def test_has_memory_with_deep(self):
+        ctx = BantzContext(deep_memory="deep recall…")
+        assert ctx.has_memory is True
+
+    def test_elapsed_ms_none_before_complete(self):
+        ctx = BantzContext()
+        assert ctx.elapsed_ms is None
+
+    def test_elapsed_ms_after_mark_complete(self):
+        ctx = BantzContext()
+        # Simulate some "work"
+        ctx.mark_complete()
+        ms = ctx.elapsed_ms
+        assert ms is not None
+        assert ms >= 0
+
+
+# ── mark_complete & as_log_dict ───────────────────────────────────────
+
+
+class TestLogDict:
+    def test_as_log_dict_keys(self):
+        ctx = BantzContext(
+            user_input="hello world",
+            route="tool",
+            tool_name="weather",
+            risk_level="safe",
+        )
+        ctx.mark_complete()
+        d = ctx.as_log_dict()
+        assert set(d.keys()) == {
+            "sid", "input", "lang", "route",
+            "tool", "risk", "ok", "stream", "ms",
+        }
+        assert d["input"] == "hello world"
+        assert d["route"] == "tool"
+        assert d["tool"] == "weather"
+        assert d["ms"] is not None
+
+    def test_log_dict_truncates_long_input(self):
+        ctx = BantzContext(user_input="x" * 200)
+        d = ctx.as_log_dict()
+        assert len(d["input"]) == 80

--- a/tests/data/test_async_executor.py
+++ b/tests/data/test_async_executor.py
@@ -1,0 +1,192 @@
+"""Tests for bantz.data.async_executor — AsyncDBExecutor (#224)."""
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from bantz.data.connection_pool import SQLitePool, get_pool
+from bantz.data import async_executor
+from bantz.data.async_executor import run_read, run_write, run_in_db, shutdown
+
+
+# ── fixtures ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _isolated_pool(tmp_path: Path):
+    """Ensure every test gets its own pool + executor, then tear both down."""
+    SQLitePool.reset()
+    db = tmp_path / "test_async.db"
+    get_pool(db)
+
+    # Create a simple table for the tests
+    with get_pool().connection(write=True) as conn:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS items "
+            "(id INTEGER PRIMARY KEY, name TEXT NOT NULL)"
+        )
+
+    yield
+
+    shutdown(wait=True)
+    SQLitePool.reset()
+
+
+# ── run_read ──────────────────────────────────────────────────────────
+
+
+class TestRunRead:
+    @pytest.mark.asyncio
+    async def test_read_returns_rows(self):
+        # seed
+        with get_pool().connection(write=True) as conn:
+            conn.execute("INSERT INTO items(name) VALUES (?)", ("alpha",))
+            conn.execute("INSERT INTO items(name) VALUES (?)", ("beta",))
+
+        rows = await run_read(
+            lambda conn: conn.execute("SELECT name FROM items ORDER BY id").fetchall()
+        )
+        names = [r["name"] for r in rows]
+        assert names == ["alpha", "beta"]
+
+    @pytest.mark.asyncio
+    async def test_read_empty_table(self):
+        rows = await run_read(
+            lambda conn: conn.execute("SELECT * FROM items").fetchall()
+        )
+        assert rows == []
+
+    @pytest.mark.asyncio
+    async def test_read_with_args(self):
+        with get_pool().connection(write=True) as conn:
+            conn.execute("INSERT INTO items(name) VALUES (?)", ("gamma",))
+
+        row = await run_read(
+            lambda conn, name: conn.execute(
+                "SELECT * FROM items WHERE name = ?", (name,)
+            ).fetchone(),
+            "gamma",
+        )
+        assert row is not None
+        assert row["name"] == "gamma"
+
+
+# ── run_write ─────────────────────────────────────────────────────────
+
+
+class TestRunWrite:
+    @pytest.mark.asyncio
+    async def test_write_inserts_row(self):
+        await run_write(
+            lambda conn: conn.execute(
+                "INSERT INTO items(name) VALUES (?)", ("delta",)
+            )
+        )
+        rows = await run_read(
+            lambda conn: conn.execute("SELECT name FROM items").fetchall()
+        )
+        assert [r["name"] for r in rows] == ["delta"]
+
+    @pytest.mark.asyncio
+    async def test_write_rollback_on_error(self):
+        """Write failure must rollback and not poison the pool."""
+
+        def _bad_write(conn):
+            conn.execute(
+                "INSERT INTO items(id, name) VALUES (?, ?)", (1, "first")
+            )
+            # duplicate PK → IntegrityError
+            conn.execute(
+                "INSERT INTO items(id, name) VALUES (?, ?)", (1, "dup")
+            )
+
+        with pytest.raises(sqlite3.IntegrityError):
+            await run_write(_bad_write)
+
+        # The transaction should have rolled back — row "first" must be gone
+        rows = await run_read(
+            lambda conn: conn.execute("SELECT count(*) AS c FROM items").fetchone()
+        )
+        assert rows["c"] == 0  # rolled back, pool alive
+
+
+# ── run_in_db (unified entry) ────────────────────────────────────────
+
+
+class TestRunInDB:
+    @pytest.mark.asyncio
+    async def test_run_in_db_read(self):
+        with get_pool().connection(write=True) as conn:
+            conn.execute("INSERT INTO items(name) VALUES (?)", ("epsilon",))
+
+        rows = await run_in_db(
+            lambda conn: conn.execute("SELECT name FROM items").fetchall(),
+            write=False,
+        )
+        assert [r["name"] for r in rows] == ["epsilon"]
+
+    @pytest.mark.asyncio
+    async def test_run_in_db_write(self):
+        await run_in_db(
+            lambda conn: conn.execute(
+                "INSERT INTO items(name) VALUES (?)", ("zeta",)
+            ),
+            write=True,
+        )
+        rows = await run_in_db(
+            lambda conn: conn.execute("SELECT name FROM items").fetchall(),
+        )
+        assert [r["name"] for r in rows] == ["zeta"]
+
+
+# ── non-blocking proof ───────────────────────────────────────────────
+
+
+class TestNonBlocking:
+    @pytest.mark.asyncio
+    async def test_does_not_block_event_loop(self):
+        """Prove the DB call runs in a background thread.
+
+        We schedule a DB read AND a pure-coroutine counter concurrently.
+        If run_read blocked the loop the counter would never increment
+        until after the DB call (sequentially).
+        """
+        counter = 0
+
+        async def ticker():
+            nonlocal counter
+            for _ in range(5):
+                counter += 1
+                await asyncio.sleep(0.01)
+
+        with get_pool().connection(write=True) as conn:
+            conn.execute("INSERT INTO items(name) VALUES (?)", ("test",))
+
+        # Run both concurrently
+        await asyncio.gather(
+            run_read(lambda conn: conn.execute("SELECT * FROM items").fetchall()),
+            ticker(),
+        )
+        assert counter == 5  # ticker ran fully while DB was in flight
+
+
+# ── shutdown idempotence ──────────────────────────────────────────────
+
+
+class TestShutdown:
+    @pytest.mark.asyncio
+    async def test_shutdown_then_restart(self):
+        """After shutdown, next call lazily re-creates the executor."""
+        await run_read(lambda conn: conn.execute("SELECT 1").fetchone())
+        shutdown(wait=True)
+        # Should still work — lazy re-init
+        row = await run_read(lambda conn: conn.execute("SELECT 1 AS v").fetchone())
+        assert row["v"] == 1
+
+    def test_double_shutdown_safe(self):
+        shutdown(wait=True)
+        shutdown(wait=True)  # must not raise


### PR DESCRIPTION
## Summary

Part 1 of the brain.py decomposition epic (#218). Creates the two foundational infrastructure modules that all subsequent sub-issues (#225–#228) will build on.

### Deliverables

#### 1. `BantzContext` dataclass — `src/bantz/core/context.py`

Request-scoped data carrier that flows through every pipeline stage:

| Phase | Fields |
|-------|--------|
| Input | `session_id`, `user_input`, `is_remote`, `confirmed` |
| Translation | `en_input`, `source_lang` |
| Time | `time_context` (dict snapshot) |
| RLHF | `feedback`, `feedback_hint` |
| Memory & persona | `graph_context`, `vector_context`, `deep_memory`, `desktop_context`, `persona_state`, `formality_hint`, `style_hint`, `profile_hint` |
| Routing | `route`, `tool_name`, `tool_args`, `risk_level`, `is_quick_route` |
| Execution | `tool_success`, `tool_output`, `tool_data` |
| Response | `response`, `is_streaming`, `needs_confirm`, `pending_*` |
| Timing | `created_at`, `completed_at` |

Helper properties: `is_tool_call`, `has_memory`, `elapsed_ms`, `as_log_dict()`.

**Zero internal imports** — can be imported from anywhere without circular dependency risk.

#### 2. `AsyncDBExecutor` — `src/bantz/data/async_executor.py`

`ThreadPoolExecutor(max_workers=5)` wrapping `SQLitePool.connection()` via `asyncio.run_in_executor()`. Public API:

- `await run_read(fn, *args, **kwargs)` — read connection
- `await run_write(fn, *args, **kwargs)` — write connection (acquires write-lock)
- `await run_in_db(fn, *args, write=False, **kwargs)` — unified entry point
- `shutdown(wait=True)` — teardown

**Fixes the async-blocking risk** identified during #222 review (documented on #218).

### Tests

- `tests/core/test_context.py` — 19 tests (defaults, construction, helpers, log dict)
- `tests/data/test_async_executor.py` — 10 tests (read, write, rollback, non-blocking proof, shutdown idempotence)

**29/29 new tests pass. Full suite: 2306 passed, 3 pre-existing failures.**

### What this does NOT change

- `brain.py` is untouched — subsequent PRs (#225–#228) will incrementally adopt these modules
- No existing imports or call sites are modified

Closes #224
