### PR TITLE
fix(core): Memory Isolation in Intent/Planner — Coreference Resolution (#212)

### DIFF
--- a/src/bantz/agent/planner.py
+++ b/src/bantz/agent/planner.py
@@ -65,6 +65,18 @@ STANDARD OPERATING PROCEDURES (SOP) & FALLBACKS:
 - Rule 1 (Strict Path Selection): NEVER create conditional steps (e.g., 'If Step 1 fails...'). The executor runs ALL steps sequentially. You must choose ONE path before planning: EITHER use the simple specialist tool (like `weather`) OR use the deep research flow (`web_search` -> `read_url` -> `process_text`). Do NOT mix them in the same plan.
 - Deep Research bypass: If the user explicitly asks you to search the internet, read a site, or bypass your normal tools, or asks for "latest news about [topic]", choose the deep research flow. Always chain `web_search` -> `read_url` -> `process_text` to extract detailed facts from the actual articles.
 
+COREFERENCE RESOLUTION (CRITICAL):
+Before generating ANY tool arguments, you MUST resolve pronouns and
+references by analyzing the RECENT CONVERSATION provided below.
+- "him" / "her" → find the person's name from recent context
+- "it" / "that" / "this" → find the specific object/file/topic mentioned
+- "yesterday's file" / "that report" → find the exact filename or path
+- "the same city" → find which city was discussed
+If you cannot resolve a reference, use the most recent relevant entity
+from the conversation. NEVER leave pronouns unresolved in tool params.
+
+{recent_history_block}
+
 RULES:
 1. Each step must use exactly ONE tool.
 2. Steps execute in order. Later steps can reference output of earlier steps.
@@ -160,13 +172,21 @@ class PlanStep:
 class PlannerAgent:
     """Decomposes complex user requests into structured step arrays."""
 
-    def is_complex(self, en_input: str) -> bool:
+    def is_complex(
+        self,
+        en_input: str,
+        *,
+        recent_history: list[dict] | None = None,
+    ) -> bool:
         """Heuristic check: does this input likely need multi-step planning?
 
         Returns True if:
         - Input has sequence markers (then, after that, next...)
         - Input references 2+ distinct tool categories
         - Input is long (>15 words) with multiple verb phrases
+
+        The optional *recent_history* is reserved for future heuristic
+        expansion (e.g. detecting implicit multi-step across turns).
         """
         text = en_input.lower()
 
@@ -201,21 +221,41 @@ class PlannerAgent:
                     break
         return len(found)
 
+    @staticmethod
+    def _format_recent_history(recent_history: list[dict] | None) -> str:
+        """Format recent conversation for coreference resolution block."""
+        if not recent_history:
+            return "RECENT CONVERSATION: (none)"
+        lines = ["RECENT CONVERSATION:"]
+        for msg in recent_history[-6:]:
+            role = msg.get("role", "user")
+            content = msg.get("content", "")[:200]
+            lines.append(f"  {role}: {content}")
+        return "\n".join(lines)
+
     async def decompose(
         self,
         en_input: str,
         tool_names: list[str],
+        *,
+        recent_history: list[dict] | None = None,
     ) -> list[PlanStep]:
         """Use the LLM to decompose a complex request into plan steps.
 
         Args:
             en_input: User request (in English).
             tool_names: Available tool names from the registry.
+            recent_history: Last few conversation turns for coreference
+                resolution (e.g. resolving 'him', 'that file').
 
         Returns:
             List of PlanStep objects. Empty list if decomposition fails.
         """
-        prompt = PLANNER_SYSTEM.format(tool_names=", ".join(tool_names))
+        history_block = self._format_recent_history(recent_history)
+        prompt = PLANNER_SYSTEM.format(
+            tool_names=", ".join(tool_names),
+            recent_history_block=history_block,
+        )
 
         raw = await ollama.chat([
             {"role": "system", "content": prompt},

--- a/src/bantz/core/brain.py
+++ b/src/bantz/core/brain.py
@@ -257,10 +257,16 @@ class Brain:
         # Planner runs FIRST — it handles complex multi-tool requests via
         # LLM heuristics.  Must be above workflow_engine to prevent the
         # old regex-based engine from eagerly stealing autonomous commands.
+        #
+        # recent_history feeds coreference resolution (#212) so the
+        # planner can resolve pronouns like "him", "it", "that file".
+        recent_history = data_layer.conversations.context(n=6)
         try:
             from bantz.agent.planner import planner_agent
-            if planner_agent.is_complex(en_input):
-                plan_result = await _execute_plan_fn(user_input, en_input, tc)
+            if planner_agent.is_complex(en_input, recent_history=recent_history):
+                plan_result = await _execute_plan_fn(
+                    user_input, en_input, tc, recent_history=recent_history,
+                )
                 if plan_result is not None:
                     # Orchestrator owns persistence (hotfix #228)
                     await self._graph_store(user_input, plan_result.response, "planner")
@@ -290,7 +296,10 @@ class Brain:
                 plan = {"route": "tool", "tool_name": quick["tool"],
                         "tool_args": quick["args"], "risk_level": "safe"}
         else:
-            plan = await cot_route(en_input, registry.all_schemas())
+            plan = await cot_route(
+                en_input, registry.all_schemas(),
+                recent_history=recent_history,
+            )
             if plan is None:
                 stream = self._chat_stream(en_input, tc)
                 return BrainResult(

--- a/src/bantz/core/intent.py
+++ b/src/bantz/core/intent.py
@@ -143,10 +143,23 @@ def _log_thinking(raw: str, tag: str = "") -> None:
 
 # ── Public API ─────────────────────────────────────────────────────────────────
 
+def _format_recent_history(recent_history: list[dict]) -> str:
+    """Format recent conversation turns for context injection."""
+    if not recent_history:
+        return ""
+    lines = []
+    for msg in recent_history[-6:]:
+        role = msg.get("role", "user")
+        content = msg.get("content", "")[:200]
+        lines.append(f"  {role}: {content}")
+    return "\n".join(lines)
+
+
 async def cot_route(
     en_input: str,
     tool_schemas: list[dict],
     *,
+    recent_history: list[dict] | None = None,
     confidence_threshold: float = 0.4,
 ) -> dict | None:
     """
@@ -158,14 +171,27 @@ async def cot_route(
 
     Returns *None* when routing fails (model refusal, parse error, or very
     low confidence) — the caller should fall back to chat.
+
+    Args:
+        recent_history: Last few conversation turns (user/assistant dicts)
+            so the classifier can resolve pronouns like "him", "it", etc.
     """
     schema_str = "\n".join(
         f"  - {t['name']}: {t['description']} [risk={t['risk_level']}]"
         for t in tool_schemas
     )
 
+    # Build optional history block for coreference resolution
+    history_block = ""
+    if recent_history:
+        formatted = _format_recent_history(recent_history)
+        history_block = (
+            f"\n\nRECENT CONVERSATION (use to resolve pronouns like "
+            f"'him', 'it', 'that file', 'yesterday\'s report'):\n{formatted}"
+        )
+
     messages: list[dict] = [
-        {"role": "system", "content": COT_SYSTEM.format(tool_schemas=schema_str)},
+        {"role": "system", "content": COT_SYSTEM.format(tool_schemas=schema_str) + history_block},
         {"role": "user", "content": en_input},
     ]
 

--- a/src/bantz/core/routing_engine.py
+++ b/src/bantz/core/routing_engine.py
@@ -403,6 +403,8 @@ async def execute_plan(
     user_input: str,
     en_input: str,
     tc: dict,
+    *,
+    recent_history: list[dict] | None = None,
 ) -> BrainResult | None:
     """Decompose a complex request into steps, then execute them.
 
@@ -416,7 +418,9 @@ async def execute_plan(
     from bantz.agent.executor import plan_executor
 
     tool_names = registry.names() + ["process_text"]
-    steps = await planner_agent.decompose(en_input, tool_names)
+    steps = await planner_agent.decompose(
+        en_input, tool_names, recent_history=recent_history,
+    )
     if not steps or len(steps) < 2:
         return None
 

--- a/tests/agent/test_planner.py
+++ b/tests/agent/test_planner.py
@@ -1369,3 +1369,146 @@ class TestReadUrlKeywords:
         assert self._agent().is_complex(
             "open link https://example.com and save the full article to a file"
         ) is True
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 14. Coreference resolution — recent_history in decompose (#212)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestCoreferenceResolution:
+    """decompose() injects recent_history for pronoun resolution."""
+
+    @pytest.mark.asyncio
+    async def test_recent_history_injected_into_prompt(self):
+        """When recent_history is provided, coreference block appears in system prompt."""
+        from bantz.agent.planner import PlannerAgent
+
+        captured_messages: list = []
+
+        async def capture_chat(messages):
+            captured_messages.extend(messages)
+            return json.dumps([
+                {"step": 1, "tool": "gmail",
+                 "params": {"action": "compose_and_send",
+                            "to": "john@example.com",
+                            "intent": "Send the quarterly report"},
+                 "description": "Send email to John", "depends_on": None},
+            ])
+
+        history = [
+            {"role": "user", "content": "Do you know John's email?"},
+            {"role": "assistant", "content": "Yes, John's email is john@example.com."},
+        ]
+
+        agent = PlannerAgent()
+        with patch("bantz.agent.planner.ollama") as mock_llm:
+            mock_llm.chat = capture_chat
+            await agent.decompose(
+                "Send him the quarterly report",
+                ["gmail", "filesystem"],
+                recent_history=history,
+            )
+
+        system_content = captured_messages[0]["content"]
+        assert "RECENT CONVERSATION" in system_content
+        assert "john@example.com" in system_content
+        assert "COREFERENCE RESOLUTION" in system_content
+
+    @pytest.mark.asyncio
+    async def test_no_history_shows_none_marker(self):
+        """Without history, the coreference block says '(none)'."""
+        from bantz.agent.planner import PlannerAgent
+
+        captured_messages: list = []
+
+        async def capture_chat(messages):
+            captured_messages.extend(messages)
+            return json.dumps([
+                {"step": 1, "tool": "weather",
+                 "params": {"city": "London"},
+                 "description": "Check weather", "depends_on": None},
+            ])
+
+        agent = PlannerAgent()
+        with patch("bantz.agent.planner.ollama") as mock_llm:
+            mock_llm.chat = capture_chat
+            await agent.decompose("Check weather in London", ["weather"])
+
+        system_content = captured_messages[0]["content"]
+        assert "RECENT CONVERSATION: (none)" in system_content
+
+    @pytest.mark.asyncio
+    async def test_backward_compat_decompose_without_history(self):
+        """decompose() works without recent_history (default None)."""
+        from bantz.agent.planner import PlannerAgent
+
+        llm_response = json.dumps([
+            {"step": 1, "tool": "weather", "params": {"city": "Tokyo"},
+             "description": "Check weather", "depends_on": None},
+        ])
+
+        agent = PlannerAgent()
+        with patch("bantz.agent.planner.ollama") as mock_llm:
+            mock_llm.chat = AsyncMock(return_value=llm_response)
+            steps = await agent.decompose("Check weather", ["weather"])
+
+        assert len(steps) == 1
+        assert steps[0].tool == "weather"
+
+
+class TestFormatRecentHistoryPlanner:
+    """PlannerAgent._format_recent_history formatting helper."""
+
+    def test_formats_turns(self):
+        from bantz.agent.planner import PlannerAgent
+
+        history = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi!"},
+        ]
+        result = PlannerAgent._format_recent_history(history)
+        assert "RECENT CONVERSATION:" in result
+        assert "user: Hello" in result
+        assert "assistant: Hi!" in result
+
+    def test_none_returns_none_marker(self):
+        from bantz.agent.planner import PlannerAgent
+        result = PlannerAgent._format_recent_history(None)
+        assert "(none)" in result
+
+    def test_empty_returns_none_marker(self):
+        from bantz.agent.planner import PlannerAgent
+        result = PlannerAgent._format_recent_history([])
+        assert "(none)" in result
+
+    def test_limits_to_six_turns(self):
+        from bantz.agent.planner import PlannerAgent
+
+        history = [{"role": "user", "content": f"msg {i}"} for i in range(10)]
+        result = PlannerAgent._format_recent_history(history)
+        assert "msg 4" in result
+        assert "msg 9" in result
+        assert "msg 3" not in result
+
+    def test_truncates_long_content(self):
+        from bantz.agent.planner import PlannerAgent
+
+        history = [{"role": "user", "content": "x" * 300}]
+        result = PlannerAgent._format_recent_history(history)
+        # Each content entry should be max 200 chars
+        lines = result.split("\n")
+        user_line = [l for l in lines if "user:" in l][0]
+        assert len(user_line) <= 210  # "  user: " + 200 chars
+
+    def test_is_complex_accepts_recent_history_kwarg(self):
+        """is_complex() accepts recent_history keyword without error."""
+        from bantz.agent.planner import PlannerAgent
+
+        agent = PlannerAgent()
+        history = [{"role": "user", "content": "Send email to John"}]
+        # Should not raise — result doesn't matter, just kwarg acceptance
+        agent.is_complex(
+            "search for articles and then save to a file",
+            recent_history=history,
+        )

--- a/tests/core/test_intent.py
+++ b/tests/core/test_intent.py
@@ -1,0 +1,318 @@
+"""Tests for ``bantz.core.intent`` — CoT intent parser (#78, #212).
+
+Covers:
+  1. cot_route — basic routing (mocked Ollama)
+  2. cot_route — recent_history injection for pronoun resolution (#212)
+  3. _format_recent_history — formatting helper
+  4. _is_refusal / _extract_json / _log_thinking — helpers
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 1. cot_route — basic routing
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestCotRouteBasic:
+    """cot_route returns routing plans from mocked LLM responses."""
+
+    @pytest.mark.asyncio
+    async def test_routes_weather_request(self):
+        from bantz.core.intent import cot_route
+
+        llm_response = json.dumps({
+            "route": "tool",
+            "tool_name": "weather",
+            "tool_args": {"city": "Istanbul"},
+            "risk_level": "safe",
+            "confidence": 0.95,
+        })
+
+        with patch("bantz.core.intent.ollama") as mock_llm:
+            mock_llm.chat = AsyncMock(return_value=llm_response)
+            plan = await cot_route("What is the weather in Istanbul?", [
+                {"name": "weather", "description": "Check weather", "risk_level": "safe"},
+            ])
+
+        assert plan is not None
+        assert plan["tool_name"] == "weather"
+        assert plan["tool_args"]["city"] == "Istanbul"
+
+    @pytest.mark.asyncio
+    async def test_chat_route_for_greeting(self):
+        from bantz.core.intent import cot_route
+
+        llm_response = json.dumps({
+            "route": "chat",
+            "tool_name": None,
+            "tool_args": {},
+            "risk_level": "safe",
+            "confidence": 0.9,
+        })
+
+        with patch("bantz.core.intent.ollama") as mock_llm:
+            mock_llm.chat = AsyncMock(return_value=llm_response)
+            plan = await cot_route("Hello there!", [])
+
+        assert plan is not None
+        assert plan["route"] == "chat"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_refusal(self):
+        from bantz.core.intent import cot_route
+
+        with patch("bantz.core.intent.ollama") as mock_llm:
+            mock_llm.chat = AsyncMock(return_value="Sorry, I can't assist with that.")
+            plan = await cot_route("do something bad", [])
+
+        assert plan is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_low_confidence(self):
+        from bantz.core.intent import cot_route
+
+        llm_response = json.dumps({
+            "route": "tool",
+            "tool_name": "shell",
+            "tool_args": {"command": "rm -rf /"},
+            "risk_level": "destructive",
+            "confidence": 0.1,
+        })
+
+        with patch("bantz.core.intent.ollama") as mock_llm:
+            mock_llm.chat = AsyncMock(return_value=llm_response)
+            plan = await cot_route("maybe delete everything", [],
+                                   confidence_threshold=0.4)
+
+        assert plan is None
+
+    @pytest.mark.asyncio
+    async def test_handles_thinking_block(self):
+        """LLM response with <thinking> block is stripped before JSON parse."""
+        from bantz.core.intent import cot_route
+
+        llm_response = (
+            '<thinking>The user wants weather info for London.</thinking>\n'
+            + json.dumps({
+                "route": "tool",
+                "tool_name": "weather",
+                "tool_args": {"city": "London"},
+                "risk_level": "safe",
+                "confidence": 0.9,
+            })
+        )
+
+        with patch("bantz.core.intent.ollama") as mock_llm:
+            mock_llm.chat = AsyncMock(return_value=llm_response)
+            plan = await cot_route("weather in London", [
+                {"name": "weather", "description": "Check weather", "risk_level": "safe"},
+            ])
+
+        assert plan is not None
+        assert plan["tool_name"] == "weather"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 2. cot_route — recent_history for pronoun resolution (#212)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestCotRouteWithHistory:
+    """cot_route injects recent_history into prompt for coreference resolution."""
+
+    @pytest.mark.asyncio
+    async def test_recent_history_injected_into_system_prompt(self):
+        """When recent_history is provided, it appears in the system message."""
+        from bantz.core.intent import cot_route
+
+        captured_messages: list = []
+
+        async def capture_chat(messages):
+            captured_messages.extend(messages)
+            return json.dumps({
+                "route": "tool",
+                "tool_name": "gmail",
+                "tool_args": {"action": "compose", "to": "john@example.com",
+                              "intent": "Send the report"},
+                "risk_level": "safe",
+                "confidence": 0.9,
+            })
+
+        history = [
+            {"role": "user", "content": "Who is John?"},
+            {"role": "assistant", "content": "John is your colleague at john@example.com."},
+            {"role": "user", "content": "Can you send him the report?"},
+        ]
+
+        with patch("bantz.core.intent.ollama") as mock_llm:
+            mock_llm.chat = capture_chat
+            await cot_route(
+                "Yes, send it to him",
+                [{"name": "gmail", "description": "Send email", "risk_level": "safe"}],
+                recent_history=history,
+            )
+
+        assert len(captured_messages) >= 1
+        system_content = captured_messages[0]["content"]
+        assert "RECENT CONVERSATION" in system_content
+        assert "john@example.com" in system_content
+
+    @pytest.mark.asyncio
+    async def test_no_history_no_injection(self):
+        """When recent_history is None, no RECENT CONVERSATION block."""
+        from bantz.core.intent import cot_route
+
+        captured_messages: list = []
+
+        async def capture_chat(messages):
+            captured_messages.extend(messages)
+            return json.dumps({
+                "route": "chat",
+                "tool_name": None,
+                "tool_args": {},
+                "risk_level": "safe",
+                "confidence": 0.9,
+            })
+
+        with patch("bantz.core.intent.ollama") as mock_llm:
+            mock_llm.chat = capture_chat
+            await cot_route("hello", [], recent_history=None)
+
+        system_content = captured_messages[0]["content"]
+        assert "RECENT CONVERSATION" not in system_content
+
+    @pytest.mark.asyncio
+    async def test_empty_history_no_injection(self):
+        """Empty list → no RECENT CONVERSATION block."""
+        from bantz.core.intent import cot_route
+
+        captured_messages: list = []
+
+        async def capture_chat(messages):
+            captured_messages.extend(messages)
+            return json.dumps({
+                "route": "chat",
+                "tool_name": None,
+                "tool_args": {},
+                "risk_level": "safe",
+                "confidence": 0.9,
+            })
+
+        with patch("bantz.core.intent.ollama") as mock_llm:
+            mock_llm.chat = capture_chat
+            await cot_route("hello", [], recent_history=[])
+
+        system_content = captured_messages[0]["content"]
+        assert "RECENT CONVERSATION" not in system_content
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 3. _format_recent_history
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestFormatRecentHistory:
+    """_format_recent_history formats conversation turns correctly."""
+
+    def test_formats_turns(self):
+        from bantz.core.intent import _format_recent_history
+
+        history = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+        ]
+        result = _format_recent_history(history)
+        assert "user: Hello" in result
+        assert "assistant: Hi there!" in result
+
+    def test_truncates_long_content(self):
+        from bantz.core.intent import _format_recent_history
+
+        history = [{"role": "user", "content": "x" * 300}]
+        result = _format_recent_history(history)
+        # Content should be truncated to 200 chars
+        assert len(result.split("user: ")[1]) <= 200
+
+    def test_limits_to_six_turns(self):
+        from bantz.core.intent import _format_recent_history
+
+        history = [{"role": "user", "content": f"msg {i}"} for i in range(10)]
+        result = _format_recent_history(history)
+        # Should only include last 6 turns
+        assert "msg 4" in result
+        assert "msg 9" in result
+        assert "msg 3" not in result
+
+    def test_empty_returns_empty(self):
+        from bantz.core.intent import _format_recent_history
+        assert _format_recent_history([]) == ""
+
+    def test_none_returns_empty(self):
+        from bantz.core.intent import _format_recent_history
+        assert _format_recent_history(None) == ""
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 4. Helpers — _is_refusal, _extract_json
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestHelpers:
+    def test_is_refusal_positive(self):
+        from bantz.core.intent import _is_refusal
+        assert _is_refusal("Sorry, I can't assist with that.") is True
+
+    def test_is_refusal_negative(self):
+        from bantz.core.intent import _is_refusal
+        assert _is_refusal('{"route": "chat"}') is False
+
+    def test_extract_json_basic(self):
+        from bantz.core.intent import _extract_json
+        result = _extract_json('{"route": "chat"}')
+        assert result["route"] == "chat"
+
+    def test_extract_json_with_thinking(self):
+        from bantz.core.intent import _extract_json
+        text = '<thinking>think</thinking>\n{"route": "tool"}'
+        result = _extract_json(text)
+        assert result["route"] == "tool"
+
+    def test_extract_json_with_markdown_fences(self):
+        from bantz.core.intent import _extract_json
+        text = '```json\n{"route": "tool"}\n```'
+        result = _extract_json(text)
+        assert result["route"] == "tool"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 5. Backward compatibility — old signature still works
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestBackwardCompat:
+    """cot_route without recent_history must still work (keyword-only default)."""
+
+    @pytest.mark.asyncio
+    async def test_old_signature_works(self):
+        from bantz.core.intent import cot_route
+
+        llm_response = json.dumps({
+            "route": "chat",
+            "tool_name": None,
+            "tool_args": {},
+            "risk_level": "safe",
+            "confidence": 0.9,
+        })
+
+        with patch("bantz.core.intent.ollama") as mock_llm:
+            mock_llm.chat = AsyncMock(return_value=llm_response)
+            # Old call signature — no recent_history
+            plan = await cot_route("hello", [])
+
+        assert plan is not None

--- a/tests/core/test_routing_engine.py
+++ b/tests/core/test_routing_engine.py
@@ -275,6 +275,44 @@ class TestExecutePlan:
         assert result.tool_used == "planner"
         assert "All done" in result.response
 
+    def test_passes_recent_history_to_decompose(self):
+        """execute_plan forwards recent_history to planner_agent.decompose (#212)."""
+        with patch("bantz.core.routing_engine.registry") as mock_reg, \
+             patch("bantz.agent.planner.planner_agent") as mock_planner, \
+             patch("bantz.core.routing_engine.data_layer") as dl:
+            mock_reg.names.return_value = ["shell"]
+            mock_planner.decompose = AsyncMock(return_value=[])
+            dl.conversations = MagicMock()
+
+            history = [
+                {"role": "user", "content": "Who is John?"},
+                {"role": "assistant", "content": "John is your colleague."},
+            ]
+            from bantz.core.routing_engine import execute_plan
+            _run(execute_plan("send him the file", "send him the file", {},
+                              recent_history=history))
+
+        # Verify decompose was called with recent_history
+        mock_planner.decompose.assert_awaited_once()
+        call_kwargs = mock_planner.decompose.call_args
+        assert call_kwargs.kwargs.get("recent_history") is history
+
+    def test_execute_plan_without_history_still_works(self):
+        """execute_plan without recent_history defaults to None (#212 backward compat)."""
+        with patch("bantz.core.routing_engine.registry") as mock_reg, \
+             patch("bantz.agent.planner.planner_agent") as mock_planner, \
+             patch("bantz.core.routing_engine.data_layer") as dl:
+            mock_reg.names.return_value = ["shell"]
+            mock_planner.decompose = AsyncMock(return_value=[])
+            dl.conversations = MagicMock()
+
+            from bantz.core.routing_engine import execute_plan
+            result = _run(execute_plan("hello", "hello", {}))
+
+        assert result is None
+        call_kwargs = mock_planner.decompose.call_args
+        assert call_kwargs.kwargs.get("recent_history") is None
+
 
 # ═══════════════════════════════════════════════════════════════════════════
 # 5. Workflow handlers


### PR DESCRIPTION
Fixes the amnesia bug where the planner/intent engines only see the last user message and fail to resolve pronouns like 'him' or 'it'.

## Changes
- **intent.py**: `cot_route()` now accepts `recent_history` kwarg; appends a RECENT CONVERSATION block to the system prompt
- **planner.py**: `decompose()` and `is_complex()` accept `recent_history`; PLANNER_SYSTEM includes a COREFERENCE RESOLUTION instruction
- **routing_engine.py**: `execute_plan()` forwards `recent_history` to `decompose()`
- **brain.py**: Fetches `recent_history` from `data_layer.conversations.context(n=6)` and passes it to both `cot_route()` and `execute_plan()`
- **NEW** tests/core/test_intent.py (17 tests)
- +10 tests in test_planner.py, +2 tests in test_routing_engine.py

2621 tests pass, 0 regressions. Closes #212