### PR TITLE
feat(#220): EventBus — thread-safe async singleton (Sprint 3 Part 1)

### DIFF
--- a/src/bantz/core/event_bus.py
+++ b/src/bantz/core/event_bus.py
@@ -1,0 +1,313 @@
+"""
+Bantz — Thread-Safe Async EventBus (#220, Sprint 3 Part 1)
+
+A **singleton** publish/subscribe event bus that bridges background
+sensor threads (wake_word, observer, ambient) with the asyncio-based
+Brain and Textual TUI.
+
+Design constraints solved here
+-------------------------------
+1. **Thread safety.**  Sensors run on daemon threads (Picovoice C-thread,
+   observer thread).  ``emit_threadsafe()`` enqueues events via
+   ``loop.call_soon_threadsafe`` so the emitter *never* touches the
+   asyncio loop directly.
+
+2. **TUI crash prevention.**  Textual raises ``ThreadError`` when UI is
+   updated outside the main thread.  The bus dispatches events through
+   ``asyncio.Queue`` → an async dispatcher task; TUI subscribers should
+   further relay through ``app.call_from_thread(app.post_message, ...)``
+   inside their own callback.
+
+3. **Zero coupling.**  Sensors import *only* this module; they never
+   import brain.py, tui/app.py, or each other.
+
+Public API (all importable from ``bantz.core.event_bus``)
+---------------------------------------------------------
+.. code-block:: python
+
+    from bantz.core.event_bus import bus, Event
+
+    # ── Publishing (from any thread) ──────────────
+    bus.emit_threadsafe("WAKE_WORD_DETECTED", confidence=0.93)
+
+    # ── Publishing (from inside the asyncio loop) ─
+    await bus.emit("AMBIENT_NOISE_HIGH", rms=450.2)
+
+    # ── Subscribing (async) ───────────────────────
+    async def on_wake(event: Event) -> None:
+        print(event.name, event.data)
+
+    bus.on("WAKE_WORD_DETECTED", on_wake)
+
+    # ── Wildcard (catches everything) ─────────────
+    bus.on("*", my_logger)
+
+    # ── Unsubscribe ───────────────────────────────
+    bus.off("WAKE_WORD_DETECTED", on_wake)
+
+This module is **dependency-free** within the ``bantz`` package — it
+imports nothing from ``bantz.*`` and can be safely imported anywhere.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Awaitable
+
+log = logging.getLogger("bantz.event_bus")
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 1. Event dataclass
+# ═══════════════════════════════════════════════════════════════════════════
+
+@dataclass(frozen=True, slots=True)
+class Event:
+    """Immutable carrier for a single bus event.
+
+    *name* is the channel string (e.g. ``"WAKE_WORD_DETECTED"``).
+    *data* holds arbitrary keyword payload from the emitter.
+    *ts* is auto-stamped at creation (``time.monotonic()``).
+    """
+
+    name: str
+    data: dict[str, Any] = field(default_factory=dict)
+    ts: float = field(default_factory=time.monotonic)
+
+
+# Type aliases for subscriber callbacks
+SyncCallback = Callable[[Event], None]
+AsyncCallback = Callable[[Event], Awaitable[None]]
+Callback = SyncCallback | AsyncCallback
+
+# Sentinel for wildcard subscriptions
+_WILDCARD = "*"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 2. EventBus — thread-safe, asyncio-native singleton
+# ═══════════════════════════════════════════════════════════════════════════
+
+class EventBus:
+    """Thread-safe publish/subscribe event bus.
+
+    The bus owns an internal ``asyncio.Queue`` and a dispatcher task.
+    Events land in the queue from *any* thread via ``emit_threadsafe()``
+    or from the async loop via ``emit()``.  The dispatcher drains the
+    queue and fans out to subscribers one-by-one (async or sync).
+
+    Subscribers are called **in registration order**.  A failing
+    subscriber logs the exception and does **not** prevent subsequent
+    subscribers from running.
+    """
+
+    def __init__(self) -> None:
+        # {event_name: [callback, ...]}  —  "*" key for wildcard
+        self._subs: dict[str, list[Callback]] = {}
+        self._lock = threading.Lock()  # protects _subs
+
+        # Queue + dispatcher task (created lazily on first emit)
+        self._queue: asyncio.Queue[Event] | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._dispatcher_task: asyncio.Task | None = None
+        self._started = False
+
+    # ── lifecycle ─────────────────────────────────────────────────────
+
+    def bind_loop(self, loop: asyncio.AbstractEventLoop | None = None) -> None:
+        """Attach the bus to an asyncio event loop and start dispatching.
+
+        If *loop* is ``None``, uses ``asyncio.get_running_loop()``.
+        Safe to call multiple times (idempotent).
+        """
+        if self._started:
+            return
+        if loop is None:
+            loop = asyncio.get_running_loop()
+        self._loop = loop
+        self._queue = asyncio.Queue()
+        self._dispatcher_task = loop.create_task(
+            self._dispatcher(), name="bantz-event-bus",
+        )
+        self._started = True
+        log.debug("EventBus bound to loop %s", id(loop))
+
+    async def shutdown(self) -> None:
+        """Drain remaining events, cancel the dispatcher, and reset.
+
+        Call during application teardown.
+        """
+        if not self._started:
+            return
+        # Flush remaining items
+        if self._queue is not None:
+            while not self._queue.empty():
+                try:
+                    event = self._queue.get_nowait()
+                    await self._dispatch(event)
+                except asyncio.QueueEmpty:
+                    break
+        if self._dispatcher_task is not None:
+            self._dispatcher_task.cancel()
+            try:
+                await self._dispatcher_task
+            except asyncio.CancelledError:
+                pass
+        self._started = False
+        self._queue = None
+        self._loop = None
+        self._dispatcher_task = None
+        log.debug("EventBus shut down")
+
+    def reset(self) -> None:
+        """Remove all subscribers and reset state.  For testing only."""
+        with self._lock:
+            self._subs.clear()
+        if self._dispatcher_task is not None and not self._dispatcher_task.done():
+            self._dispatcher_task.cancel()
+        self._started = False
+        self._queue = None
+        self._loop = None
+        self._dispatcher_task = None
+
+    # ── subscribe / unsubscribe ───────────────────────────────────────
+
+    def on(self, event_name: str, callback: Callback) -> Callback:
+        """Register *callback* for *event_name*.
+
+        Use ``"*"`` as event_name to catch **all** events (wildcard).
+        Returns the callback for use as a decorator::
+
+            @bus.on("WAKE_WORD_DETECTED")
+            async def handle_wake(event: Event) -> None: ...
+        """
+        with self._lock:
+            self._subs.setdefault(event_name, []).append(callback)
+        return callback
+
+    def off(self, event_name: str, callback: Callback) -> None:
+        """Remove *callback* from *event_name*.  No-op if not registered."""
+        with self._lock:
+            cbs = self._subs.get(event_name)
+            if cbs:
+                try:
+                    cbs.remove(callback)
+                except ValueError:
+                    pass
+                if not cbs:
+                    del self._subs[event_name]
+
+    def clear(self, event_name: str | None = None) -> None:
+        """Remove all subscribers for *event_name*, or all if ``None``."""
+        with self._lock:
+            if event_name is None:
+                self._subs.clear()
+            else:
+                self._subs.pop(event_name, None)
+
+    # ── emit (from asyncio loop) ──────────────────────────────────────
+
+    async def emit(self, event_name: str, **data: Any) -> None:
+        """Emit an event **from inside the running asyncio loop**.
+
+        The event is placed on the internal queue; the dispatcher
+        task picks it up and fans out to subscribers.
+        """
+        event = Event(name=event_name, data=data)
+        if self._queue is not None:
+            await self._queue.put(event)
+        else:
+            # Bus not started yet — dispatch inline as best-effort
+            log.warning("EventBus.emit() called before bind_loop(); "
+                        "dispatching inline for %r", event_name)
+            await self._dispatch(event)
+
+    # ── emit_threadsafe (from any thread) ─────────────────────────────
+
+    def emit_threadsafe(self, event_name: str, **data: Any) -> None:
+        """Emit an event **from any thread** (including C-extension threads).
+
+        This is the primary entry point for sensors running on daemon
+        threads (wake_word, observer).  It uses
+        ``loop.call_soon_threadsafe`` to safely bridge into the async
+        world, so the calling thread *never* blocks or corrupts the
+        event loop.
+        """
+        event = Event(name=event_name, data=data)
+        loop = self._loop
+        if loop is not None and not loop.is_closed():
+            loop.call_soon_threadsafe(self._enqueue_sync, event)
+        else:
+            log.warning(
+                "emit_threadsafe(%r) dropped — no active event loop",
+                event_name,
+            )
+
+    def _enqueue_sync(self, event: Event) -> None:
+        """Put *event* on the queue from within the loop thread.
+
+        Called by ``call_soon_threadsafe`` — guaranteed to run on
+        the loop thread so ``Queue.put_nowait`` is safe.
+        """
+        if self._queue is not None:
+            self._queue.put_nowait(event)
+
+    # ── dispatcher task ───────────────────────────────────────────────
+
+    async def _dispatcher(self) -> None:
+        """Long-running task: drain the queue and fan out to subscribers."""
+        assert self._queue is not None
+        try:
+            while True:
+                event = await self._queue.get()
+                await self._dispatch(event)
+                self._queue.task_done()
+        except asyncio.CancelledError:
+            return
+
+    async def _dispatch(self, event: Event) -> None:
+        """Fan out *event* to matching subscribers + wildcard."""
+        with self._lock:
+            specific = list(self._subs.get(event.name, []))
+            wildcard = list(self._subs.get(_WILDCARD, []))
+        for cb in specific + wildcard:
+            try:
+                ret = cb(event)
+                if asyncio.iscoroutine(ret):
+                    await ret
+            except Exception:
+                log.exception(
+                    "Subscriber %r failed for event %r",
+                    getattr(cb, "__name__", cb),
+                    event.name,
+                )
+
+    # ── introspection ─────────────────────────────────────────────────
+
+    @property
+    def is_running(self) -> bool:
+        """True when the dispatcher task is active."""
+        return self._started and self._dispatcher_task is not None \
+            and not self._dispatcher_task.done()
+
+    def subscriber_count(self, event_name: str | None = None) -> int:
+        """Number of subscribers for *event_name*, or total if ``None``."""
+        with self._lock:
+            if event_name is not None:
+                return len(self._subs.get(event_name, []))
+            return sum(len(v) for v in self._subs.values())
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 3. Module-level singleton
+# ═══════════════════════════════════════════════════════════════════════════
+
+bus = EventBus()
+"""The global event bus instance.  Import and use directly::
+
+    from bantz.core.event_bus import bus
+    bus.emit_threadsafe("MY_EVENT", key="value")
+"""

--- a/tests/core/test_event_bus.py
+++ b/tests/core/test_event_bus.py
@@ -1,0 +1,358 @@
+"""Tests for ``bantz.core.event_bus`` — Thread-safe async EventBus (#220).
+
+Covers:
+  1. Event dataclass (immutability, auto-timestamp)
+  2. Subscribe / unsubscribe / clear
+  3. Async emit + dispatch
+  4. emit_threadsafe from background threads
+  5. Wildcard subscribers
+  6. Subscriber error isolation
+  7. Lifecycle: bind_loop / shutdown / reset
+  8. Introspection helpers
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from bantz.core.event_bus import Event, EventBus
+
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+async def _make_bus() -> EventBus:
+    """Create a fresh EventBus bound to the current running loop."""
+    b = EventBus()
+    b.bind_loop(asyncio.get_running_loop())
+    return b
+
+
+@pytest.fixture()
+async def eb():
+    """Fresh EventBus bound to the test's event loop — auto-shutdown."""
+    b = await _make_bus()
+    yield b
+    await b.shutdown()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 1. Event dataclass
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestEvent:
+    def test_name_and_data(self):
+        e = Event(name="TEST", data={"k": 1})
+        assert e.name == "TEST"
+        assert e.data == {"k": 1}
+
+    def test_auto_timestamp(self):
+        before = time.monotonic()
+        e = Event(name="T")
+        after = time.monotonic()
+        assert before <= e.ts <= after
+
+    def test_frozen(self):
+        e = Event(name="T")
+        with pytest.raises(AttributeError):
+            e.name = "CHANGED"  # type: ignore[misc]
+
+    def test_default_data_is_empty_dict(self):
+        e = Event(name="T")
+        assert e.data == {}
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 2. Subscribe / Unsubscribe
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestSubscription:
+    def test_on_registers_callback(self):
+        b = EventBus()
+        cb = MagicMock()
+        b.on("X", cb)
+        assert b.subscriber_count("X") == 1
+
+    def test_on_returns_callback_for_decorator_use(self):
+        b = EventBus()
+        cb = MagicMock()
+        assert b.on("X", cb) is cb
+
+    def test_off_removes_callback(self):
+        b = EventBus()
+        cb = MagicMock()
+        b.on("X", cb)
+        b.off("X", cb)
+        assert b.subscriber_count("X") == 0
+
+    def test_off_noop_for_unknown(self):
+        """off() must not raise for unregistered callbacks."""
+        b = EventBus()
+        b.off("NEVER", MagicMock())  # no error
+
+    def test_clear_specific(self):
+        b = EventBus()
+        b.on("A", MagicMock())
+        b.on("B", MagicMock())
+        b.clear("A")
+        assert b.subscriber_count("A") == 0
+        assert b.subscriber_count("B") == 1
+
+    def test_clear_all(self):
+        b = EventBus()
+        b.on("A", MagicMock())
+        b.on("B", MagicMock())
+        b.clear()
+        assert b.subscriber_count() == 0
+
+    def test_multiple_subscribers_same_event(self):
+        b = EventBus()
+        b.on("X", MagicMock())
+        b.on("X", MagicMock())
+        assert b.subscriber_count("X") == 2
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 3. Async emit + dispatch
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestAsyncEmit:
+    async def test_async_subscriber_receives_event(self, eb: EventBus):
+        received: list[Event] = []
+
+        async def handler(event: Event) -> None:
+            received.append(event)
+
+        eb.on("PING", handler)
+        await eb.emit("PING", value=42)
+        # Give dispatcher a tick to drain the queue
+        await asyncio.sleep(0.05)
+        assert len(received) == 1
+        assert received[0].name == "PING"
+        assert received[0].data == {"value": 42}
+
+    async def test_sync_subscriber_receives_event(self, eb: EventBus):
+        received: list[Event] = []
+
+        def handler(event: Event) -> None:
+            received.append(event)
+
+        eb.on("PONG", handler)
+        await eb.emit("PONG", v=1)
+        await asyncio.sleep(0.05)
+        assert len(received) == 1
+
+    async def test_multiple_events_ordered(self, eb: EventBus):
+        names: list[str] = []
+
+        async def handler(event: Event) -> None:
+            names.append(event.name)
+
+        eb.on("A", handler)
+        eb.on("B", handler)
+        await eb.emit("A")
+        await eb.emit("B")
+        await eb.emit("A")
+        await asyncio.sleep(0.05)
+        assert names == ["A", "B", "A"]
+
+    async def test_no_subscribers_no_crash(self, eb: EventBus):
+        """Emit with zero subscribers must not raise."""
+        await eb.emit("NOBODY_LISTENS")
+        await asyncio.sleep(0.02)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 4. emit_threadsafe — cross-thread publishing
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestEmitThreadsafe:
+    async def test_event_arrives_from_background_thread(self, eb: EventBus):
+        received: list[Event] = []
+
+        async def handler(event: Event) -> None:
+            received.append(event)
+
+        eb.on("THREAD_EVENT", handler)
+
+        # Fire from a background thread (simulates sensor)
+        def bg():
+            eb.emit_threadsafe("THREAD_EVENT", source="bg_thread")
+
+        t = threading.Thread(target=bg)
+        t.start()
+        t.join(timeout=2)
+        await asyncio.sleep(0.1)
+        assert len(received) == 1
+        assert received[0].data["source"] == "bg_thread"
+
+    async def test_multiple_threads_concurrent(self, eb: EventBus):
+        counter: list[int] = []
+
+        async def handler(event: Event) -> None:
+            counter.append(1)
+
+        eb.on("MT", handler)
+
+        threads = []
+        for i in range(10):
+            t = threading.Thread(target=lambda: eb.emit_threadsafe("MT", i=i))
+            threads.append(t)
+            t.start()
+        for t in threads:
+            t.join(timeout=2)
+
+        await asyncio.sleep(0.2)
+        assert len(counter) == 10
+
+    def test_emit_threadsafe_without_loop_does_not_crash(self):
+        """Before bind_loop(), emit_threadsafe logs a warning and drops."""
+        b = EventBus()  # no bind_loop
+        b.emit_threadsafe("DROPPED")  # must not raise
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 5. Wildcard subscribers
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestWildcard:
+    async def test_wildcard_catches_all(self, eb: EventBus):
+        log: list[str] = []
+
+        async def catch_all(event: Event) -> None:
+            log.append(event.name)
+
+        eb.on("*", catch_all)
+        await eb.emit("ALPHA")
+        await eb.emit("BETA")
+        await asyncio.sleep(0.05)
+        assert log == ["ALPHA", "BETA"]
+
+    async def test_wildcard_plus_specific(self, eb: EventBus):
+        specific_log: list[str] = []
+        wild_log: list[str] = []
+
+        async def specific(e: Event) -> None:
+            specific_log.append(e.name)
+
+        async def wild(e: Event) -> None:
+            wild_log.append(e.name)
+
+        eb.on("ONLY_THIS", specific)
+        eb.on("*", wild)
+
+        await eb.emit("ONLY_THIS")
+        await eb.emit("OTHER")
+        await asyncio.sleep(0.05)
+        assert specific_log == ["ONLY_THIS"]
+        assert wild_log == ["ONLY_THIS", "OTHER"]
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 6. Subscriber error isolation
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestErrorIsolation:
+    async def test_failing_sub_does_not_block_others(self, eb: EventBus):
+        results: list[str] = []
+
+        async def boom(event: Event) -> None:
+            raise RuntimeError("subscriber crash")
+
+        async def safe(event: Event) -> None:
+            results.append("ok")
+
+        eb.on("ERR", boom)
+        eb.on("ERR", safe)
+        await eb.emit("ERR")
+        await asyncio.sleep(0.05)
+        assert results == ["ok"]
+
+    async def test_sync_subscriber_exception_isolated(self, eb: EventBus):
+        results: list[str] = []
+
+        def boom(event: Event) -> None:
+            raise ValueError("sync crash")
+
+        def safe(event: Event) -> None:
+            results.append("ok")
+
+        eb.on("SE", boom)
+        eb.on("SE", safe)
+        await eb.emit("SE")
+        await asyncio.sleep(0.05)
+        assert results == ["ok"]
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 7. Lifecycle: bind_loop / shutdown / reset
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestLifecycle:
+    async def test_bind_loop_is_idempotent(self):
+        b = EventBus()
+        loop = asyncio.get_running_loop()
+        b.bind_loop(loop)
+        task1 = b._dispatcher_task
+        b.bind_loop(loop)  # second call
+        assert b._dispatcher_task is task1  # same task, not duplicated
+        await b.shutdown()
+
+    async def test_shutdown_drains_pending(self):
+        b = EventBus()
+        b.bind_loop(asyncio.get_running_loop())
+
+        received: list[Event] = []
+
+        async def handler(e: Event) -> None:
+            received.append(e)
+
+        b.on("DRAIN", handler)
+        # Put event on queue without giving dispatcher time
+        await b._queue.put(Event(name="DRAIN"))
+        await b.shutdown()  # should drain
+        assert any(e.name == "DRAIN" for e in received)
+
+    def test_reset_clears_everything(self):
+        b = EventBus()
+        b.on("X", MagicMock())
+        b.reset()
+        assert b.subscriber_count() == 0
+        assert not b._started
+
+    async def test_is_running(self):
+        b = EventBus()
+        assert not b.is_running
+        b.bind_loop(asyncio.get_running_loop())
+        assert b.is_running
+        await b.shutdown()
+        assert not b.is_running
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 8. Introspection
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestIntrospection:
+    def test_subscriber_count_specific(self):
+        b = EventBus()
+        b.on("A", MagicMock())
+        b.on("A", MagicMock())
+        b.on("B", MagicMock())
+        assert b.subscriber_count("A") == 2
+        assert b.subscriber_count("B") == 1
+
+    def test_subscriber_count_total(self):
+        b = EventBus()
+        b.on("A", MagicMock())
+        b.on("B", MagicMock())
+        b.on("*", MagicMock())
+        assert b.subscriber_count() == 3
+
+    def test_subscriber_count_empty(self):
+        b = EventBus()
+        assert b.subscriber_count("NOPE") == 0
+        assert b.subscriber_count() == 0


### PR DESCRIPTION
## Summary
Thread-safe asyncio-native EventBus — the foundation for all Sprint 3 sensor work.

### What
- `src/bantz/core/event_bus.py` (314 LOC) — zero internal dependencies
- `tests/core/test_event_bus.py` (29 tests across 8 categories)

### Design
- `Event`: frozen, slotted dataclass (`name`, `data`, `ts`)
- `EventBus`: `asyncio.Queue` + dispatcher task, `threading.Lock` for subscriber registry
- `emit_threadsafe()`: bridges daemon threads → async loop via `call_soon_threadsafe`
- `emit()`: async path for in-loop callers  
- Wildcard `*` subscribers, error isolation (one crash ≠ block others), idempotent `bind_loop()`

### Risks addressed
1. **GIL/thread trap** → `emit_threadsafe` never touches the loop directly
2. **TUI crash** → dispatcher runs on loop thread; TUI subs relay via `call_from_thread`
3. **Wayland** → EventBus is display-agnostic (deferred to Part 4)

### Test results
29 new tests passing | 2476 suite total | 0 regressions

Closes #220 (Part 1 of 6)