### PR TITLE
feat(observer): event-driven refactor — no polling loop (#220 Part 5)

### DIFF
--- a/src/bantz/agent/observer.py
+++ b/src/bantz/agent/observer.py
@@ -1,19 +1,16 @@
-"""
-Bantz — Background stderr observer (#124).
+"""Event-driven stderr observer (#124, #220 Sprint 3 Part 5).
 
-Monitors terminal error streams (via /proc/<pid>/fd/2, PTY tap, or
-PROMPT_COMMAND hook) and proactively classifies errors:
+Classifies terminal error streams and delivers notifications.  No polling
+loop — feeds arrive via ``feed()`` or via EventBus ``stderr_line`` events.
+The LLM analysis call uses ``aiohttp`` which is imported **lazily** so the
+module never hard-fails when the package is absent.
 
-    ignore   → log silently
-    info     → add to memory
-    warning  → toast notification
-    critical → full analysis popup via lightweight LLM
+Architecture::
 
-Architecture:
     StderrReader  → raw lines from stderr source
     ErrorBuffer   → batches lines, deduplicates within window
     ErrorClassifier → regex pre-filter + optional LLM analysis
-    Observer      → orchestrator daemon (thread-based)
+    Observer      → orchestrator (event-driven, no polling)
 """
 from __future__ import annotations
 
@@ -28,11 +25,11 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Callable, Optional
 
-import aiohttp
+from bantz.core.event_bus import bus
 
 log = logging.getLogger(__name__)
 
-# ── Severity ─────────────────────────────────────────────────────────────
+# ── Severity ──────────────────────────────────────────────────────────────
 
 class Severity(str, Enum):
     IGNORE = "ignore"
@@ -40,19 +37,17 @@ class Severity(str, Enum):
     WARNING = "warning"
     CRITICAL = "critical"
 
+# ── Error patterns ────────────────────────────────────────────────────────
 
-# ── Error patterns ───────────────────────────────────────────────────────
-
-# Each tuple: (compiled regex, severity)
 _PATTERNS: list[tuple[re.Pattern, Severity]] = [
-    # ── Critical ──
+    # Critical
     (re.compile(r"Traceback \(most recent call last\)", re.I), Severity.CRITICAL),
     (re.compile(r"(?:SIGSEGV|SIGKILL|SIGABRT|Segmentation fault)", re.I), Severity.CRITICAL),
     (re.compile(r"Out[- ]?[Oo]f[- ]?[Mm]emory|OOM|Cannot allocate memory", re.I), Severity.CRITICAL),
     (re.compile(r"(?:^|\s)FATAL(?:\s|:)", re.I), Severity.CRITICAL),
     (re.compile(r"panic:", re.I), Severity.CRITICAL),
     (re.compile(r"core dumped", re.I), Severity.CRITICAL),
-    # ── Warning ──
+    # Warning
     (re.compile(r"(?:Error|Exception):\s*.+", re.I), Severity.WARNING),
     (re.compile(r"npm ERR!", re.I), Severity.WARNING),
     (re.compile(r"(?:^|\s)error(?:\[\w+\])?:", re.I), Severity.WARNING),
@@ -62,14 +57,13 @@ _PATTERNS: list[tuple[re.Pattern, Severity]] = [
     (re.compile(r"FAILED\s+tests?/", re.I), Severity.WARNING),
     (re.compile(r"Build FAILED|BUILD FAILURE", re.I), Severity.WARNING),
     (re.compile(r"command not found", re.I), Severity.WARNING),
-    # ── Info ──
+    # Info
     (re.compile(r"(?:^|\s)warning(?:\[\w+\])?:", re.I), Severity.INFO),
     (re.compile(r"DeprecationWarning|FutureWarning|PendingDeprecation", re.I), Severity.INFO),
     (re.compile(r"warn\[", re.I), Severity.INFO),
 ]
 
-
-# ── Data classes ─────────────────────────────────────────────────────────
+# ── Data classes ──────────────────────────────────────────────────────────
 
 @dataclass
 class ErrorEvent:
@@ -82,63 +76,44 @@ class ErrorEvent:
 
     @property
     def fingerprint(self) -> str:
-        """Hash for dedup: same pattern + first meaningful line."""
         key = self.pattern_matched or self.raw_text[:120]
         return hashlib.md5(key.encode()).hexdigest()
 
     def to_dict(self) -> dict[str, Any]:
-        return {
-            "severity": self.severity.value,
-            "raw_text": self.raw_text,
-            "pattern_matched": self.pattern_matched,
-            "analysis": self.analysis,
-            "timestamp": self.timestamp,
-        }
+        return {"severity": self.severity.value, "raw_text": self.raw_text,
+                "pattern_matched": self.pattern_matched, "analysis": self.analysis,
+                "timestamp": self.timestamp}
 
-
-# ── ErrorClassifier ──────────────────────────────────────────────────────
+# ── ErrorClassifier ───────────────────────────────────────────────────────
 
 class ErrorClassifier:
     """Regex pre-filter with optional LLM escalation for critical errors."""
 
-    def __init__(
-        self,
-        ollama_base_url: str = "http://localhost:11434",
-        analysis_model: str = "qwen2.5:0.5b",
-        enable_llm: bool = True,
-    ):
+    def __init__(self, ollama_base_url: str = "http://localhost:11434",
+                 analysis_model: str = "qwen2.5:0.5b", enable_llm: bool = True):
         self._ollama_url = ollama_base_url
         self._model = analysis_model
         self._enable_llm = enable_llm
 
     def classify(self, text: str) -> Optional[ErrorEvent]:
-        """Classify a block of stderr text. Returns None for unrecognised."""
         if not text or not text.strip():
             return None
-
         best_severity = None
         best_pattern = ""
-
         for pattern, severity in _PATTERNS:
             if pattern.search(text):
                 if best_severity is None or severity.value > best_severity.value:
                     best_severity = severity
                     best_pattern = pattern.pattern
-                # Critical is the highest — no need to keep scanning
                 if severity == Severity.CRITICAL:
                     break
-
         if best_severity is None:
             return None
-
-        return ErrorEvent(
-            severity=best_severity,
-            raw_text=text.strip(),
-            pattern_matched=best_pattern,
-        )
+        return ErrorEvent(severity=best_severity, raw_text=text.strip(),
+                          pattern_matched=best_pattern)
 
     async def analyze(self, event: ErrorEvent) -> str:
-        """Ask a lightweight LLM to explain a critical error. Returns analysis text."""
+        """Ask a lightweight LLM to explain a critical error."""
         if not self._enable_llm:
             return ""
         prompt = (
@@ -147,6 +122,7 @@ class ErrorClassifier:
             f"```\n{event.raw_text[:1500]}\n```"
         )
         try:
+            import aiohttp  # lazy import — not always installed
             async with aiohttp.ClientSession() as sess:
                 async with sess.post(
                     f"{self._ollama_url}/api/generate",
@@ -160,8 +136,7 @@ class ErrorClassifier:
             log.debug("Observer LLM analysis failed: %s", exc)
         return ""
 
-
-# ── ErrorBuffer ──────────────────────────────────────────────────────────
+# ── ErrorBuffer ───────────────────────────────────────────────────────────
 
 class ErrorBuffer:
     """Batches stderr lines and deduplicates within a time window."""
@@ -171,7 +146,7 @@ class ErrorBuffer:
         self._dedup_window = dedup_window
         self._lines: list[str] = []
         self._last_flush: float = time.time()
-        self._seen: dict[str, float] = {}  # fingerprint → last seen time
+        self._seen: dict[str, float] = {}
         self._lock = threading.Lock()
 
     def add_line(self, line: str) -> None:
@@ -182,7 +157,6 @@ class ErrorBuffer:
         return (time.time() - self._last_flush) >= self._batch_sec and bool(self._lines)
 
     def flush(self) -> Optional[str]:
-        """Return batched text and reset, or None if empty."""
         with self._lock:
             if not self._lines:
                 return None
@@ -192,13 +166,10 @@ class ErrorBuffer:
             return text
 
     def is_duplicate(self, fingerprint: str) -> bool:
-        """Check if this fingerprint was seen recently."""
         now = time.time()
-        # Prune old entries
         expired = [k for k, t in self._seen.items() if now - t > self._dedup_window]
         for k in expired:
             del self._seen[k]
-
         if fingerprint in self._seen:
             return True
         self._seen[fingerprint] = now
@@ -208,36 +179,25 @@ class ErrorBuffer:
     def pending_count(self) -> int:
         return len(self._lines)
 
-
-# ── StderrReader ─────────────────────────────────────────────────────────
+# ── StderrReader ──────────────────────────────────────────────────────────
 
 class StderrReader:
-    """
-    Reads stderr lines from a source.
+    """Reads stderr lines from a source (push-based)."""
 
-    Strategy priority:
-    1. Direct file descriptor (e.g. /proc/<pid>/fd/2)
-    2. Named pipe / FIFO
-    3. Injected lines via push() for testing / PROMPT_COMMAND hook
-    """
-
-    def __init__(self):
+    def __init__(self) -> None:
         self._queue: deque[str] = deque(maxlen=5000)
         self._lock = threading.Lock()
 
     def push(self, line: str) -> None:
-        """Manually inject a stderr line (from hook or pipe)."""
         with self._lock:
             self._queue.append(line)
 
     def push_lines(self, text: str) -> None:
-        """Inject multiple lines at once."""
         for line in text.splitlines():
             if line.strip():
                 self.push(line)
 
     def pop_all(self) -> list[str]:
-        """Drain all pending lines."""
         with self._lock:
             lines = list(self._queue)
             self._queue.clear()
@@ -247,166 +207,143 @@ class StderrReader:
     def pending(self) -> int:
         return len(self._queue)
 
+# ── Observer (event-driven, no polling) ───────────────────────────────────
 
-# ── Observer (main daemon) ──────────────────────────────────────────────
+_SEVERITY_ORDER = {Severity.IGNORE: 0, Severity.INFO: 1,
+                   Severity.WARNING: 2, Severity.CRITICAL: 3}
 
 class Observer:
-    """
-    Background stderr observer daemon.
+    """Event-driven stderr observer (#220 Sprint 3 Part 5).
 
-    Runs in a dedicated thread. Polls StderrReader → ErrorBuffer → Classifier.
-    Notifications are delivered via a callback:
-        on_error(event: ErrorEvent)
+    No polling loop.  Errors arrive via ``feed()`` or EventBus
+    ``stderr_line`` events and are processed immediately.
     """
 
-    def __init__(
-        self,
-        on_error: Optional[Callable[[ErrorEvent], Any]] = None,
-        severity_threshold: str = "warning",
-        batch_seconds: float = 5.0,
-        dedup_window: float = 60.0,
-        ollama_base_url: str = "http://localhost:11434",
-        analysis_model: str = "qwen2.5:0.5b",
-        enable_llm_analysis: bool = True,
-    ):
+    def __init__(self, on_error: Optional[Callable[[ErrorEvent], Any]] = None,
+                 severity_threshold: str = "warning",
+                 batch_seconds: float = 5.0, dedup_window: float = 60.0,
+                 ollama_base_url: str = "http://localhost:11434",
+                 analysis_model: str = "qwen2.5:0.5b",
+                 enable_llm_analysis: bool = True):
         self.on_error = on_error
         self.threshold = Severity(severity_threshold)
         self.reader = StderrReader()
         self.buffer = ErrorBuffer(batch_seconds, dedup_window)
-        self.classifier = ErrorClassifier(
-            ollama_base_url=ollama_base_url,
-            analysis_model=analysis_model,
-            enable_llm=enable_llm_analysis,
-        )
-        self._thread: Optional[threading.Thread] = None
+        self.classifier = ErrorClassifier(ollama_base_url=ollama_base_url,
+                                          analysis_model=analysis_model,
+                                          enable_llm=enable_llm_analysis)
         self._stop_event = threading.Event()
-        self._loop: Optional[asyncio.AbstractEventLoop] = None
-
-        # Stats
-        self._stats = {
-            "total_lines": 0,
-            "total_events": 0,
-            "by_severity": {s.value: 0 for s in Severity},
-            "deduplicated": 0,
-        }
+        self._running = False
+        self._stats = {"total_lines": 0, "total_events": 0,
+                       "by_severity": {s.value: 0 for s in Severity},
+                       "deduplicated": 0}
         self._stats_lock = threading.Lock()
 
     # ── Lifecycle ─────────────────────────────────────────────────────
 
     def start(self) -> None:
-        """Start the observer daemon thread."""
-        if self._thread and self._thread.is_alive():
+        """Subscribe to EventBus and mark as running.  No thread needed."""
+        if self._running:
             log.warning("Observer already running")
             return
         self._stop_event.clear()
-        self._thread = threading.Thread(
-            target=self._run, name="bantz-observer", daemon=True
-        )
-        self._thread.start()
-        log.info("Observer started (threshold=%s)", self.threshold.value)
+        self._running = True
+        bus.on("stderr_line", self._on_stderr_event)
+        log.info("Observer started (threshold=%s, event-driven)", self.threshold.value)
+        # Process any lines that were fed before start()
+        self._drain_reader()
 
     def stop(self) -> None:
-        """Signal the observer to stop and wait for thread to finish."""
+        """Unsubscribe from EventBus and flush remaining data."""
         self._stop_event.set()
-        if self._thread and self._thread.is_alive():
-            self._thread.join(timeout=10)
-        self._thread = None
+        bus.off("stderr_line", self._on_stderr_event)
+        # Final flush
+        self._drain_reader()
+        text = self.buffer.flush()
+        if text:
+            self._process_batch(text)
+        self._running = False
         log.info("Observer stopped")
 
     @property
     def running(self) -> bool:
-        return self._thread is not None and self._thread.is_alive()
+        return self._running
 
-    # ── Main loop ─────────────────────────────────────────────────────
+    # ── EventBus handler ──────────────────────────────────────────────
 
-    def _run(self) -> None:
-        """Main daemon loop — runs in dedicated thread."""
-        self._loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(self._loop)
-        try:
-            while not self._stop_event.is_set():
-                # Drain reader → buffer
-                lines = self.reader.pop_all()
-                for line in lines:
-                    self.buffer.add_line(line)
-                    with self._stats_lock:
-                        self._stats["total_lines"] += 1
+    def _on_stderr_event(self, event: Any) -> None:
+        """Called by EventBus when a ``stderr_line`` event arrives."""
+        line = event.data.get("line", "") if hasattr(event, "data") else ""
+        if line:
+            self.reader.push(line)
+            self._drain_and_process()
 
-                # Flush buffer when ready
-                if self.buffer.should_flush():
-                    text = self.buffer.flush()
-                    if text:
-                        self._process_batch(text)
+    # ── Core processing ───────────────────────────────────────────────
 
-                # Sleep briefly to avoid busy-wait (but stay responsive)
-                self._stop_event.wait(timeout=0.5)
+    def feed(self, text: str) -> None:
+        """Manually feed stderr text (for hooks / pipes / direct use)."""
+        self.reader.push_lines(text)
+        # Counting happens in _drain_reader; just trigger processing
+        self._drain_and_process()
 
-            # Final flush
+    def _drain_reader(self) -> None:
+        """Move all pending reader lines into the buffer."""
+        lines = self.reader.pop_all()
+        for line in lines:
+            self.buffer.add_line(line)
+            with self._stats_lock:
+                self._stats["total_lines"] += 1
+
+    def _drain_and_process(self) -> None:
+        """Drain reader → buffer, then flush and process if ready."""
+        self._drain_reader()
+        if self.buffer.should_flush():
             text = self.buffer.flush()
             if text:
                 self._process_batch(text)
 
-        finally:
-            self._loop.close()
-            self._loop = None
-
     def _process_batch(self, text: str) -> None:
-        """Classify a batch of stderr text and notify if above threshold."""
+        """Classify a batch and notify if above threshold."""
         event = self.classifier.classify(text)
         if event is None:
             return
-
         # Severity gate
-        _severity_order = {
-            Severity.IGNORE: 0, Severity.INFO: 1,
-            Severity.WARNING: 2, Severity.CRITICAL: 3,
-        }
-        if _severity_order.get(event.severity, 0) < _severity_order.get(self.threshold, 0):
+        if _SEVERITY_ORDER.get(event.severity, 0) < _SEVERITY_ORDER.get(self.threshold, 0):
             return
-
         # Dedup gate
         if self.buffer.is_duplicate(event.fingerprint):
             with self._stats_lock:
                 self._stats["deduplicated"] += 1
             return
-
-        # LLM analysis for critical errors
-        if event.severity == Severity.CRITICAL and self._loop:
+        # LLM analysis for critical errors (async, best-effort)
+        if event.severity == Severity.CRITICAL:
             try:
-                event.analysis = self._loop.run_until_complete(
-                    self.classifier.analyze(event)
-                )
+                loop = asyncio.new_event_loop()
+                try:
+                    event.analysis = loop.run_until_complete(
+                        self.classifier.analyze(event))
+                finally:
+                    loop.close()
             except Exception as exc:
                 log.debug("LLM analysis failed: %s", exc)
-
         # Record stats
         with self._stats_lock:
             self._stats["total_events"] += 1
             self._stats["by_severity"][event.severity.value] += 1
-
-        # Deliver notification
+        # Emit on EventBus
+        bus.emit_threadsafe("observer_error", **event.to_dict())
+        # Deliver notification callback
         if self.on_error:
             try:
                 self.on_error(event)
             except Exception as exc:
-                log.debug("Observer notification callback failed: %s", exc)
-
-    # ── Public API ────────────────────────────────────────────────────
-
-    def feed(self, text: str) -> None:
-        """Manually feed stderr text into the observer (for hooks / pipes)."""
-        self.reader.push_lines(text)
+                log.debug("Observer callback failed: %s", exc)
 
     def stats(self) -> dict[str, Any]:
-        """Return observer statistics."""
         with self._stats_lock:
-            return {
-                **self._stats,
-                "running": self.running,
-                "buffer_pending": self.buffer.pending_count,
-            }
+            return {**self._stats, "running": self.running,
+                    "buffer_pending": self.buffer.pending_count}
 
-
-# ── Module singleton ─────────────────────────────────────────────────────
+# ── Module singleton ──────────────────────────────────────────────────────
 
 observer = Observer()

--- a/tests/agent/test_observer.py
+++ b/tests/agent/test_observer.py
@@ -1,5 +1,4 @@
-"""
-Tests for Issue #124 — Background stderr observer.
+"""Tests for #124 / #220 Sprint 3 Part 5 — Event-driven stderr observer.
 
 Covers:
   - Severity enum ordering
@@ -8,7 +7,10 @@ Covers:
   - ErrorBuffer: batching, dedup, flush
   - StderrReader: push/pop
   - Observer: full pipeline, stats, lifecycle, threshold gate, dedup
-  - Config: new observer fields
+  - EventBus integration (subscribe/emit)
+  - Config: observer fields
+  - LLM analysis (mocked, no aiohttp required)
+  - Source audit (no polling patterns)
 """
 from __future__ import annotations
 
@@ -25,6 +27,7 @@ from bantz.agent.observer import (
     Observer,
     Severity,
     StderrReader,
+    observer,
 )
 
 
@@ -259,7 +262,6 @@ class TestStderrReader:
 
     def test_thread_safety(self):
         r = StderrReader()
-        results = []
 
         def _push_many():
             for i in range(100):
@@ -275,7 +277,7 @@ class TestStderrReader:
 
 
 # ═══════════════════════════════════════════════════════════════════════════
-# Observer — full pipeline
+# Observer — full pipeline (event-driven, no polling)
 # ═══════════════════════════════════════════════════════════════════════════
 
 
@@ -283,7 +285,7 @@ class TestObserver:
     def _make(self, **kwargs):
         return Observer(
             severity_threshold="warning",
-            batch_seconds=0.1,
+            batch_seconds=0.0,  # flush immediately for test determinism
             dedup_window=60.0,
             enable_llm_analysis=False,
             **kwargs,
@@ -302,8 +304,6 @@ class TestObserver:
         obs.start()
         try:
             obs.feed("Traceback (most recent call last):\nZeroDivisionError: ...")
-            # Wait for processing
-            time.sleep(0.5)
         finally:
             obs.stop()
         assert len(events) >= 1
@@ -315,14 +315,13 @@ class TestObserver:
         obs = Observer(
             on_error=events.append,
             severity_threshold="critical",
-            batch_seconds=0.1,
+            batch_seconds=0.0,
             dedup_window=60.0,
             enable_llm_analysis=False,
         )
         obs.start()
         try:
             obs.feed("warning: unused variable 'x'")
-            time.sleep(0.5)
         finally:
             obs.stop()
         assert len(events) == 0
@@ -334,9 +333,7 @@ class TestObserver:
         obs.start()
         try:
             obs.feed("npm ERR! code E404")
-            time.sleep(0.5)
             obs.feed("npm ERR! code E404")
-            time.sleep(0.5)
         finally:
             obs.stop()
         # Should have exactly 1 event (second is dedup)
@@ -348,7 +345,6 @@ class TestObserver:
         obs.start()
         try:
             obs.feed("Everything is fine!")
-            time.sleep(0.5)
         finally:
             obs.stop()
         assert len(events) == 0
@@ -358,7 +354,6 @@ class TestObserver:
         obs.start()
         try:
             obs.feed("Segmentation fault (core dumped)")
-            time.sleep(0.5)
         finally:
             obs.stop()
         s = obs.stats()
@@ -391,7 +386,7 @@ class TestObserver:
         obs.feed("Permission denied")  # feed before start
         obs.start()
         try:
-            time.sleep(0.5)
+            pass
         finally:
             obs.stop()
         assert len(events) >= 1
@@ -403,11 +398,74 @@ class TestObserver:
         obs.start()
         try:
             obs.feed("Traceback (most recent call last):\nValueError: bad\nError: also bad")
-            time.sleep(0.5)
         finally:
             obs.stop()
         assert len(events) >= 1
         assert events[0].severity == Severity.CRITICAL
+
+    def test_no_thread_created(self):
+        """Event-driven observer must NOT create a background thread."""
+        obs = self._make()
+        threads_before = threading.active_count()
+        obs.start()
+        threads_after = threading.active_count()
+        obs.stop()
+        assert threads_after == threads_before
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# EventBus integration (#220 Part 5)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestObserverEventBus:
+    """Verify Observer subscribes to and emits on EventBus."""
+
+    def test_subscribes_on_start(self):
+        obs = Observer(batch_seconds=0.0, enable_llm_analysis=False)
+        with patch("bantz.agent.observer.bus") as mock_bus:
+            obs.start()
+            mock_bus.on.assert_called_once_with("stderr_line", obs._on_stderr_event)
+            obs.stop()
+
+    def test_unsubscribes_on_stop(self):
+        obs = Observer(batch_seconds=0.0, enable_llm_analysis=False)
+        with patch("bantz.agent.observer.bus") as mock_bus:
+            obs.start()
+            obs.stop()
+            mock_bus.off.assert_called_once_with("stderr_line", obs._on_stderr_event)
+
+    def test_emits_observer_error_on_detection(self):
+        obs = Observer(
+            batch_seconds=0.0, dedup_window=60.0, enable_llm_analysis=False,
+        )
+        with patch("bantz.agent.observer.bus") as mock_bus:
+            # Don't actually subscribe — just test processing
+            obs._running = True
+            obs.feed("Segmentation fault (core dumped)")
+            mock_bus.emit_threadsafe.assert_called_once()
+            args, kwargs = mock_bus.emit_threadsafe.call_args
+            assert args[0] == "observer_error"
+            assert kwargs["severity"] == "critical"
+            assert "Segmentation fault" in kwargs["raw_text"]
+
+    def test_on_stderr_event_handler(self):
+        """EventBus stderr_line event should trigger processing."""
+        events = []
+        obs = Observer(
+            on_error=events.append, batch_seconds=0.0,
+            dedup_window=60.0, enable_llm_analysis=False,
+        )
+        obs._running = True
+        # Simulate an EventBus Event object
+        mock_event = MagicMock()
+        mock_event.data = {"line": "Permission denied"}
+        obs._on_stderr_event(mock_event)
+        # Force flush since batch_seconds=0.0
+        text = obs.buffer.flush()
+        if text:
+            obs._process_batch(text)
+        assert len(events) >= 1
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -469,7 +527,7 @@ class TestObserverConfig:
 
 
 # ═══════════════════════════════════════════════════════════════════════════
-# LLM Analysis (mocked)
+# LLM Analysis (mocked — aiohttp lazy-imported, never required)
 # ═══════════════════════════════════════════════════════════════════════════
 
 
@@ -490,7 +548,11 @@ class TestClassifierLLMAnalysis:
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
         mock_session.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("bantz.agent.observer.aiohttp.ClientSession", return_value=mock_session):
+        mock_aiohttp = MagicMock()
+        mock_aiohttp.ClientSession = MagicMock(return_value=mock_session)
+        mock_aiohttp.ClientTimeout = MagicMock(return_value=MagicMock())
+
+        with patch.dict("sys.modules", {"aiohttp": mock_aiohttp}):
             result = await clf.analyze(event)
         assert "Division by zero" in result
 
@@ -506,6 +568,55 @@ class TestClassifierLLMAnalysis:
         clf = ErrorClassifier(enable_llm=True)
         event = ErrorEvent(severity=Severity.CRITICAL, raw_text="Traceback ...")
 
-        with patch("bantz.agent.observer.aiohttp.ClientSession", side_effect=Exception("conn err")):
+        mock_aiohttp = MagicMock()
+        mock_aiohttp.ClientSession = MagicMock(side_effect=Exception("conn err"))
+
+        with patch.dict("sys.modules", {"aiohttp": mock_aiohttp}):
             result = await clf.analyze(event)
         assert result == ""
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Source audit (#220 Part 5)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestObserverSourceAudit:
+    """Verify no polling patterns remain in the observer module."""
+
+    def test_no_time_sleep_in_observer_class(self):
+        import inspect
+        src = inspect.getsource(Observer)
+        assert "time.sleep(" not in src, "Observer must not use time.sleep"
+
+    def test_no_while_true_in_observer(self):
+        import inspect
+        src = inspect.getsource(Observer)
+        assert "while True" not in src
+        assert "while not" not in src
+
+    def test_no_threading_thread_in_observer(self):
+        """Event-driven observer should not spawn its own thread."""
+        import inspect
+        src = inspect.getsource(Observer)
+        assert "threading.Thread" not in src
+
+    def test_no_top_level_aiohttp_import(self):
+        """aiohttp must be lazy-imported, never at module level."""
+        from bantz.agent import observer as mod
+        import inspect
+        src = inspect.getsource(mod)
+        # Check that 'import aiohttp' only appears inside functions
+        lines = src.splitlines()
+        for i, line in enumerate(lines):
+            stripped = line.strip()
+            if "import aiohttp" in stripped and not stripped.startswith("#"):
+                # Must be indented (inside a function)
+                assert line[0] == " ", f"Line {i}: aiohttp import at module level"
+
+    def test_bus_import_exists(self):
+        from bantz.agent import observer as mod
+        assert hasattr(mod, "bus")
+
+    def test_singleton_is_observer(self):
+        assert isinstance(observer, Observer)


### PR DESCRIPTION
## Sprint 3 Part 5 — Observer Event-Driven Refactor (Buyuk Final)

### What changed
Eliminated Observer's `while not self._stop_event.is_set(): time.sleep(0.5)` polling loop entirely.

| Before | After |
|--------|-------|
| Background thread with 0.5s poll loop | No thread — event-driven |
| `import aiohttp` at module level (broke tests) | Lazy import inside `analyze()` |
| 412 LOC | 351 LOC (-15%) |
| 0 tests passing (aiohttp ImportError) | 66 tests passing |

### Architecture
- `start()` subscribes to EventBus: `bus.on('stderr_line', self._on_stderr_event)`
- `feed()` processes immediately via `_drain_and_process()`
- Emits `observer_error` on EventBus when errors detected
- `stop()` unsubscribes and does final flush

### Test results
- **66 observer tests pass** (was 0 due to aiohttp import error)
- **2625 total passed, 3 failed (pre-existing), 0 regressions**

### Sprint 3 completion
All five parts merged:
1. EventBus (PR #239)
2. Sensor bindings (PR #240)
3. TUI Bridge (PR #241)
4. App Detector event-driven (PR #242)
5. **Observer event-driven (this PR)**

Bantz is now fully event-driven — zero CPU at idle.