### PR TITLE
refactor(#226): extract translation layer & RL hooks from brain.py

### DIFF
--- a/src/bantz/core/brain.py
+++ b/src/bantz/core/brain.py
@@ -8,6 +8,10 @@ Extracted modules:
   - core/finalizer.py    — LLM post-processing + hallucination check
   - core/intent.py       — Qwen CoT intent parser
   - core/router.py       — simpler one-shot routing
+  - core/notification_manager.py — toast/notification routing (#225)
+  - core/location_handler.py     — GPS/place management (#225)
+  - core/translation_layer.py    — i18n bridge, feedback detection (#226)
+  - core/rl_hooks.py             — RL reward signals via AsyncDBExecutor (#226)
   - memory/nodes.py      — graph schema + entity extraction
   - memory/context_builder.py — graph → LLM context string
 """
@@ -45,60 +49,14 @@ except ImportError:
     graph_memory = None  # neo4j driver not installed
 
 
-# ── Direct RLHF: Sentiment & Feedback Keywords (#180) ───────────────
-# Uses phrase-based patterns with regex \b word boundaries to prevent
-# false positives (e.g. "Can you stop the alarm?" ≠ scolding).
-# MUST be checked against the RAW (untranslated) user input so Turkish
-# keywords are found even when brain.process() translates to English.
-
-POSITIVE_FEEDBACK_KWS: tuple[str, ...] = (
-    # English — phrases & safe single words
-    "good job", "well done", "nice work", "thank you", "thanks a lot",
-    "perfect", "great job", "excellent", "brilliant", "love it",
-    "amazing", "awesome", "impressed", "bravo", "spot on",
-    "nicely done", "good work", "great work", "much appreciated",
-    # Turkish
-    "aferin", "helal", "harikasın", "süpersin", "çok iyi",
-    "teşekkürler", "sağ ol", "güzel iş", "mükemmel", "muhteşem",
-    "bravo", "tebrikler", "eyvallah", "eline sağlık", "harika",
+# ── RLHF keywords & feedback detection (#180 → #226 translation_layer) ──
+# Canonical implementation now in ``translation_layer.py``.
+# Re-exported here for backward compat (test imports, etc.).
+from bantz.core.translation_layer import (  # noqa: F401  — public re-exports
+    POSITIVE_FEEDBACK_KWS,
+    NEGATIVE_FEEDBACK_KWS,
+    detect_feedback as _detect_feedback,
 )
-
-NEGATIVE_FEEDBACK_KWS: tuple[str, ...] = (
-    # English — intent-bearing phrases (not bare "stop" or "bad")
-    "you are wrong", "that's wrong", "that is wrong", "not right",
-    "bad answer", "terrible answer", "useless answer",
-    "you messed up", "not helpful", "completely wrong",
-    "wrong answer", "you failed", "this is wrong",
-    "are you stupid", "are you dumb", "what a mess",
-    # Turkish — intent-bearing phrases
-    "hata yapıyorsun", "saçmalama", "yanlış yaptın", "yanlış cevap",
-    "berbat cevap", "işe yaramaz", "hiç yardımcı olmadın",
-    "hayır yanlış", "olmamış", "ne saçmalıyorsun", "düzelt şunu",
-)
-
-
-def _detect_feedback(raw_input: str) -> str | None:
-    """Check if the *raw* (untranslated) user input contains explicit feedback.
-
-    Uses regex word boundaries (\\b) to prevent false positives like
-    'bus stop' triggering the 'stop' keyword.  Takes the RAW input so
-    Turkish keywords are matched before the translation layer.
-
-    Returns ``'positive'``, ``'negative'``, or ``None``.
-    Negative is checked first (higher priority).
-    """
-    lower = raw_input.lower()
-
-    # Check negative FIRST — scolding outranks praise
-    for kw in NEGATIVE_FEEDBACK_KWS:
-        if re.search(r"\b" + re.escape(kw) + r"\b", lower):
-            return "negative"
-
-    for kw in POSITIVE_FEEDBACK_KWS:
-        if re.search(r"\b" + re.escape(kw) + r"\b", lower):
-            return "positive"
-
-    return None
 
 
 # ── Toast notification hook (#137 → #225 notification_manager) ───────
@@ -249,7 +207,6 @@ class Brain:
             import bantz.tools.gui_action  # noqa: F401  (#123)
         except (ImportError, ModuleNotFoundError):
             pass
-        self._bridge = None
         self._memory_ready = False
         self._graph_ready = False
         # Session state: stores last tool results for contextual follow-ups
@@ -376,59 +333,19 @@ class Brain:
                 pass
 
     def _get_bridge(self):
-        if self._bridge is None:
-            try:
-                from bantz.i18n.bridge import bridge
-                self._bridge = bridge
-            except Exception:
-                self._bridge = False
-        return self._bridge or None
+        """Delegate to translation_layer (#226)."""
+        from bantz.core.translation_layer import get_bridge
+        return get_bridge()
 
     async def _to_en(self, text: str) -> str:
-        b = self._get_bridge()
-        if b and b.is_enabled():
-            try:
-                return await asyncio.wait_for(b.to_english(text), timeout=10)
-            except (asyncio.TimeoutError, Exception):
-                pass
-        return text
+        """Delegate to translation_layer (#226)."""
+        from bantz.core.translation_layer import to_en
+        return await to_en(text)
 
     def _resolve_message_ref(self, text: str) -> str | None:
-        """Resolve contextual email references like 'the first one', 'the linkedin one'."""
-        if not self._last_messages:
-            return None
-
-        t = text.lower().strip()
-
-        # Ordinals
-        _ORDINALS = {
-            "first": 0, "1st": 0, "second": 1, "2nd": 1,
-            "third": 2, "3rd": 2, "fourth": 3, "4th": 3,
-            "fifth": 4, "5th": 4, "last": -1,
-        }
-        for word, idx in _ORDINALS.items():
-            if word in t:
-                try:
-                    return self._last_messages[idx]["id"]
-                except (IndexError, KeyError):
-                    return None
-
-        # Keyword match against sender/subject
-        # "the linkedin one", "the google cloud one", "read the mail from ali"
-        for msg in self._last_messages:
-            sender = (msg.get("from") or "").lower()
-            subject = (msg.get("subject") or "").lower()
-            # Check if any significant word from user input appears in sender or subject
-            words = re.findall(r"[a-zA-Z0-9]{3,}", t)
-            skip = {"read", "that", "this", "the", "one", "email", "mail", "from", "about",
-                    "please", "can", "you", "want", "open", "show", "check"}
-            keywords = [w for w in words if w not in skip]
-            for kw in keywords:
-                if kw in sender or kw in subject:
-                    return msg["id"]
-
-        # No match — return first message as fallback
-        return self._last_messages[0]["id"] if self._last_messages else None
+        """Delegate to translation_layer (#226)."""
+        from bantz.core.translation_layer import resolve_message_ref
+        return resolve_message_ref(text, self._last_messages)
 
     @staticmethod
     def _quick_route(orig: str, en: str) -> dict | None:
@@ -576,20 +493,10 @@ class Brain:
     # ── RL & Intervention hooks (#125, #126) ─────────────────────────
 
     def _rl_reward_hook(self, tool_name: str, result: ToolResult) -> None:
-        """Fire-and-forget: give RL engine a positive reward on tool success."""
+        """Delegate to rl_hooks — offloaded via AsyncDBExecutor (#226)."""
         try:
-            from bantz.agent.rl_engine import rl_engine, encode_state
-            if not rl_engine.initialized:
-                return
-            tc = time_ctx.snapshot()
-            state = encode_state(
-                time_segment=tc.get("time_segment", "morning"),
-                day=tc.get("day_name", "monday").lower(),
-                location=tc.get("location", "home"),
-                recent_tool=tool_name,
-            )
-            reward_val = 1.0 if result.success else -0.5
-            rl_engine.reward(reward_val, next_state=state)
+            from bantz.core.rl_hooks import rl_reward_hook
+            asyncio.get_event_loop().create_task(rl_reward_hook(tool_name, result))
         except Exception:
             pass  # never crash the pipeline
 
@@ -710,18 +617,12 @@ class Brain:
         # before the translation layer converts them to English.
         feedback = _detect_feedback(user_input)
         if feedback:
+            # Offload RL write to AsyncDBExecutor thread-pool (#226)
             try:
-                from bantz.agent.rl_engine import rl_engine, Action, encode_state
-                if rl_engine.initialized:
-                    state = encode_state(
-                        time_segment=tc.get("time_segment", "morning"),
-                        day=tc.get("day_name", "monday").lower(),
-                        location=tc.get("location", "home"),
-                        recent_tool="feedback_chat",
-                    )
-                    reward_val = 2.0 if feedback == "positive" else -2.0
-                    rl_engine.force_reward(state, Action.FEEDBACK_CHAT, reward_val)
-                    log.info("RLHF sentiment: %s → reward %.1f", feedback, reward_val)
+                from bantz.core.rl_hooks import rl_feedback_reward
+                asyncio.get_event_loop().create_task(
+                    rl_feedback_reward(feedback, tc)
+                )
             except Exception:
                 pass  # never crash the pipeline
             if feedback == "positive":

--- a/src/bantz/core/rl_hooks.py
+++ b/src/bantz/core/rl_hooks.py
@@ -1,0 +1,103 @@
+"""
+Bantz — RL Hooks (#226)
+
+Extracted from ``brain.py``: reinforcement-learning reward signals
+that fire after tool execution and sentiment feedback.
+
+Key improvement: ``rl_reward_hook`` now offloads the RL engine's
+synchronous SQLite writes (Q-table updates, episode logs) to the
+``AsyncDBExecutor`` thread-pool (#224), so the async event-loop is
+**never blocked** by RL bookkeeping.
+
+Public API
+----------
+- ``rl_reward_hook(tool_name, result)``          → fire-and-forget async
+- ``rl_feedback_reward(raw_input, time_ctx)``    → sentiment RLHF signal
+"""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bantz.tools import ToolResult
+
+log = logging.getLogger("bantz.rl_hooks")
+
+
+# ── Reward hook (tool success / failure) ─────────────────────────────
+
+
+async def rl_reward_hook(tool_name: str, result: "ToolResult") -> None:
+    """Give the RL engine a reward signal after tool execution.
+
+    Offloads the blocking ``rl_engine.reward()`` call (which writes to
+    SQLite) onto ``AsyncDBExecutor`` so the event-loop stays free.
+
+    Silently swallows all errors — this must never crash the pipeline.
+    """
+    try:
+        from bantz.agent.rl_engine import rl_engine, encode_state
+        if not rl_engine.initialized:
+            return
+
+        from bantz.core.time_context import time_ctx
+        tc = time_ctx.snapshot()
+        state = encode_state(
+            time_segment=tc.get("time_segment", "morning"),
+            day=tc.get("day_name", "monday").lower(),
+            location=tc.get("location", "home"),
+            recent_tool=tool_name,
+        )
+        reward_val = 1.0 if result.success else -0.5
+
+        # Offload the synchronous rl_engine.reward() to the DB thread-pool
+        from bantz.data.async_executor import run_in_db
+        await run_in_db(
+            lambda conn: rl_engine.reward(reward_val, next_state=state),
+            write=True,
+        )
+    except Exception:
+        pass  # never crash the pipeline
+
+
+# ── Sentiment RLHF feedback (#180) ──────────────────────────────────
+
+
+async def rl_feedback_reward(
+    feedback: str,
+    time_snapshot: dict,
+) -> None:
+    """Send a strong sentiment reward to the RL engine.
+
+    Parameters
+    ----------
+    feedback : str
+        ``'positive'`` or ``'negative'``.
+    time_snapshot : dict
+        Result of ``time_ctx.snapshot()`` — provides state context.
+
+    Offloads ``rl_engine.force_reward()`` to the DB thread-pool via
+    ``run_in_db``.
+    """
+    try:
+        from bantz.agent.rl_engine import rl_engine, Action, encode_state
+        if not rl_engine.initialized:
+            return
+
+        state = encode_state(
+            time_segment=time_snapshot.get("time_segment", "morning"),
+            day=time_snapshot.get("day_name", "monday").lower(),
+            location=time_snapshot.get("location", "home"),
+            recent_tool="feedback_chat",
+        )
+        reward_val = 2.0 if feedback == "positive" else -2.0
+
+        from bantz.data.async_executor import run_in_db
+        await run_in_db(
+            lambda conn: rl_engine.force_reward(state, Action.FEEDBACK_CHAT, reward_val),
+            write=True,
+        )
+        log.info("RLHF sentiment: %s → reward %.1f", feedback, reward_val)
+    except Exception:
+        pass  # never crash the pipeline

--- a/src/bantz/core/translation_layer.py
+++ b/src/bantz/core/translation_layer.py
@@ -1,0 +1,165 @@
+"""
+Bantz — Translation Layer (#226)
+
+Extracted from ``brain.py``: language-bridge helpers that run
+*before* the intent router sees the user's message.
+
+Public API
+----------
+- ``get_bridge()``         → cached i18n Bridge instance (or ``None``)
+- ``to_en(text)``          → async translate-to-English (no-op when bridge disabled)
+- ``resolve_message_ref(text, messages)`` → resolve "the first one" to a message-id
+- ``detect_feedback(raw)`` → ``'positive'`` | ``'negative'`` | ``None``
+- ``POSITIVE_FEEDBACK_KWS`` / ``NEGATIVE_FEEDBACK_KWS`` — keyword tuples
+"""
+from __future__ import annotations
+
+import asyncio
+import re
+from typing import Sequence
+
+import logging
+
+log = logging.getLogger("bantz.translation")
+
+# ── Bridge singleton cache ───────────────────────────────────────────
+
+_bridge_cache: object | None = None  # None = not probed, False = unavailable
+
+
+def get_bridge():
+    """Return the i18n Bridge instance, or *None* if unavailable.
+
+    Lazily imports ``bantz.i18n.bridge`` on first call and caches the
+    result so subsequent calls are free.
+    """
+    global _bridge_cache
+    if _bridge_cache is None:
+        try:
+            from bantz.i18n.bridge import bridge
+            _bridge_cache = bridge
+        except Exception:
+            _bridge_cache = False
+    return _bridge_cache or None
+
+
+async def to_en(text: str) -> str:
+    """Translate *text* to English via the i18n bridge.
+
+    Returns the original *text* unchanged when the bridge is disabled
+    or unavailable.
+    """
+    b = get_bridge()
+    if b and b.is_enabled():
+        try:
+            return await asyncio.wait_for(b.to_english(text), timeout=10)
+        except (asyncio.TimeoutError, Exception):
+            pass
+    return text
+
+
+# ── Message-reference resolution ─────────────────────────────────────
+
+_ORDINALS: dict[str, int] = {
+    "first": 0, "1st": 0, "second": 1, "2nd": 1,
+    "third": 2, "3rd": 2, "fourth": 3, "4th": 3,
+    "fifth": 4, "5th": 4, "last": -1,
+}
+
+_SKIP_WORDS = frozenset({
+    "read", "that", "this", "the", "one", "email", "mail", "from",
+    "about", "please", "can", "you", "want", "open", "show", "check",
+})
+
+
+def resolve_message_ref(
+    text: str,
+    messages: Sequence[dict],
+) -> str | None:
+    """Resolve contextual email references like *'the first one'*.
+
+    Parameters
+    ----------
+    text : str
+        The user's (English) input.
+    messages : sequence of dict
+        Previously fetched messages, each with ``id``, ``from``, ``subject``.
+    """
+    if not messages:
+        return None
+
+    t = text.lower().strip()
+
+    # Ordinals
+    for word, idx in _ORDINALS.items():
+        if word in t:
+            try:
+                return messages[idx]["id"]
+            except (IndexError, KeyError):
+                return None
+
+    # Keyword match against sender / subject
+    for msg in messages:
+        sender = (msg.get("from") or "").lower()
+        subject = (msg.get("subject") or "").lower()
+        words = re.findall(r"[a-zA-Z0-9]{3,}", t)
+        keywords = [w for w in words if w not in _SKIP_WORDS]
+        for kw in keywords:
+            if kw in sender or kw in subject:
+                return msg["id"]
+
+    # No match — return first message as fallback
+    return messages[0]["id"] if messages else None
+
+
+# ── Sentiment / RLHF feedback detection (#180) ──────────────────────
+
+POSITIVE_FEEDBACK_KWS: tuple[str, ...] = (
+    # English — phrases & safe single words
+    "good job", "well done", "nice work", "thank you", "thanks a lot",
+    "perfect", "great job", "excellent", "brilliant", "love it",
+    "amazing", "awesome", "impressed", "bravo", "spot on",
+    "nicely done", "good work", "great work", "much appreciated",
+    # Turkish
+    "aferin", "helal", "harikasın", "süpersin", "çok iyi",
+    "teşekkürler", "sağ ol", "güzel iş", "mükemmel", "muhteşem",
+    "bravo", "tebrikler", "eyvallah", "eline sağlık", "harika",
+)
+
+NEGATIVE_FEEDBACK_KWS: tuple[str, ...] = (
+    # English — intent-bearing phrases (not bare "stop" or "bad")
+    "you are wrong", "that's wrong", "that is wrong", "not right",
+    "bad answer", "terrible answer", "useless answer",
+    "you messed up", "not helpful", "completely wrong",
+    "wrong answer", "you failed", "this is wrong",
+    "are you stupid", "are you dumb", "what a mess",
+    # Turkish — intent-bearing phrases
+    "hata yapıyorsun", "saçmalama", "yanlış yaptın", "yanlış cevap",
+    "berbat cevap", "işe yaramaz", "hiç yardımcı olmadın",
+    "hayır yanlış", "olmamış", "ne saçmalıyorsun", "düzelt şunu",
+)
+
+
+def detect_feedback(raw_input: str) -> str | None:
+    """Check if the *raw* (untranslated) user input contains explicit feedback.
+
+    Uses regex word boundaries (``\\b``) to prevent false positives like
+    'bus stop' triggering the 'stop' keyword.  Takes the RAW input so
+    Turkish keywords are matched before the translation layer converts
+    them to English.
+
+    Returns ``'positive'``, ``'negative'``, or ``None``.
+    Negative is checked first (higher priority).
+    """
+    lower = raw_input.lower()
+
+    # Check negative FIRST — scolding outranks praise
+    for kw in NEGATIVE_FEEDBACK_KWS:
+        if re.search(r"\b" + re.escape(kw) + r"\b", lower):
+            return "negative"
+
+    for kw in POSITIVE_FEEDBACK_KWS:
+        if re.search(r"\b" + re.escape(kw) + r"\b", lower):
+            return "positive"
+
+    return None

--- a/tests/core/test_brain_integrations.py
+++ b/tests/core/test_brain_integrations.py
@@ -120,12 +120,11 @@ class TestQuickRouteMaintenanceReflection:
 # ═══════════════════════════════════════════════════════════════════════════
 
 class TestRLRewardHook:
-    """Verify _rl_reward_hook calls rl_engine.reward on tool success/failure."""
+    """Verify _rl_reward_hook delegates to rl_hooks module (#226)."""
 
     def _make_brain(self):
         from bantz.core.brain import Brain
         b = Brain.__new__(Brain)
-        b._bridge = False
         b._memory_ready = True
         b._graph_ready = True
         b._last_messages = []
@@ -134,58 +133,43 @@ class TestRLRewardHook:
         return b
 
     def test_reward_positive_on_success(self):
+        """_rl_reward_hook creates a task that calls rl_hooks.rl_reward_hook."""
         b = self._make_brain()
         from bantz.tools import ToolResult
         result = ToolResult(success=True, output="ok")
 
-        mock_engine = MagicMock()
-        mock_engine.initialized = True
-        mock_encode = MagicMock(return_value=MagicMock(key="morning|monday|home|weather"))
+        mock_rl_hook = AsyncMock()
+        mock_task = MagicMock()
 
-        with patch("bantz.agent.rl_engine.rl_engine", mock_engine), \
-             patch("bantz.agent.rl_engine.encode_state", mock_encode):
+        with patch("bantz.core.rl_hooks.rl_reward_hook", mock_rl_hook), \
+             patch("asyncio.get_event_loop") as mock_loop:
+            mock_loop.return_value.create_task = mock_task
             b._rl_reward_hook("weather", result)
 
-        mock_engine.reward.assert_called_once()
-        call_args = mock_engine.reward.call_args
-        assert call_args[0][0] == 1.0  # positive reward
+        mock_task.assert_called_once()
 
     def test_reward_negative_on_failure(self):
+        """_rl_reward_hook fires for failure results too."""
         b = self._make_brain()
         from bantz.tools import ToolResult
         result = ToolResult(success=False, output="", error="fail")
 
-        mock_engine = MagicMock()
-        mock_engine.initialized = True
-        mock_encode = MagicMock(return_value=MagicMock(key="morning|monday|home|shell"))
+        mock_rl_hook = AsyncMock()
+        mock_task = MagicMock()
 
-        with patch("bantz.agent.rl_engine.rl_engine", mock_engine), \
-             patch("bantz.agent.rl_engine.encode_state", mock_encode):
+        with patch("bantz.core.rl_hooks.rl_reward_hook", mock_rl_hook), \
+             patch("asyncio.get_event_loop") as mock_loop:
+            mock_loop.return_value.create_task = mock_task
             b._rl_reward_hook("shell", result)
 
-        mock_engine.reward.assert_called_once()
-        call_args = mock_engine.reward.call_args
-        assert call_args[0][0] == -0.5  # negative reward
-
-    def test_hook_noop_when_uninitialized(self):
-        b = self._make_brain()
-        from bantz.tools import ToolResult
-        result = ToolResult(success=True, output="ok")
-
-        mock_engine = MagicMock()
-        mock_engine.initialized = False
-
-        with patch("bantz.agent.rl_engine.rl_engine", mock_engine):
-            b._rl_reward_hook("shell", result)
-
-        mock_engine.reward.assert_not_called()
+        mock_task.assert_called_once()
 
     def test_hook_no_crash_on_import_error(self):
         b = self._make_brain()
         from bantz.tools import ToolResult
         result = ToolResult(success=True, output="ok")
 
-        with patch.dict("sys.modules", {"bantz.agent.rl_engine": None}):
+        with patch.dict("sys.modules", {"bantz.core.rl_hooks": None}):
             # Should not raise even when module fails to import
             b._rl_reward_hook("weather", result)
 

--- a/tests/core/test_rl_hooks.py
+++ b/tests/core/test_rl_hooks.py
@@ -1,0 +1,169 @@
+"""Tests for bantz.core.rl_hooks (#226).
+
+Covers:
+  - rl_reward_hook: positive/negative/uninitialized/error paths
+  - rl_feedback_reward: positive/negative sentiment + offloading
+  - AsyncDBExecutor integration (run_in_db is called with write=True)
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bantz.core.rl_hooks import rl_reward_hook, rl_feedback_reward
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# rl_reward_hook
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestRLRewardHook:
+    """rl_reward_hook offloads RL engine via run_in_db."""
+
+    @pytest.mark.asyncio
+    async def test_positive_reward_on_success(self):
+        from bantz.tools import ToolResult
+        result = ToolResult(success=True, output="ok")
+
+        mock_engine = MagicMock()
+        mock_engine.initialized = True
+        mock_encode = MagicMock(return_value=MagicMock(key="morning|monday|home|weather"))
+
+        mock_run_in_db = AsyncMock()
+
+        with patch("bantz.agent.rl_engine.rl_engine", mock_engine), \
+             patch("bantz.agent.rl_engine.encode_state", mock_encode), \
+             patch("bantz.core.time_context.time_ctx") as mock_tc, \
+             patch("bantz.data.async_executor.run_in_db", mock_run_in_db):
+            mock_tc.snapshot.return_value = {
+                "time_segment": "morning",
+                "day_name": "monday",
+                "location": "home",
+            }
+            # Need to re-import to get patched version
+            from bantz.core import rl_hooks
+            await rl_hooks.rl_reward_hook("weather", result)
+
+        mock_run_in_db.assert_called_once()
+        call_kwargs = mock_run_in_db.call_args
+        assert call_kwargs[1]["write"] is True
+
+    @pytest.mark.asyncio
+    async def test_negative_reward_on_failure(self):
+        from bantz.tools import ToolResult
+        result = ToolResult(success=False, output="", error="fail")
+
+        mock_engine = MagicMock()
+        mock_engine.initialized = True
+        mock_encode = MagicMock(return_value=MagicMock(key="morning|monday|home|shell"))
+
+        mock_run_in_db = AsyncMock()
+
+        with patch("bantz.agent.rl_engine.rl_engine", mock_engine), \
+             patch("bantz.agent.rl_engine.encode_state", mock_encode), \
+             patch("bantz.core.time_context.time_ctx") as mock_tc, \
+             patch("bantz.data.async_executor.run_in_db", mock_run_in_db):
+            mock_tc.snapshot.return_value = {
+                "time_segment": "morning",
+                "day_name": "monday",
+                "location": "home",
+            }
+            from bantz.core import rl_hooks
+            await rl_hooks.rl_reward_hook("shell", result)
+
+        mock_run_in_db.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_noop_when_uninitialized(self):
+        from bantz.tools import ToolResult
+        result = ToolResult(success=True, output="ok")
+
+        mock_engine = MagicMock()
+        mock_engine.initialized = False
+
+        mock_run_in_db = AsyncMock()
+
+        with patch("bantz.agent.rl_engine.rl_engine", mock_engine), \
+             patch("bantz.data.async_executor.run_in_db", mock_run_in_db):
+            await rl_reward_hook("shell", result)
+
+        mock_run_in_db.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_crash_on_import_error(self):
+        from bantz.tools import ToolResult
+        result = ToolResult(success=True, output="ok")
+
+        with patch.dict("sys.modules", {"bantz.agent.rl_engine": None}):
+            # Should not raise
+            await rl_reward_hook("weather", result)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# rl_feedback_reward
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestRLFeedbackReward:
+    """rl_feedback_reward offloads sentiment RL signal via run_in_db."""
+
+    @pytest.mark.asyncio
+    async def test_positive_feedback(self):
+        mock_engine = MagicMock()
+        mock_engine.initialized = True
+        mock_encode = MagicMock(return_value=MagicMock())
+        mock_action = MagicMock()
+
+        mock_run_in_db = AsyncMock()
+
+        tc = {"time_segment": "morning", "day_name": "monday", "location": "home"}
+
+        with patch("bantz.agent.rl_engine.rl_engine", mock_engine), \
+             patch("bantz.agent.rl_engine.encode_state", mock_encode), \
+             patch("bantz.agent.rl_engine.Action", mock_action), \
+             patch("bantz.data.async_executor.run_in_db", mock_run_in_db):
+            await rl_feedback_reward("positive", tc)
+
+        mock_run_in_db.assert_called_once()
+        assert mock_run_in_db.call_args[1]["write"] is True
+
+    @pytest.mark.asyncio
+    async def test_negative_feedback(self):
+        mock_engine = MagicMock()
+        mock_engine.initialized = True
+        mock_encode = MagicMock(return_value=MagicMock())
+        mock_action = MagicMock()
+
+        mock_run_in_db = AsyncMock()
+
+        tc = {"time_segment": "evening", "day_name": "friday", "location": "office"}
+
+        with patch("bantz.agent.rl_engine.rl_engine", mock_engine), \
+             patch("bantz.agent.rl_engine.encode_state", mock_encode), \
+             patch("bantz.agent.rl_engine.Action", mock_action), \
+             patch("bantz.data.async_executor.run_in_db", mock_run_in_db):
+            await rl_feedback_reward("negative", tc)
+
+        mock_run_in_db.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_noop_when_uninitialized(self):
+        mock_engine = MagicMock()
+        mock_engine.initialized = False
+
+        mock_run_in_db = AsyncMock()
+
+        tc = {"time_segment": "morning", "day_name": "monday", "location": "home"}
+
+        with patch("bantz.agent.rl_engine.rl_engine", mock_engine), \
+             patch("bantz.data.async_executor.run_in_db", mock_run_in_db):
+            await rl_feedback_reward("positive", tc)
+
+        mock_run_in_db.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_crash_on_import_error(self):
+        with patch.dict("sys.modules", {"bantz.agent.rl_engine": None}):
+            await rl_feedback_reward("positive", {})

--- a/tests/core/test_translation_layer.py
+++ b/tests/core/test_translation_layer.py
@@ -1,0 +1,198 @@
+"""Tests for bantz.core.translation_layer (#226).
+
+Covers:
+  - get_bridge() caching & fallback
+  - to_en() delegation & timeout
+  - resolve_message_ref() ordinals, keyword matching, fallback
+  - detect_feedback() positive/negative/neutral + boundary safety
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bantz.core.translation_layer import (
+    get_bridge,
+    to_en,
+    resolve_message_ref,
+    detect_feedback,
+    POSITIVE_FEEDBACK_KWS,
+    NEGATIVE_FEEDBACK_KWS,
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# get_bridge
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestGetBridge:
+    """Bridge singleton cache."""
+
+    def setup_method(self):
+        """Reset the module-level cache before each test."""
+        import bantz.core.translation_layer as mod
+        mod._bridge_cache = None
+
+    def test_returns_bridge_when_available(self):
+        mock_bridge = MagicMock()
+        import bantz.core.translation_layer as mod
+        mod._bridge_cache = None
+        fake_module = MagicMock(bridge=mock_bridge)
+        with patch.dict("sys.modules", {"bantz.i18n.bridge": fake_module}):
+            result = mod.get_bridge()
+        assert result is mock_bridge
+
+    def test_returns_none_when_import_fails(self):
+        import bantz.core.translation_layer as mod
+        mod._bridge_cache = None
+        with patch.dict("sys.modules", {"bantz.i18n.bridge": None}):
+            mod._bridge_cache = None
+            result = mod.get_bridge()
+        assert result is None
+
+    def test_caches_result(self):
+        import bantz.core.translation_layer as mod
+        sentinel = MagicMock()
+        mod._bridge_cache = sentinel
+        result = mod.get_bridge()
+        assert result is sentinel
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# to_en
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestToEn:
+    """Async translation to English."""
+
+    def setup_method(self):
+        import bantz.core.translation_layer as mod
+        mod._bridge_cache = None
+
+    @pytest.mark.asyncio
+    async def test_passthrough_when_bridge_disabled(self):
+        import bantz.core.translation_layer as mod
+        mod._bridge_cache = False  # bridge unavailable
+        result = await to_en("merhaba dünya")
+        assert result == "merhaba dünya"
+
+    @pytest.mark.asyncio
+    async def test_translates_when_bridge_enabled(self):
+        mock_bridge = MagicMock()
+        mock_bridge.is_enabled.return_value = True
+        mock_bridge.to_english = AsyncMock(return_value="hello world")
+
+        import bantz.core.translation_layer as mod
+        mod._bridge_cache = mock_bridge
+        result = await to_en("merhaba dünya")
+        assert result == "hello world"
+
+    @pytest.mark.asyncio
+    async def test_fallback_on_timeout(self):
+        mock_bridge = MagicMock()
+        mock_bridge.is_enabled.return_value = True
+
+        async def slow_translate(text):
+            await asyncio.sleep(100)  # Will timeout
+            return "translated"
+
+        mock_bridge.to_english = slow_translate
+
+        import bantz.core.translation_layer as mod
+        mod._bridge_cache = mock_bridge
+
+        # Patch asyncio.wait_for timeout to be very short
+        result = await to_en("test")
+        # The 10s timeout won't actually fire in test, but the function
+        # should gracefully handle it. Since we can't easily test real timeout
+        # in a unit test, test the error path directly:
+        mock_bridge.to_english = AsyncMock(side_effect=asyncio.TimeoutError)
+        result = await to_en("test")
+        assert result == "test"  # falls back to original
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# resolve_message_ref
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestResolveMessageRef:
+    """Email/message reference resolution."""
+
+    MESSAGES = [
+        {"id": "msg_1", "from": "ali@test.com", "subject": "LinkedIn Update"},
+        {"id": "msg_2", "from": "google-cloud@google.com", "subject": "Billing Alert"},
+        {"id": "msg_3", "from": "boss@work.com", "subject": "Quarterly Review"},
+    ]
+
+    def test_empty_messages_returns_none(self):
+        assert resolve_message_ref("read the first one", []) is None
+
+    def test_ordinal_first(self):
+        assert resolve_message_ref("read the first one", self.MESSAGES) == "msg_1"
+
+    def test_ordinal_second(self):
+        assert resolve_message_ref("open the second one", self.MESSAGES) == "msg_2"
+
+    def test_ordinal_last(self):
+        assert resolve_message_ref("show me the last email", self.MESSAGES) == "msg_3"
+
+    def test_ordinal_out_of_range(self):
+        assert resolve_message_ref("read the fifth one", self.MESSAGES) is None
+
+    def test_keyword_match_sender(self):
+        assert resolve_message_ref("read the google one", self.MESSAGES) == "msg_2"
+
+    def test_keyword_match_subject(self):
+        assert resolve_message_ref("open the linkedin email", self.MESSAGES) == "msg_1"
+
+    def test_fallback_to_first(self):
+        # No ordinal or keyword match → first message
+        assert resolve_message_ref("read that email", self.MESSAGES) == "msg_1"
+
+    def test_skip_words_not_matched(self):
+        # "please read the email" — all are skip words → fallback
+        assert resolve_message_ref("please read the email", self.MESSAGES) == "msg_1"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# detect_feedback
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestDetectFeedback:
+    """Feedback detection with word-boundary safety."""
+
+    def test_positive_english(self):
+        assert detect_feedback("good job on that") == "positive"
+
+    def test_positive_turkish(self):
+        assert detect_feedback("aferin sana") == "positive"
+
+    def test_negative_english(self):
+        assert detect_feedback("you are wrong about this") == "negative"
+
+    def test_negative_turkish(self):
+        assert detect_feedback("yanlış cevap verdin") == "negative"
+
+    def test_neutral_returns_none(self):
+        assert detect_feedback("what is the weather today") is None
+
+    def test_negative_priority(self):
+        # Negative checked first — if both match, negative wins
+        assert detect_feedback("bravo, but you are wrong") == "negative"
+
+    def test_case_insensitive(self):
+        assert detect_feedback("GOOD JOB") == "positive"
+
+    def test_word_boundary_bus_stop(self):
+        """'bus stop' should NOT trigger feedback."""
+        assert detect_feedback("Can you tell me about the bus stop?") is None
+
+    def test_keyword_tuples_nonempty(self):
+        assert len(POSITIVE_FEEDBACK_KWS) > 0
+        assert len(NEGATIVE_FEEDBACK_KWS) > 0


### PR DESCRIPTION
## Issue #226 — Part 3 of brain.py decomposition (#218)

### What
Extract translation/i18n helpers and RL reward hooks from `brain.py` into standalone modules:

- **`translation_layer.py`** — i18n bridge cache, `to_en()`, `resolve_message_ref()`, feedback detection (`detect_feedback`, keyword tuples)
- **`rl_hooks.py`** — `rl_reward_hook()` and `rl_feedback_reward()`, both offloaded via **AsyncDBExecutor** (`run_in_db`) so the event-loop is never blocked by RL SQLite writes

### Key improvement: AsyncDBExecutor integration
`rl_engine.reward()` and `rl_engine.force_reward()` perform synchronous SQLite writes (Q-table updates, episode logs). Previously these ran on the event-loop thread. Now they are offloaded to the `AsyncDBExecutor` thread-pool via `run_in_db(fn, write=True)` — exactly the pattern built in Part 1 (#224).

### Changes
| File | Delta |
|------|-------|
| `src/bantz/core/brain.py` | –104 LOC (1182 → 1082) |
| `src/bantz/core/translation_layer.py` | +165 LOC (new) |
| `src/bantz/core/rl_hooks.py` | +103 LOC (new) |
| `tests/core/test_translation_layer.py` | +198 LOC, 24 tests |
| `tests/core/test_rl_hooks.py` | +169 LOC, 8 tests |
| `tests/core/test_brain_integrations.py` | Updated for async delegation |

### Backward compat
- `brain._detect_feedback`, `brain.POSITIVE_FEEDBACK_KWS`, `brain.NEGATIVE_FEEDBACK_KWS` re-exported for existing imports
- `Brain._to_en()`, `Brain._resolve_message_ref()`, `Brain._rl_reward_hook()` remain as thin delegation stubs

### Test results
```
2357 passed, 3 failed (pre-existing), 30 skipped
```