### PR TITLE
feat(tts): Animatronic Voice Filter Pipeline — SoX integration (#248)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -133,12 +133,13 @@ BANTZ_NOTIFICATION_SOUND=false
 
 # ── TTS / Audio Briefing (#131 — Piper text-to-speech) ───────────────────
 BANTZ_TTS_ENABLED=false
-BANTZ_TTS_MODEL=en_US-lessac-medium
+BANTZ_TTS_MODEL=en_US-danny-low
 BANTZ_TTS_MODEL_PATH=
 BANTZ_TTS_SPEAKER=0
 BANTZ_TTS_RATE=1.0
 BANTZ_TTS_AUTO_BRIEFING=true
 BANTZ_TTS_SPEAK_ALL_RESPONSES=false
+BANTZ_TTS_ANIMATRONIC_FILTER=false
 
 # ── Audio Ducking (#171 — lower other apps while TTS speaks) ────────────
 # Requires pactl (PulseAudio/PipeWire).  Duck percentage = target volume

--- a/src/bantz/agent/tts.py
+++ b/src/bantz/agent/tts.py
@@ -156,10 +156,12 @@ class TTSEngine:
     def __init__(self) -> None:
         self._piper_path: str | None = None
         self._aplay_path: str | None = None
+        self._sox_path: str | None = None
         self._model_path: str | None = None
         self._speaker: int = 0
         self._rate: float = 1.0
         self._playing: asyncio.subprocess.Process | None = None
+        self._sox_proc: asyncio.subprocess.Process | None = None
         self._speaking: bool = False
         self._stop_requested: bool = False
         self._speak_task: asyncio.Task | None = None
@@ -244,6 +246,16 @@ class TTSEngine:
         self._model_path = model
         self._speaker = config.tts_speaker
         self._rate = config.tts_rate
+
+        # Discover sox for animatronic filter (#248)
+        sox = shutil.which("sox")
+        if sox:
+            self._sox_path = sox
+            log.info("TTS: sox found at %s (animatronic filter available)", sox)
+        else:
+            self._sox_path = ""
+            log.debug("TTS: sox not found — animatronic filter unavailable")
+
         log.info("TTS: ready — piper=%s model=%s", piper, model)
         return True
 
@@ -391,7 +403,12 @@ class TTSEngine:
     # ── Internal: Playback ──────────────────────────────────────────────
 
     async def _play(self, wav_data: bytes) -> None:
-        """Play raw WAV data via aplay (16-bit, 22050 Hz mono for Piper).
+        """Play raw WAV data via aplay, optionally through SoX (#248).
+
+        When ``config.tts_animatronic_filter`` is enabled **and** ``sox`` is
+        available, the pipeline becomes:
+            stdin → sox (pitch/reverb/overdrive) → aplay
+        Otherwise falls back to direct aplay playback.
 
         Sets PULSE_PROP so PulseAudio/PipeWire labels this stream as
         'BantzTTS' — the audio ducker uses this to skip Bantz's own audio.
@@ -403,37 +420,88 @@ class TTSEngine:
         env = os.environ.copy()
         env["PULSE_PROP"] = "application.name='BantzTTS'"
 
+        # Determine if animatronic SoX filter should be active
+        use_sox = False
         try:
-            proc = await asyncio.create_subprocess_exec(
-                self._aplay_path,
-                "-r", "22050",
-                "-f", "S16_LE",
-                "-t", "raw",
-                "-c", "1",
-                stdin=asyncio.subprocess.PIPE,
-                stdout=asyncio.subprocess.DEVNULL,
-                stderr=asyncio.subprocess.DEVNULL,
-                env=env,
-            )
-            self._playing = proc
-            await proc.communicate(input=wav_data)
-            self._playing = None
+            from bantz.config import config
+            use_sox = config.tts_animatronic_filter and bool(self._sox_path)
+        except Exception:
+            pass
+
+        try:
+            if use_sox:
+                # Pipeline: stdin → sox (effects) → aplay
+                sox_proc = await asyncio.create_subprocess_exec(
+                    self._sox_path,
+                    "-t", "raw", "-r", "22050", "-e", "signed",
+                    "-b", "16", "-c", "1", "-",   # input spec
+                    "-t", "raw", "-",               # output spec
+                    "pitch", "-300",
+                    "reverb", "50",
+                    "overdrive", "10",
+                    stdin=asyncio.subprocess.PIPE,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.DEVNULL,
+                    env=env,
+                )
+                aplay_proc = await asyncio.create_subprocess_exec(
+                    self._aplay_path,
+                    "-r", "22050",
+                    "-f", "S16_LE",
+                    "-t", "raw",
+                    "-c", "1",
+                    stdin=sox_proc.stdout,
+                    stdout=asyncio.subprocess.DEVNULL,
+                    stderr=asyncio.subprocess.DEVNULL,
+                    env=env,
+                )
+                self._sox_proc = sox_proc
+                self._playing = aplay_proc
+
+                # Feed wav data to sox and close its stdin
+                sox_proc.stdin.write(wav_data)
+                await sox_proc.stdin.drain()
+                sox_proc.stdin.close()
+
+                # Wait for both processes to finish
+                await aplay_proc.wait()
+                await sox_proc.wait()
+                self._playing = None
+                self._sox_proc = None
+            else:
+                # Direct: stdin → aplay
+                proc = await asyncio.create_subprocess_exec(
+                    self._aplay_path,
+                    "-r", "22050",
+                    "-f", "S16_LE",
+                    "-t", "raw",
+                    "-c", "1",
+                    stdin=asyncio.subprocess.PIPE,
+                    stdout=asyncio.subprocess.DEVNULL,
+                    stderr=asyncio.subprocess.DEVNULL,
+                    env=env,
+                )
+                self._playing = proc
+                await proc.communicate(input=wav_data)
+                self._playing = None
         except asyncio.CancelledError:
             self._kill_playback()
             raise
         except Exception as exc:
             log.warning("TTS: playback error — %s", exc)
             self._playing = None
+            self._sox_proc = None
 
     def _kill_playback(self) -> None:
-        """Send SIGTERM to the active aplay process."""
-        proc = self._playing
-        if proc and proc.returncode is None:
-            try:
-                proc.send_signal(signal.SIGTERM)
-            except (ProcessLookupError, OSError):
-                pass
-            self._playing = None
+        """Send SIGTERM to active playback processes (aplay + sox)."""
+        for proc in (self._playing, self._sox_proc):
+            if proc and proc.returncode is None:
+                try:
+                    proc.send_signal(signal.SIGTERM)
+                except (ProcessLookupError, OSError):
+                    pass
+        self._playing = None
+        self._sox_proc = None
 
     # ── Diagnostics ─────────────────────────────────────────────────────
 
@@ -443,6 +511,7 @@ class TTSEngine:
             "speaking": self._speaking,
             "piper": self._piper_path or "not found",
             "aplay": self._aplay_path or "not found",
+            "sox": self._sox_path or "not found",
             "model": self._model_path or "not found",
         }
 

--- a/src/bantz/config.py
+++ b/src/bantz/config.py
@@ -149,12 +149,13 @@ class Config(BaseSettings):
 
     # ── TTS / Audio Briefing (#131) ──────────────────────────────────────
     tts_enabled: bool = Field(False, alias="BANTZ_TTS_ENABLED")
-    tts_model: str = Field("en_US-lessac-medium", alias="BANTZ_TTS_MODEL")
+    tts_model: str = Field("en_US-danny-low", alias="BANTZ_TTS_MODEL")
     tts_model_path: str = Field("", alias="BANTZ_TTS_MODEL_PATH")
     tts_speaker: int = Field(0, alias="BANTZ_TTS_SPEAKER")
     tts_rate: float = Field(1.0, alias="BANTZ_TTS_RATE")
     tts_auto_briefing: bool = Field(True, alias="BANTZ_TTS_AUTO_BRIEFING")
     tts_speak_all_responses: bool = Field(False, alias="BANTZ_TTS_SPEAK_ALL_RESPONSES")
+    tts_animatronic_filter: bool = Field(False, alias="BANTZ_TTS_ANIMATRONIC_FILTER")
 
     # ── Audio Ducking (#171) ──────────────────────────────────────────────
     audio_duck_enabled: bool = Field(False, alias="BANTZ_AUDIO_DUCK_ENABLED")

--- a/tests/agent/test_tts.py
+++ b/tests/agent/test_tts.py
@@ -764,7 +764,7 @@ class TestTTSConfig:
         from bantz.config import Config
         cfg = Config(_env_file=None)
         assert cfg.tts_enabled is False
-        assert cfg.tts_model == "en_US-lessac-medium"
+        assert cfg.tts_model == "en_US-danny-low"
         assert cfg.tts_model_path == ""
         assert cfg.tts_speaker == 0
         assert cfg.tts_rate == 1.0
@@ -1017,3 +1017,252 @@ class TestGlobalTTSConfig:
         field = Config.model_fields["tts_speak_all_responses"]
         alias = field.alias
         assert alias == "BANTZ_TTS_SPEAK_ALL_RESPONSES"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 13. Animatronic voice filter config & SoX discovery (#248)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestAnimatronicConfig:
+    """Verify the tts_animatronic_filter config field."""
+
+    def test_field_exists(self):
+        from bantz.config import Config
+        cfg = Config()
+        assert hasattr(cfg, "tts_animatronic_filter")
+
+    def test_default_is_false(self):
+        from bantz.config import Config
+        cfg = Config()
+        assert cfg.tts_animatronic_filter is False
+
+    def test_env_alias(self):
+        from bantz.config import Config
+        field = Config.model_fields["tts_animatronic_filter"]
+        assert field.alias == "BANTZ_TTS_ANIMATRONIC_FILTER"
+
+    def test_default_model_is_danny(self):
+        """Default TTS model should be en_US-danny-low (#248)."""
+        from bantz.config import Config
+        # Check the Field default directly (immune to .env overrides)
+        field = Config.model_fields["tts_model"]
+        assert field.default == "en_US-danny-low"
+
+
+class TestSoxDiscovery:
+    """Verify _ensure_init discovers sox binary."""
+
+    def test_sox_found_when_present(self):
+        """When sox is on PATH, _sox_path is set."""
+        from bantz.agent.tts import TTSEngine
+
+        eng = TTSEngine()
+        model_path = "/tmp/test_model.onnx"
+
+        mock_cfg = MagicMock()
+        mock_cfg.tts_enabled = True
+        mock_cfg.tts_model_path = model_path
+        mock_cfg.tts_model = "en_US-danny-low"
+        mock_cfg.tts_speaker = 0
+        mock_cfg.tts_rate = 1.0
+
+        with patch("bantz.agent.tts.shutil.which") as mock_which, \
+             patch("pathlib.Path.exists", return_value=True), \
+             patch("bantz.config.config", mock_cfg):
+            mock_which.side_effect = lambda name: {
+                "piper": "/usr/bin/piper",
+                "aplay": "/usr/bin/aplay",
+                "sox": "/usr/bin/sox",
+            }.get(name)
+
+            result = eng._ensure_init()
+
+        assert result is True
+        assert eng._sox_path == "/usr/bin/sox"
+
+    def test_sox_not_found(self):
+        """When sox is not on PATH, _sox_path is empty string."""
+        from bantz.agent.tts import TTSEngine
+
+        eng = TTSEngine()
+        model_path = "/tmp/test_model.onnx"
+
+        mock_cfg = MagicMock()
+        mock_cfg.tts_enabled = True
+        mock_cfg.tts_model_path = model_path
+        mock_cfg.tts_model = "en_US-danny-low"
+        mock_cfg.tts_speaker = 0
+        mock_cfg.tts_rate = 1.0
+
+        with patch("bantz.agent.tts.shutil.which") as mock_which, \
+             patch("pathlib.Path.exists", return_value=True), \
+             patch("bantz.config.config", mock_cfg):
+            mock_which.side_effect = lambda name: {
+                "piper": "/usr/bin/piper",
+                "aplay": "/usr/bin/aplay",
+                "sox": None,
+            }.get(name)
+
+            result = eng._ensure_init()
+
+        assert result is True
+        assert eng._sox_path == ""
+
+
+class TestPlayPipeline:
+    """Verify _play uses SoX when animatronic filter is active."""
+
+    @pytest.mark.asyncio
+    async def test_clean_play_no_sox(self):
+        """When filter disabled, only aplay is spawned (no sox)."""
+        from bantz.agent.tts import TTSEngine
+
+        eng = TTSEngine()
+        eng._aplay_path = "/usr/bin/aplay"
+        eng._sox_path = "/usr/bin/sox"
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock()
+        mock_proc.returncode = 0
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec, \
+             patch("bantz.config.config") as mock_cfg:
+            mock_cfg.tts_animatronic_filter = False
+
+            await eng._play(b"\x00" * 100)
+
+        # Should be called exactly once — aplay only
+        assert mock_exec.call_count == 1
+        cmd = mock_exec.call_args[0]
+        assert cmd[0] == "/usr/bin/aplay"
+
+    @pytest.mark.asyncio
+    async def test_animatronic_play_uses_sox(self):
+        """When filter enabled and sox available, two subprocesses are created."""
+        from bantz.agent.tts import TTSEngine
+
+        eng = TTSEngine()
+        eng._aplay_path = "/usr/bin/aplay"
+        eng._sox_path = "/usr/bin/sox"
+
+        # Mock sox process with stdin/stdout pipes
+        mock_sox = MagicMock()
+        mock_sox.stdout = MagicMock()
+        mock_sox.stdin = MagicMock()
+        mock_sox.stdin.write = MagicMock()
+        mock_sox.stdin.drain = AsyncMock()
+        mock_sox.stdin.close = MagicMock()
+        mock_sox.wait = AsyncMock(return_value=0)
+        mock_sox.returncode = 0
+
+        # Mock aplay process
+        mock_aplay = MagicMock()
+        mock_aplay.wait = AsyncMock(return_value=0)
+        mock_aplay.returncode = 0
+
+        call_count = {"n": 0}
+
+        async def mock_exec(*args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return mock_sox
+            return mock_aplay
+
+        with patch("asyncio.create_subprocess_exec", side_effect=mock_exec) as mock_exec_fn, \
+             patch("bantz.config.config") as mock_cfg:
+            mock_cfg.tts_animatronic_filter = True
+
+            await eng._play(b"\x00" * 100)
+
+        # Two subprocesses: sox + aplay
+        assert mock_exec_fn.call_count == 2
+        sox_cmd = mock_exec_fn.call_args_list[0][0]
+        aplay_cmd = mock_exec_fn.call_args_list[1][0]
+        assert sox_cmd[0] == "/usr/bin/sox"
+        assert "pitch" in sox_cmd
+        assert "-300" in sox_cmd
+        assert "reverb" in sox_cmd
+        assert "overdrive" in sox_cmd
+        assert aplay_cmd[0] == "/usr/bin/aplay"
+
+    @pytest.mark.asyncio
+    async def test_animatronic_fallback_when_sox_missing(self):
+        """When filter enabled but sox not found, falls back to clean play."""
+        from bantz.agent.tts import TTSEngine
+
+        eng = TTSEngine()
+        eng._aplay_path = "/usr/bin/aplay"
+        eng._sox_path = ""  # sox not installed
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock()
+        mock_proc.returncode = 0
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec, \
+             patch("bantz.config.config") as mock_cfg:
+            mock_cfg.tts_animatronic_filter = True  # enabled but no sox
+
+            await eng._play(b"\x00" * 100)
+
+        # Falls back to single aplay
+        assert mock_exec.call_count == 1
+        cmd = mock_exec.call_args[0]
+        assert cmd[0] == "/usr/bin/aplay"
+
+    @pytest.mark.asyncio
+    async def test_play_empty_data_noop(self):
+        """Empty wav_data does nothing."""
+        from bantz.agent.tts import TTSEngine
+
+        eng = TTSEngine()
+        eng._aplay_path = "/usr/bin/aplay"
+
+        with patch("asyncio.create_subprocess_exec") as mock_exec:
+            await eng._play(b"")
+
+        mock_exec.assert_not_called()
+
+
+class TestKillPlaybackSox:
+    """Verify _kill_playback terminates both sox and aplay."""
+
+    def test_kill_both_processes(self):
+        from bantz.agent.tts import TTSEngine
+
+        eng = TTSEngine()
+
+        mock_aplay = MagicMock()
+        mock_aplay.returncode = None
+        mock_aplay.send_signal = MagicMock()
+
+        mock_sox = MagicMock()
+        mock_sox.returncode = None
+        mock_sox.send_signal = MagicMock()
+
+        eng._playing = mock_aplay
+        eng._sox_proc = mock_sox
+
+        eng._kill_playback()
+
+        mock_aplay.send_signal.assert_called_once_with(signal.SIGTERM)
+        mock_sox.send_signal.assert_called_once_with(signal.SIGTERM)
+        assert eng._playing is None
+        assert eng._sox_proc is None
+
+    def test_kill_only_aplay_when_no_sox(self):
+        from bantz.agent.tts import TTSEngine
+
+        eng = TTSEngine()
+
+        mock_aplay = MagicMock()
+        mock_aplay.returncode = None
+        mock_aplay.send_signal = MagicMock()
+
+        eng._playing = mock_aplay
+        eng._sox_proc = None
+
+        eng._kill_playback()
+
+        mock_aplay.send_signal.assert_called_once()
+        assert eng._playing is None


### PR DESCRIPTION
## Summary
Resolves **#248** — Adds an optional SoX post-processing pipeline that transforms Piper's clean TTS output into a dark animatronic voice.

### Changes

| File | Change |
|------|--------|
| `src/bantz/config.py` | Default model → `en_US-danny-low`, add `tts_animatronic_filter` toggle |
| `src/bantz/agent/tts.py` | SoX discovery in `_ensure_init`, dual-mode `_play()`, kill both procs |
| `.env.example` | Add `BANTZ_TTS_ANIMATRONIC_FILTER=false`, update default model |
| `tests/agent/test_tts.py` | 12 new tests (config, discovery, pipeline, fallback, kill) |

### How It Works

**Filter OFF** (default) — standard clean pipeline:
```
piper → aplay
```

**Filter ON** (`BANTZ_TTS_ANIMATRONIC_FILTER=true`) — SoX in the middle:
```
piper → sox -t raw -r 22050 -e signed -b 16 -c 1 - -t raw - pitch -300 reverb 50 overdrive 10 → aplay
```

### Graceful Fallback
- If `tts_animatronic_filter=true` but `sox` is not installed → falls back to direct aplay (no crash)
- `_kill_playback()` terminates **both** sox and aplay when user says "sus"
- SoX binary discovered once during lazy init, cached alongside piper/aplay

### Test Results
**2680 passed** (baseline 2668, +12 net new). Only 3 pre-existing failures.

Closes #248