### PR TITLE
refactor(#225): extract notification & location side-effects from brain.py

### DIFF
--- a/src/bantz/core/brain.py
+++ b/src/bantz/core/brain.py
@@ -101,39 +101,25 @@ def _detect_feedback(raw_input: str) -> str | None:
     return None
 
 
-# ── Toast notification hook (#137) ──────────────────────────────────
-# Set by the TUI app on mount: ``brain_mod._toast_callback = app._on_brain_toast``
-_toast_callback = None
+# ── Toast notification hook (#137 → #225 notification_manager) ───────
+# Canonical implementation now lives in ``notification_manager.py``.
+# We keep ``_toast_callback`` and ``_notify_toast`` here as **thin
+# backward-compat shims** so that ``brain_mod._toast_callback = cb``
+# and ``brain_mod._notify_toast(…)`` still work for existing callers
+# (app.py, tests).  New code should import from notification_manager.
+import bantz.core.notification_manager as _notif_mod
+
+_toast_callback = None  # ← compat: written by app.py / tests
 
 
 def _notify_toast(title: str, reason: str = "", toast_type: str = "info") -> None:
-    """Push a toast notification to the TUI from brain / background context.
+    """Compat shim → ``notification_manager.notify_toast``.
 
-    Uses the same ``App.current`` pattern as ollama._notify_health (#136).
-    Falls back to the callback if set, then desktop notify-send, or does nothing.
+    Syncs the local ``_toast_callback`` into the canonical module before
+    delegating, so old ``brain_mod._toast_callback = cb`` callers work.
     """
-    if _toast_callback:
-        try:
-            _toast_callback(title, reason, toast_type)
-            return
-        except Exception:
-            pass
-    # Fallback: try App.current directly
-    try:
-        from textual.app import App as _App
-        app = _App.current
-        if app and hasattr(app, "push_toast"):
-            app.call_from_thread(app.push_toast, title, reason, toast_type)
-            return
-    except Exception:
-        pass
-    # Fallback: desktop notification via notify-send (#153)
-    try:
-        from bantz.agent.notifier import notifier
-        if notifier.enabled:
-            notifier.send(f"Bantz: {title}", reason or "")
-    except Exception:
-        pass
+    _notif_mod.toast_callback = _toast_callback
+    _notif_mod.notify_toast(title, reason, toast_type)
 
 
 def _style_hint() -> str:
@@ -607,40 +593,12 @@ class Brain:
         except Exception:
             pass  # never crash the pipeline
 
-    async def _check_intervention_queue(self) -> str | None:
-        """[Deprecated — #137] Queue is now consumed by TUI toast system.
-
-        Kept for backward compat in case headless mode needs it.
-        """
-        try:
-            from bantz.agent.interventions import intervention_queue
-            iv = intervention_queue.pop()
-            if iv is None:
-                return None
-            return f"💡 [{iv.source}] {iv.title}\n   {iv.reason}"
-        except Exception:
-            return None
-
-    def _prepend_intervention(self, response: str) -> str:
-        """[Deprecated — #137] Toast system renders interventions separately.
-
-        Kept for backward compat in case headless mode needs it.
-        """
-        iv = getattr(self, "_pending_intervention", None)
-        if iv:
-            self._pending_intervention = None
-            return f"{iv}\n\n{response}"
-        return response
-
     def _push_toast(
         self, title: str, reason: str = "", toast_type: str = "info",
     ) -> None:
-        """Push a toast notification from brain context (#137).
-
-        Delegates to the module-level ``_notify_toast()`` which routes
-        to the TUI via callback or App.current.
-        """
-        _notify_toast(title, reason, toast_type)
+        """Push a toast notification (#137 → #225 notification_manager)."""
+        from bantz.core.notification_manager import push_toast
+        push_toast(title, reason, toast_type)
 
     # ── Maintenance & Reflection handlers (#129, #130) ────────────────
 
@@ -720,91 +678,24 @@ class Brain:
         return BrainResult(response=resp, tool_used="planner")
 
     async def _handle_location(self) -> str:
-        """Handle 'where am i' queries — show GPS/location info."""
-        from bantz.core.location import location_service
-        from bantz.core.places import places as _places
-
-        # Check phone GPS first — it's the most accurate source
-        gps_loc = None
-        try:
-            from bantz.core.gps_server import gps_server
-            gps_loc = gps_server.latest
-        except Exception:
-            pass
-
-        try:
-            loc = await location_service.get()
-        except Exception:
-            loc = None
-
-        lines: list[str] = []
-
-        # Show current named place first if any
-        cur_label = _places.current_place_label()
-        if cur_label:
-            lines.append(f"📌 You're at: {cur_label}")
-
-        # Prefer phone GPS as primary when available
-        if gps_loc:
-            acc = round(gps_loc.get("accuracy", 0))
-            lines.append(f"📍 Phone GPS: {gps_loc['lat']:.6f}, {gps_loc['lon']:.6f} (±{acc}m)")
-        elif loc and loc.is_live:
-            lines.append(f"📍 {loc.display}")
-            if loc.lat and loc.lon:
-                lines.append(f"   Coordinates: {loc.lat:.6f}, {loc.lon:.6f}")
-            lines.append(f"   Source: {loc.source}")
-        else:
-            lines.append(
-                "I can't pinpoint where you are right now — "
-                "I need your phone GPS to figure that out."
-            )
-            try:
-                from bantz.core.gps_server import gps_server
-                lines.append(
-                    f"Open {gps_server.url} on your phone and "
-                    f"hit 'Share Location' so I can see where you are."
-                )
-            except Exception:
-                pass
-
-        return "\n".join(lines)
+        """Delegate to location_handler (#225)."""
+        from bantz.core.location_handler import handle_location
+        return await handle_location()
 
     async def _handle_save_place(self, name: str) -> str:
-        """Save current GPS position as a named place."""
-        from bantz.core.places import places as _places
-        result = _places.save_here(name)
-        if result:
-            lat = result.get("lat", 0.0)
-            lon = result.get("lon", 0.0)
-            return (
-                f"📌 Saved '{name}' as a place!\n"
-                f"   Coordinates: {lat:.6f}, {lon:.6f}\n"
-                f"   Radius: {result.get('radius', 100)}m"
-            )
-        return "❌ No GPS data — couldn't save location. Is the phone GPS on?"
+        """Delegate to location_handler (#225)."""
+        from bantz.core.location_handler import handle_save_place
+        return await handle_save_place(name)
 
     async def _handle_list_places(self) -> str:
-        """List all saved places."""
-        from bantz.core.places import places as _places
-        all_p = _places.all_places()
-        if not all_p:
-            return "No saved places yet. Say 'save here as X' to save one."
-        lines = ["📌 Saved places:"]
-        for key, p in all_p.items():
-            label = p.get("label", key)
-            lat = p.get("lat", 0.0)
-            lon = p.get("lon", 0.0)
-            radius = p.get("radius", 100)
-            marker = " ⬅ you are here" if key == _places._current_place_key else ""
-            lines.append(f"  • {label} ({lat:.4f}, {lon:.4f}, r={radius}m){marker}")
-        return "\n".join(lines)
+        """Delegate to location_handler (#225)."""
+        from bantz.core.location_handler import handle_list_places
+        return await handle_list_places()
 
     async def _handle_delete_place(self, name: str) -> str:
-        """Delete a saved place."""
-        from bantz.core.places import places as _places
-        if _places.delete_place(name):
-            return f"📌 '{name}' deleted."
-        return f"❌ No saved place named '{name}' found."
+        """Delegate to location_handler (#225)."""
+        from bantz.core.location_handler import handle_delete_place
+        return await handle_delete_place(name)
 
     async def process(self, user_input: str, confirmed: bool = False,
                       is_remote: bool = False) -> BrainResult:

--- a/src/bantz/core/location_handler.py
+++ b/src/bantz/core/location_handler.py
@@ -1,0 +1,115 @@
+"""
+Bantz — Location Handler (#225)
+
+Extracts all GPS / place-management side-effects from ``brain.py`` into a
+standalone module.  These functions interact with:
+  - ``bantz.core.location``   — IP / GeoClue location service
+  - ``bantz.core.gps_server`` — phone GPS relay
+  - ``bantz.core.places``     — named-place CRUD (PlaceStore)
+
+None of them touch the LLM, routing, or memory — they are pure
+side-effect handlers that return formatted strings for the assistant.
+
+Closes #225 (Part 2-B of #218).
+"""
+from __future__ import annotations
+
+import logging
+
+log = logging.getLogger("bantz.core.location_handler")
+
+
+async def handle_location() -> str:
+    """Handle 'where am i' queries — show GPS / location info."""
+    from bantz.core.location import location_service
+    from bantz.core.places import places as _places
+
+    # Check phone GPS first — it's the most accurate source
+    gps_loc = None
+    try:
+        from bantz.core.gps_server import gps_server
+        gps_loc = gps_server.latest
+    except Exception:
+        pass
+
+    try:
+        loc = await location_service.get()
+    except Exception:
+        loc = None
+
+    lines: list[str] = []
+
+    # Show current named place first if any
+    cur_label = _places.current_place_label()
+    if cur_label:
+        lines.append(f"📌 You're at: {cur_label}")
+
+    # Prefer phone GPS as primary when available
+    if gps_loc:
+        acc = round(gps_loc.get("accuracy", 0))
+        lines.append(
+            f"📍 Phone GPS: {gps_loc['lat']:.6f}, {gps_loc['lon']:.6f} (±{acc}m)"
+        )
+    elif loc and loc.is_live:
+        lines.append(f"📍 {loc.display}")
+        if loc.lat and loc.lon:
+            lines.append(f"   Coordinates: {loc.lat:.6f}, {loc.lon:.6f}")
+        lines.append(f"   Source: {loc.source}")
+    else:
+        lines.append(
+            "I can't pinpoint where you are right now — "
+            "I need your phone GPS to figure that out."
+        )
+        try:
+            from bantz.core.gps_server import gps_server
+            lines.append(
+                f"Open {gps_server.url} on your phone and "
+                f"hit 'Share Location' so I can see where you are."
+            )
+        except Exception:
+            pass
+
+    return "\n".join(lines)
+
+
+async def handle_save_place(name: str) -> str:
+    """Save current GPS position as a named place."""
+    from bantz.core.places import places as _places
+
+    result = _places.save_here(name)
+    if result:
+        lat = result.get("lat", 0.0)
+        lon = result.get("lon", 0.0)
+        return (
+            f"📌 Saved '{name}' as a place!\n"
+            f"   Coordinates: {lat:.6f}, {lon:.6f}\n"
+            f"   Radius: {result.get('radius', 100)}m"
+        )
+    return "❌ No GPS data — couldn't save location. Is the phone GPS on?"
+
+
+async def handle_list_places() -> str:
+    """List all saved places."""
+    from bantz.core.places import places as _places
+
+    all_p = _places.all_places()
+    if not all_p:
+        return "No saved places yet. Say 'save here as X' to save one."
+    lines = ["📌 Saved places:"]
+    for key, p in all_p.items():
+        label = p.get("label", key)
+        lat = p.get("lat", 0.0)
+        lon = p.get("lon", 0.0)
+        radius = p.get("radius", 100)
+        marker = " ⬅ you are here" if key == _places._current_place_key else ""
+        lines.append(f"  • {label} ({lat:.4f}, {lon:.4f}, r={radius}m){marker}")
+    return "\n".join(lines)
+
+
+async def handle_delete_place(name: str) -> str:
+    """Delete a saved place."""
+    from bantz.core.places import places as _places
+
+    if _places.delete_place(name):
+        return f"📌 '{name}' deleted."
+    return f"❌ No saved place named '{name}' found."

--- a/src/bantz/core/notification_manager.py
+++ b/src/bantz/core/notification_manager.py
@@ -1,0 +1,74 @@
+"""
+Bantz — Notification Manager (#225)
+
+Centralises all UI / desktop / sound notification side-effects that were
+previously scattered across ``brain.py``.
+
+Extracted surface:
+  - ``toast_callback`` — TUI callback hook (set by the app on mount)
+  - ``notify_toast()`` — push a toast to TUI → App.current → notify-send
+  - ``push_toast()``   — public convenience wrapper
+
+The module is **intentionally thin**: it just routes a (title, reason, type)
+triple to the best available output channel.  No LLM, no routing, no memory.
+
+Backward compatibility:
+  ``brain.py`` re-exports ``_toast_callback`` and ``_notify_toast`` at
+  module level so that existing callers (``app.py``, tests) keep working
+  until they migrate to ``from bantz.core.notification_manager import …``.
+
+Closes #225 (Part 2-A of #218).
+"""
+from __future__ import annotations
+
+import logging
+
+log = logging.getLogger("bantz.core.notifications")
+
+# ── TUI callback hook ────────────────────────────────────────────────
+# Set by the TUI app on mount:
+#   ``notification_manager.toast_callback = app._on_brain_toast``
+toast_callback = None
+
+
+def notify_toast(title: str, reason: str = "", toast_type: str = "info") -> None:
+    """Push a toast notification to the best available channel.
+
+    Resolution order:
+      1. ``toast_callback`` (set by TUI on mount)
+      2. ``App.current.push_toast`` (Textual's thread-safe call)
+      3. ``notify-send`` via ``bantz.agent.notifier`` (desktop fallback)
+      4. Silent no-op
+
+    Never raises — all exceptions are swallowed so the main pipeline
+    is never interrupted by a notification failure.
+    """
+    if toast_callback:
+        try:
+            toast_callback(title, reason, toast_type)
+            return
+        except Exception:
+            pass
+
+    # Fallback: try App.current directly
+    try:
+        from textual.app import App as _App
+        app = _App.current
+        if app and hasattr(app, "push_toast"):
+            app.call_from_thread(app.push_toast, title, reason, toast_type)
+            return
+    except Exception:
+        pass
+
+    # Fallback: desktop notification via notify-send (#153)
+    try:
+        from bantz.agent.notifier import notifier
+        if notifier.enabled:
+            notifier.send(f"Bantz: {title}", reason or "")
+    except Exception:
+        pass
+
+
+def push_toast(title: str, reason: str = "", toast_type: str = "info") -> None:
+    """Public convenience alias for :func:`notify_toast`."""
+    notify_toast(title, reason, toast_type)

--- a/src/bantz/interface/tui/app.py
+++ b/src/bantz/interface/tui/app.py
@@ -916,8 +916,15 @@ class BantzApp(App):
             pass
 
     def _wire_brain_toast_hook(self) -> None:
-        """Connect brain._notify_toast to this app's push_toast (#137)."""
+        """Connect notification system to this app's push_toast (#137, #225)."""
         try:
+            # Canonical: set on notification_manager directly
+            from bantz.core import notification_manager as _notif_mod
+            _notif_mod.toast_callback = self._on_brain_toast
+        except Exception:
+            pass
+        try:
+            # Backward compat: old brain_mod._toast_callback
             from bantz.core import brain as brain_mod
             brain_mod._toast_callback = self._on_brain_toast
         except Exception:

--- a/tests/agent/test_tts.py
+++ b/tests/agent/test_tts.py
@@ -623,7 +623,6 @@ class TestBrainTTSStopHandler:
         b._last_messages = []
         b._last_events = []
         b._last_draft = None
-        b._pending_intervention = None
         return b
 
     @pytest.mark.asyncio
@@ -640,7 +639,6 @@ class TestBrainTTSStopHandler:
              patch.object(b, "_to_en", new_callable=AsyncMock, return_value="shut up"), \
              patch.object(b, "_ensure_memory"), \
              patch.object(b, "_ensure_graph", new_callable=AsyncMock), \
-             patch.object(b, "_check_intervention_queue", new_callable=AsyncMock, return_value=None), \
              patch("bantz.core.brain.time_ctx") as mock_tc:
             mock_tc.snapshot.return_value = MagicMock()
             mock_dl.conversations = mock_conv
@@ -663,7 +661,6 @@ class TestBrainTTSStopHandler:
              patch.object(b, "_to_en", new_callable=AsyncMock, return_value="shut up"), \
              patch.object(b, "_ensure_memory"), \
              patch.object(b, "_ensure_graph", new_callable=AsyncMock), \
-             patch.object(b, "_check_intervention_queue", new_callable=AsyncMock, return_value=None), \
              patch("bantz.core.brain.time_ctx") as mock_tc:
             mock_tc.snapshot.return_value = MagicMock()
             mock_dl.conversations = mock_conv
@@ -690,7 +687,6 @@ class TestBrainBriefingWithTTS:
         b._last_messages = []
         b._last_events = []
         b._last_draft = None
-        b._pending_intervention = None
         return b
 
     @pytest.mark.asyncio
@@ -712,7 +708,6 @@ class TestBrainBriefingWithTTS:
              patch.object(b, "_to_en", new_callable=AsyncMock, return_value="good morning"), \
              patch.object(b, "_ensure_memory"), \
              patch.object(b, "_ensure_graph", new_callable=AsyncMock), \
-             patch.object(b, "_check_intervention_queue", new_callable=AsyncMock, return_value=None), \
              patch("bantz.core.brain.time_ctx") as mock_tc:
             mock_tc.snapshot.return_value = MagicMock()
             mock_dl.conversations = mock_conv
@@ -740,7 +735,6 @@ class TestBrainBriefingWithTTS:
              patch.object(b, "_to_en", new_callable=AsyncMock, return_value="good morning"), \
              patch.object(b, "_ensure_memory"), \
              patch.object(b, "_ensure_graph", new_callable=AsyncMock), \
-             patch.object(b, "_check_intervention_queue", new_callable=AsyncMock, return_value=None), \
              patch("bantz.core.brain.time_ctx") as mock_tc:
             mock_tc.snapshot.return_value = MagicMock()
             mock_dl.conversations = mock_conv

--- a/tests/core/test_brain_integrations.py
+++ b/tests/core/test_brain_integrations.py
@@ -195,72 +195,15 @@ class TestRLRewardHook:
 # ═══════════════════════════════════════════════════════════════════════════
 
 class TestInterventionQueueHook:
-    """Verify _check_intervention_queue pops next intervention."""
+    """Deprecated methods removed in #225 — verify they no longer exist."""
 
-    def _make_brain(self):
+    def test_check_intervention_queue_removed(self):
         from bantz.core.brain import Brain
-        b = Brain.__new__(Brain)
-        b._bridge = False
-        b._memory_ready = True
-        b._graph_ready = True
-        b._last_messages = []
-        b._last_events = []
-        b._last_draft = None
-        return b
+        assert not hasattr(Brain, "_check_intervention_queue")
 
-    def test_pop_returns_formatted_text(self):
-        b = self._make_brain()
-        mock_iv = MagicMock()
-        mock_iv.source = "rl_engine"
-        mock_iv.title = "Start focus mode"
-        mock_iv.reason = "You usually focus at this time"
-
-        mock_queue = MagicMock()
-        mock_queue.pop.return_value = mock_iv
-
-        with patch("bantz.agent.interventions.intervention_queue", mock_queue):
-            text = _run(b._check_intervention_queue())
-
-        assert text is not None
-        assert "rl_engine" in text
-        assert "Start focus mode" in text
-
-    def test_pop_returns_none_when_empty(self):
-        b = self._make_brain()
-        mock_queue = MagicMock()
-        mock_queue.pop.return_value = None
-
-        with patch("bantz.agent.interventions.intervention_queue", mock_queue):
-            text = _run(b._check_intervention_queue())
-
-        assert text is None
-
-    def test_pop_no_crash_on_error(self):
-        b = self._make_brain()
-        with patch.dict("sys.modules", {"bantz.agent.interventions": None}):
-            text = _run(b._check_intervention_queue())
-        assert text is None
-
-    def test_prepend_intervention_with_text(self):
-        b = self._make_brain()
-        b._pending_intervention = "💡 [observer] High CPU\n   CPU at 95%"
-        result = b._prepend_intervention("It's sunny outside.")
-        assert result.startswith("💡 [observer]")
-        assert "It's sunny outside." in result
-        # Consumed after use
-        assert b._pending_intervention is None
-
-    def test_prepend_intervention_none(self):
-        b = self._make_brain()
-        b._pending_intervention = None
-        result = b._prepend_intervention("Hello")
-        assert result == "Hello"
-
-    def test_prepend_intervention_no_attr(self):
-        b = self._make_brain()
-        # No _pending_intervention set at all
-        result = b._prepend_intervention("Hello")
-        assert result == "Hello"
+    def test_prepend_intervention_removed(self):
+        from bantz.core.brain import Brain
+        assert not hasattr(Brain, "_prepend_intervention")
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -767,12 +710,12 @@ class TestNotifyToastFallback:
             brain_mod._toast_callback = old_cb
 
     def test_notifier_src_has_fallback(self):
-        """Source code must reference notifier.send as fallback."""
+        """notification_manager source must reference notifier.send as fallback."""
         import inspect
-        import bantz.core.brain as brain_mod
-        src = inspect.getsource(brain_mod._notify_toast)
+        from bantz.core import notification_manager
+        src = inspect.getsource(notification_manager.notify_toast)
         assert "notifier.send" in src
-        assert "notify-send" in src or "notifier" in src
+        assert "notifier" in src
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/tests/core/test_location_handler.py
+++ b/tests/core/test_location_handler.py
@@ -1,0 +1,235 @@
+"""Tests for bantz.core.location_handler (#225)."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch, AsyncMock
+
+import pytest
+
+
+# ── handle_location ──────────────────────────────────────────────────
+
+
+class TestHandleLocation:
+    @pytest.mark.asyncio
+    async def test_with_gps_data(self):
+        from bantz.core.location_handler import handle_location
+
+        mock_places = MagicMock()
+        mock_places.current_place_label.return_value = None
+
+        gps = {"lat": 41.015137, "lon": 28.979530, "accuracy": 12}
+        mock_gps_server = MagicMock()
+        mock_gps_server.latest = gps
+
+        mock_loc_svc = MagicMock()
+        mock_loc_svc.get = AsyncMock(return_value=None)
+
+        with patch("bantz.core.places.places", mock_places), \
+             patch("bantz.core.location.location_service", mock_loc_svc), \
+             patch("bantz.core.gps_server.gps_server", mock_gps_server):
+            result = await handle_location()
+
+        assert "41.015137" in result
+        assert "28.979530" in result
+        assert "±12m" in result
+
+    @pytest.mark.asyncio
+    async def test_with_named_place(self):
+        from bantz.core.location_handler import handle_location
+
+        mock_places = MagicMock()
+        mock_places.current_place_label.return_value = "Home"
+
+        mock_loc_svc = MagicMock()
+        mock_loc_svc.get = AsyncMock(return_value=None)
+
+        with patch("bantz.core.places.places", mock_places), \
+             patch("bantz.core.location.location_service", mock_loc_svc), \
+             patch.dict("sys.modules", {"bantz.core.gps_server": None}):
+            result = await handle_location()
+
+        assert "Home" in result
+
+    @pytest.mark.asyncio
+    async def test_no_gps_shows_fallback(self):
+        from bantz.core.location_handler import handle_location
+
+        mock_places = MagicMock()
+        mock_places.current_place_label.return_value = None
+
+        mock_loc_svc = MagicMock()
+        mock_loc_svc.get = AsyncMock(return_value=None)
+
+        with patch("bantz.core.places.places", mock_places), \
+             patch("bantz.core.location.location_service", mock_loc_svc), \
+             patch.dict("sys.modules", {"bantz.core.gps_server": None}):
+            result = await handle_location()
+
+        assert "can't pinpoint" in result
+
+    @pytest.mark.asyncio
+    async def test_with_live_location_service(self):
+        from bantz.core.location_handler import handle_location
+
+        mock_places = MagicMock()
+        mock_places.current_place_label.return_value = None
+
+        loc_obj = SimpleNamespace(
+            is_live=True,
+            display="Istanbul, Turkey",
+            lat=41.0,
+            lon=29.0,
+            source="GeoClue",
+        )
+
+        mock_loc_svc = MagicMock()
+        mock_loc_svc.get = AsyncMock(return_value=loc_obj)
+
+        with patch("bantz.core.places.places", mock_places), \
+             patch("bantz.core.location.location_service", mock_loc_svc), \
+             patch.dict("sys.modules", {"bantz.core.gps_server": None}):
+            result = await handle_location()
+
+        assert "Istanbul" in result
+        assert "GeoClue" in result
+
+
+# ── handle_save_place ────────────────────────────────────────────────
+
+
+class TestHandleSavePlace:
+    @pytest.mark.asyncio
+    async def test_save_success(self):
+        from bantz.core.location_handler import handle_save_place
+
+        mock_places = MagicMock()
+        mock_places.save_here.return_value = {"lat": 41.0, "lon": 29.0, "radius": 100}
+
+        with patch("bantz.core.places.places", mock_places):
+            result = await handle_save_place("Home")
+
+        assert "Saved 'Home'" in result
+        assert "41.000000" in result
+        mock_places.save_here.assert_called_once_with("Home")
+
+    @pytest.mark.asyncio
+    async def test_save_no_gps(self):
+        from bantz.core.location_handler import handle_save_place
+
+        mock_places = MagicMock()
+        mock_places.save_here.return_value = None
+
+        with patch("bantz.core.places.places", mock_places):
+            result = await handle_save_place("Uni")
+
+        assert "No GPS data" in result
+
+
+# ── handle_list_places ───────────────────────────────────────────────
+
+
+class TestHandleListPlaces:
+    @pytest.mark.asyncio
+    async def test_list_empty(self):
+        from bantz.core.location_handler import handle_list_places
+
+        mock_places = MagicMock()
+        mock_places.all_places.return_value = {}
+
+        with patch("bantz.core.places.places", mock_places):
+            result = await handle_list_places()
+
+        assert "No saved places" in result
+
+    @pytest.mark.asyncio
+    async def test_list_with_places(self):
+        from bantz.core.location_handler import handle_list_places
+
+        mock_places = MagicMock()
+        mock_places.all_places.return_value = {
+            "home": {"label": "Home", "lat": 41.0, "lon": 29.0, "radius": 100},
+            "uni": {"label": "University", "lat": 41.1, "lon": 29.1, "radius": 200},
+        }
+        mock_places._current_place_key = "home"
+
+        with patch("bantz.core.places.places", mock_places):
+            result = await handle_list_places()
+
+        assert "Home" in result
+        assert "University" in result
+        assert "you are here" in result
+
+
+# ── handle_delete_place ──────────────────────────────────────────────
+
+
+class TestHandleDeletePlace:
+    @pytest.mark.asyncio
+    async def test_delete_success(self):
+        from bantz.core.location_handler import handle_delete_place
+
+        mock_places = MagicMock()
+        mock_places.delete_place.return_value = True
+
+        with patch("bantz.core.places.places", mock_places):
+            result = await handle_delete_place("Uni")
+
+        assert "'Uni' deleted" in result
+
+    @pytest.mark.asyncio
+    async def test_delete_not_found(self):
+        from bantz.core.location_handler import handle_delete_place
+
+        mock_places = MagicMock()
+        mock_places.delete_place.return_value = False
+
+        with patch("bantz.core.places.places", mock_places):
+            result = await handle_delete_place("Nowhere")
+
+        assert "No saved place" in result
+
+
+# ── brain.py delegation ──────────────────────────────────────────────
+
+
+class TestBrainDelegation:
+    """Brain methods should delegate to location_handler functions."""
+
+    @pytest.mark.asyncio
+    async def test_brain_handle_location_delegates(self):
+        from bantz.core.brain import Brain
+        with patch("bantz.core.location_handler.handle_location", new_callable=AsyncMock) as mock:
+            mock.return_value = "mocked location"
+            b = Brain.__new__(Brain)
+            result = await b._handle_location()
+        assert result == "mocked location"
+
+    @pytest.mark.asyncio
+    async def test_brain_handle_save_place_delegates(self):
+        from bantz.core.brain import Brain
+        with patch("bantz.core.location_handler.handle_save_place", new_callable=AsyncMock) as mock:
+            mock.return_value = "saved"
+            b = Brain.__new__(Brain)
+            result = await b._handle_save_place("Park")
+        mock.assert_called_once_with("Park")
+        assert result == "saved"
+
+    @pytest.mark.asyncio
+    async def test_brain_handle_list_places_delegates(self):
+        from bantz.core.brain import Brain
+        with patch("bantz.core.location_handler.handle_list_places", new_callable=AsyncMock) as mock:
+            mock.return_value = "places list"
+            b = Brain.__new__(Brain)
+            result = await b._handle_list_places()
+        assert result == "places list"
+
+    @pytest.mark.asyncio
+    async def test_brain_handle_delete_place_delegates(self):
+        from bantz.core.brain import Brain
+        with patch("bantz.core.location_handler.handle_delete_place", new_callable=AsyncMock) as mock:
+            mock.return_value = "deleted"
+            b = Brain.__new__(Brain)
+            result = await b._handle_delete_place("Gym")
+        mock.assert_called_once_with("Gym")
+        assert result == "deleted"

--- a/tests/core/test_notification_manager.py
+++ b/tests/core/test_notification_manager.py
@@ -1,0 +1,112 @@
+"""Tests for bantz.core.notification_manager (#225)."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bantz.core import notification_manager
+
+
+class TestNotifyToast:
+    """Unit tests for the notify_toast routing logic."""
+
+    def test_callback_takes_priority(self):
+        calls: list[tuple] = []
+        old = notification_manager.toast_callback
+        try:
+            notification_manager.toast_callback = lambda t, r, tt: calls.append((t, r, tt))
+            notification_manager.notify_toast("title", "reason", "warning")
+            assert calls == [("title", "reason", "warning")]
+        finally:
+            notification_manager.toast_callback = old
+
+    def test_no_crash_without_callback(self):
+        old = notification_manager.toast_callback
+        try:
+            notification_manager.toast_callback = None
+            # Should not raise even without callback or App
+            notification_manager.notify_toast("test", "reason", "info")
+        finally:
+            notification_manager.toast_callback = old
+
+    def test_fallback_to_notifier(self):
+        old = notification_manager.toast_callback
+        notification_manager.toast_callback = None
+        mock_notifier = MagicMock()
+        mock_notifier.enabled = True
+        try:
+            with patch("bantz.agent.notifier.notifier", mock_notifier):
+                # Suppress App.current failure
+                with patch("textual.app.App") as mock_app_cls:
+                    type(mock_app_cls).current = property(lambda self: None)
+                    notification_manager.notify_toast("Title", "Body", "info")
+            mock_notifier.send.assert_called_once()
+            assert "Title" in mock_notifier.send.call_args[0][0]
+        finally:
+            notification_manager.toast_callback = old
+
+    def test_push_toast_alias(self):
+        calls: list[tuple] = []
+        old = notification_manager.toast_callback
+        try:
+            notification_manager.toast_callback = lambda t, r, tt: calls.append((t, r, tt))
+            notification_manager.push_toast("hello", "world", "success")
+            assert calls == [("hello", "world", "success")]
+        finally:
+            notification_manager.toast_callback = old
+
+
+class TestBrainBackwardCompat:
+    """brain._toast_callback and brain._notify_toast must still work."""
+
+    def test_brain_module_exposes_toast_callback(self):
+        from bantz.core import brain as brain_mod
+        assert hasattr(brain_mod, "_toast_callback")
+
+    def test_brain_module_exposes_notify_toast(self):
+        from bantz.core import brain as brain_mod
+        assert hasattr(brain_mod, "_notify_toast")
+        assert callable(brain_mod._notify_toast)
+
+    def test_brain_callback_write_flows_to_notification_manager(self):
+        """Setting brain_mod._toast_callback then calling _notify_toast
+        should route through notification_manager with that callback."""
+        from bantz.core import brain as brain_mod
+        calls: list[tuple] = []
+        old = brain_mod._toast_callback
+        try:
+            brain_mod._toast_callback = lambda t, r, tt: calls.append((t, r, tt))
+            brain_mod._notify_toast("via brain", "compat", "info")
+            assert len(calls) == 1
+            assert calls[0] == ("via brain", "compat", "info")
+        finally:
+            brain_mod._toast_callback = old
+
+    def test_brain_push_toast_method(self):
+        from bantz.core.brain import Brain
+        assert hasattr(Brain, "_push_toast")
+
+    def test_brain_push_toast_delegates(self):
+        from bantz.core.brain import Brain
+        from bantz.core import brain as brain_mod
+        calls: list[tuple] = []
+        old = brain_mod._toast_callback
+        try:
+            brain_mod._toast_callback = lambda t, r, tt: calls.append((t, r, tt))
+            b = Brain.__new__(Brain)
+            b._push_toast("hello", "world", "success")
+            # push_toast goes through notification_manager directly,
+            # not through brain_mod._notify_toast, so set the canonical one too
+            notification_manager.toast_callback = brain_mod._toast_callback
+            b._push_toast("hello2", "world2", "success")
+            assert ("hello2", "world2", "success") in calls
+        finally:
+            brain_mod._toast_callback = old
+            notification_manager.toast_callback = None
+
+    def test_deprecated_methods_removed(self):
+        """_check_intervention_queue and _prepend_intervention are removed."""
+        from bantz.core.brain import Brain
+        assert not hasattr(Brain, "_check_intervention_queue")
+        assert not hasattr(Brain, "_prepend_intervention")

--- a/tests/tui/test_toast.py
+++ b/tests/tui/test_toast.py
@@ -492,19 +492,19 @@ class TestBrainToastIntegration:
         assert hasattr(Brain, "_push_toast")
 
     def test_brain_push_toast_delegates(self):
-        """Brain._push_toast should delegate to _notify_toast."""
+        """Brain._push_toast should delegate to notification_manager."""
         from bantz.core.brain import Brain
-        from bantz.core import brain as brain_mod
+        from bantz.core import notification_manager as _notif_mod
         calls = []
-        old_cb = brain_mod._toast_callback
+        old_cb = _notif_mod.toast_callback
         try:
-            brain_mod._toast_callback = lambda t, r, tt: calls.append((t, r, tt))
+            _notif_mod.toast_callback = lambda t, r, tt: calls.append((t, r, tt))
             b = Brain.__new__(Brain)
             b._push_toast("hello", "world", "success")
             assert len(calls) == 1
             assert calls[0] == ("hello", "world", "success")
         finally:
-            brain_mod._toast_callback = old_cb
+            _notif_mod.toast_callback = old_cb
 
     def test_process_no_longer_pops_queue(self):
         """brain.process() should NOT call _check_intervention_queue anymore."""
@@ -521,18 +521,14 @@ class TestBrainToastIntegration:
         assert "_prepend_intervention" not in src
 
     def test_deprecated_check_intervention_queue(self):
-        """_check_intervention_queue should be marked as deprecated."""
-        import inspect
+        """_check_intervention_queue was removed in #225."""
         from bantz.core.brain import Brain
-        src = inspect.getsource(Brain._check_intervention_queue)
-        assert "Deprecated" in src or "deprecated" in src
+        assert not hasattr(Brain, "_check_intervention_queue")
 
     def test_deprecated_prepend_intervention(self):
-        """_prepend_intervention should be marked as deprecated."""
-        import inspect
+        """_prepend_intervention was removed in #225."""
         from bantz.core.brain import Brain
-        src = inspect.getsource(Brain._prepend_intervention)
-        assert "Deprecated" in src or "deprecated" in src
+        assert not hasattr(Brain, "_prepend_intervention")
 
     def test_note_about_toast_in_process(self):
         """process() should have a comment about toast system."""


### PR DESCRIPTION
## Issue #225 — Part 2 of brain.py decomposition (#218)

### What
Extract notification and location side-effects from `brain.py` into standalone modules:

- **`notification_manager.py`** — canonical toast/notification routing (`toast_callback`, `notify_toast()`, `push_toast()`)
- **`location_handler.py`** — GPS/place management (`handle_location`, `handle_save_place`, `handle_list_places`, `handle_delete_place`)

### Changes
| File | Delta |
|------|-------|
| `src/bantz/core/brain.py` | –110 LOC, thin delegation stubs |
| `src/bantz/core/notification_manager.py` | +74 LOC (new) |
| `src/bantz/core/location_handler.py` | +115 LOC (new) |
| `src/bantz/interface/tui/app.py` | +9 LOC wiring update |
| `tests/core/test_notification_manager.py` | +112 LOC, 10 tests |
| `tests/core/test_location_handler.py` | +235 LOC, 14 tests |
| 3 existing test files | Updated for removed deprecated methods |

### Key decisions
- Removed deprecated `_check_intervention_queue` and `_prepend_intervention` (marked deprecated since #137, unused by `process()`)
- Backward-compat: `brain._toast_callback` and `brain._notify_toast()` still work via shim syncing to `notification_manager`
- `location_handler` uses lazy imports to avoid circular dependencies

### Test results
```
2326 passed, 3 failed (pre-existing), 30 skipped
```