### PR TITLE
feat(tts): Global Voice Responses & Markdown Sanitizer (#247)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -138,6 +138,7 @@ BANTZ_TTS_MODEL_PATH=
 BANTZ_TTS_SPEAKER=0
 BANTZ_TTS_RATE=1.0
 BANTZ_TTS_AUTO_BRIEFING=true
+BANTZ_TTS_SPEAK_ALL_RESPONSES=false
 
 # ── Audio Ducking (#171 — lower other apps while TTS speaks) ────────────
 # Requires pactl (PulseAudio/PipeWire).  Duck percentage = target volume

--- a/src/bantz/agent/tts.py
+++ b/src/bantz/agent/tts.py
@@ -99,6 +99,53 @@ def split_sentences(text: str) -> list[str]:
 
 
 # ═══════════════════════════════════════════════════════════════════════════
+# Markdown sanitizer for TTS (#247)
+# ═══════════════════════════════════════════════════════════════════════════
+
+# Compiled regexes — strict ordering is critical (see issue #247 commentary).
+# 1. Code blocks FIRST (before we strip backticks individually)
+_CODE_BLOCK_RE = re.compile(r"```[\s\S]*?```", re.DOTALL)
+# 2. Inline code backticks
+_INLINE_CODE_RE = re.compile(r"`[^`]+`")
+# 3. Markdown links [text](url) → keep "text"
+_MD_LINK_RE = re.compile(r"\[([^\]]+)\]\([^)]+\)")
+# 4. <thinking>…</thinking> blocks (import-free, self-contained)
+_THINKING_RE = re.compile(r"<thinking>.*?</thinking>\s*", re.DOTALL)
+# 5. Bare URLs
+_URL_RE = re.compile(r"https?://[^\s\"'>]+")
+# 6. Markdown heading hashes, bold/italic markers, blockquote
+_MD_SYMBOLS_RE = re.compile(r"[#*_>~`]+")
+
+
+def strip_markdown_for_tts(text: str) -> str:
+    """Remove code, URLs, and Markdown syntax so TTS reads clean prose.
+
+    Processing order matters — code blocks must be removed **before**
+    individual backtick stripping, otherwise partial code leaks into
+    the speech output and Piper reads it character-by-character.
+
+    Steps (in strict order):
+      1. Remove fenced code blocks (```…```) and all their content.
+      2. Remove inline code (`…`).
+      3. Convert Markdown links [text](url) → text.
+      4. Remove <thinking>…</thinking> internal monologue blocks.
+      5. Remove bare URLs (https://…).
+      6. Strip remaining Markdown symbols (#, *, _, >, ~).
+      7. Collapse whitespace.
+    """
+    if not text:
+        return ""
+    text = _CODE_BLOCK_RE.sub("", text)       # 1
+    text = _INLINE_CODE_RE.sub("", text)      # 2
+    text = _MD_LINK_RE.sub(r"\1", text)       # 3
+    text = _THINKING_RE.sub("", text)         # 4
+    text = _URL_RE.sub("", text)              # 5
+    text = _MD_SYMBOLS_RE.sub("", text)       # 6
+    text = re.sub(r"\s{2,}", " ", text)       # 7 — collapse whitespace
+    return text.strip()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
 # TTS Engine
 # ═══════════════════════════════════════════════════════════════════════════
 

--- a/src/bantz/config.py
+++ b/src/bantz/config.py
@@ -154,6 +154,7 @@ class Config(BaseSettings):
     tts_speaker: int = Field(0, alias="BANTZ_TTS_SPEAKER")
     tts_rate: float = Field(1.0, alias="BANTZ_TTS_RATE")
     tts_auto_briefing: bool = Field(True, alias="BANTZ_TTS_AUTO_BRIEFING")
+    tts_speak_all_responses: bool = Field(False, alias="BANTZ_TTS_SPEAK_ALL_RESPONSES")
 
     # ── Audio Ducking (#171) ──────────────────────────────────────────────
     audio_duck_enabled: bool = Field(False, alias="BANTZ_AUDIO_DUCK_ENABLED")

--- a/src/bantz/interface/tui/app.py
+++ b/src/bantz/interface/tui/app.py
@@ -726,6 +726,19 @@ class BantzApp(App):
             except Exception:
                 pass
 
+            # TTS: speak completed streaming response (#247)
+            try:
+                from bantz.config import config as _cfg
+                if _cfg.tts_speak_all_responses:
+                    from bantz.agent.tts import tts_engine, strip_markdown_for_tts
+                    if tts_engine.available():
+                        tts_engine.stop()
+                        tts_text = strip_markdown_for_tts(full_text)
+                        if tts_text:
+                            asyncio.create_task(tts_engine.speak_background(tts_text))
+            except Exception:
+                pass
+
             self._update_header_counts()
             return
 
@@ -740,6 +753,20 @@ class BantzApp(App):
             if result.tool_used:
                 chat.add_tool(result.tool_used)
             chat.add_bantz(result.response)
+
+            # TTS: speak completed non-streaming response (#247)
+            try:
+                from bantz.config import config as _cfg
+                if _cfg.tts_speak_all_responses:
+                    from bantz.agent.tts import tts_engine, strip_markdown_for_tts
+                    if tts_engine.available():
+                        tts_engine.stop()
+                        tts_text = strip_markdown_for_tts(result.response)
+                        if tts_text:
+                            asyncio.create_task(tts_engine.speak_background(tts_text))
+            except Exception:
+                pass
+
         self._update_header_counts()
 
     async def _handle_confirm(self, text: str, chat: ChatLog) -> None:

--- a/tests/agent/test_tts.py
+++ b/tests/agent/test_tts.py
@@ -834,3 +834,186 @@ class TestTTSSingleton:
     def test_singleton_is_tts_engine(self):
         from bantz.agent.tts import tts_engine, TTSEngine
         assert isinstance(tts_engine, TTSEngine)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 11. strip_markdown_for_tts (#247)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestStripMarkdownForTTS:
+    """Verify the TTS markdown sanitizer strips dangerous content."""
+
+    @staticmethod
+    def _strip(text: str) -> str:
+        from bantz.agent.tts import strip_markdown_for_tts
+        return strip_markdown_for_tts(text)
+
+    # ── Code blocks (Rule 1) ─────────────────────────────────────────────
+
+    def test_fenced_code_block_removed(self):
+        text = "Here's some code:\n```python\ndef foo():\n    return 42\n```\nDone."
+        result = self._strip(text)
+        assert "def foo" not in result
+        assert "return 42" not in result
+        assert "Done" in result
+
+    def test_multiline_code_block_removed(self):
+        text = "Before\n```\nline1\nline2\nline3\n```\nAfter"
+        result = self._strip(text)
+        assert "line1" not in result
+        assert "line2" not in result
+        assert "Before" in result
+        assert "After" in result
+
+    def test_multiple_code_blocks_removed(self):
+        text = "A ```x``` B ```y``` C"
+        result = self._strip(text)
+        assert "x" not in result
+        assert "y" not in result
+        assert "A" in result
+        assert "C" in result
+
+    # ── Inline code (Rule 2) ─────────────────────────────────────────────
+
+    def test_inline_code_removed(self):
+        text = "Use the `strip_thinking()` function."
+        result = self._strip(text)
+        assert "`" not in result
+        assert "strip_thinking()" not in result
+        assert "function" in result
+
+    # ── Markdown links (Rule 3) ──────────────────────────────────────────
+
+    def test_markdown_link_keeps_text(self):
+        text = "Click [here](https://example.com) for details."
+        result = self._strip(text)
+        assert "here" in result
+        assert "https://example.com" not in result
+        assert "(" not in result
+
+    def test_multiple_links(self):
+        text = "[Google](https://google.com) and [GitHub](https://github.com)"
+        result = self._strip(text)
+        assert "Google" in result
+        assert "GitHub" in result
+        assert "https://" not in result
+
+    # ── Thinking blocks (Rule 4) ─────────────────────────────────────────
+
+    def test_thinking_block_removed(self):
+        text = "<thinking>I need to plan carefully.</thinking>The answer is 42."
+        result = self._strip(text)
+        assert "<thinking>" not in result
+        assert "plan carefully" not in result
+        assert "answer is 42" in result
+
+    def test_multiline_thinking_removed(self):
+        text = "<thinking>\nStep 1: analyze.\nStep 2: respond.\n</thinking>\nHere you go."
+        result = self._strip(text)
+        assert "Step 1" not in result
+        assert "Here you go" in result
+
+    # ── Bare URLs (Rule 5) ───────────────────────────────────────────────
+
+    def test_bare_url_removed(self):
+        text = "Check https://example.com/page for more info."
+        result = self._strip(text)
+        assert "https://example.com" not in result
+        assert "Check" in result
+        assert "info" in result
+
+    # ── Markdown symbols (Rule 6) ────────────────────────────────────────
+
+    def test_heading_hashes_removed(self):
+        text = "## Section Title"
+        result = self._strip(text)
+        assert "#" not in result
+        assert "Section Title" in result
+
+    def test_bold_asterisks_removed(self):
+        text = "This is **bold** text."
+        result = self._strip(text)
+        assert "**" not in result
+        assert "bold" in result
+
+    def test_italic_underscores_removed(self):
+        text = "This is _italic_ text."
+        result = self._strip(text)
+        assert "_" not in result
+        assert "italic" in result
+
+    def test_blockquote_removed(self):
+        text = "> This is a quote."
+        result = self._strip(text)
+        assert ">" not in result
+        assert "This is a quote" in result
+
+    # ── Edge cases ───────────────────────────────────────────────────────
+
+    def test_empty_string(self):
+        assert self._strip("") == ""
+
+    def test_plain_text_unchanged(self):
+        text = "Hello, how are you doing today?"
+        assert self._strip(text) == text
+
+    def test_whitespace_collapsed(self):
+        text = "Word   one     two"
+        result = self._strip(text)
+        assert "  " not in result
+
+    def test_combined_kitchen_sink(self):
+        """Full LLM response with code, links, thinking, markdown."""
+        text = (
+            "<thinking>Let me think about this.</thinking>\n"
+            "## Summary\n\n"
+            "Here's the **result**:\n\n"
+            "```python\ndef hello():\n    print('hi')\n```\n\n"
+            "Use the `hello()` function. "
+            "See [docs](https://docs.python.org) for more.\n"
+            "Also check https://example.com/guide for tips."
+        )
+        result = self._strip(text)
+        # Code must be gone
+        assert "def hello" not in result
+        assert "print('hi')" not in result
+        # Inline code gone
+        assert "`" not in result
+        # Thinking gone
+        assert "Let me think" not in result
+        # URLs gone
+        assert "https://" not in result
+        # Markdown symbols gone
+        assert "##" not in result
+        assert "**" not in result
+        # Useful text preserved
+        assert "Summary" in result
+        assert "result" in result
+        assert "docs" in result
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 12. Global TTS config (#247)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestGlobalTTSConfig:
+    """Verify the tts_speak_all_responses config field."""
+
+    def test_config_field_exists(self):
+        from bantz.config import Config
+        cfg = Config()
+        assert hasattr(cfg, "tts_speak_all_responses")
+
+    def test_default_is_false(self):
+        from bantz.config import Config
+        cfg = Config()
+        assert cfg.tts_speak_all_responses is False
+
+    def test_env_alias(self):
+        """Config field has the correct BANTZ_ env alias."""
+        from bantz.config import Config
+        field = Config.model_fields["tts_speak_all_responses"]
+        alias = field.alias
+        assert alias == "BANTZ_TTS_SPEAK_ALL_RESPONSES"


### PR DESCRIPTION
## Summary
Resolves **#247** — Expands Piper TTS from morning-briefings-only to all LLM responses.

### Changes

| File | Change |
|------|--------|
| `src/bantz/config.py` | Add `tts_speak_all_responses` toggle (default `False`) |
| `src/bantz/agent/tts.py` | New `strip_markdown_for_tts()` — 7-step regex pipeline |
| `src/bantz/interface/tui/app.py` | TTS triggers at streaming-complete + non-streaming paths |
| `.env.example` | Add `BANTZ_TTS_SPEAK_ALL_RESPONSES=false` |
| `tests/agent/test_tts.py` | 19 new tests (sanitizer + config) |

### Architect's 3 Mines Defused

**Mine 1 — Spaghetti Reading:** `strip_markdown_for_tts()` uses strict ordered pipeline:
1. Fenced code blocks (```...```) → removed entirely (Piper never reads code)
2. Inline code (\`...\`) → removed
3. Markdown links `[text](url)` → keep text only
4. `<thinking>` blocks → removed
5. Bare URLs → removed
6. MD symbols (`# * _ >`) → removed
7. Whitespace collapsed

**Mine 2 — Overlap Cacophony:** `tts_engine.stop()` called BEFORE every new `speak_background()`. The existing `speak_background` also already cancels prior tasks.

**Mine 3 — Streaming Trap:** TTS triggers only after `chat.stream_end()` returns the complete `full_text`, never during token-by-token streaming.

### Test Results
**2668 passed** (baseline 2648, +20 net new). Only 3 pre-existing failures.

Closes #247