### PR TITLE
feat(voice): The Ghost Loop — Hands-Free STT & VAD Integration (#36)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -133,12 +133,15 @@ BANTZ_NOTIFICATION_SOUND=false
 
 # ── TTS / Audio Briefing (#131 — Piper text-to-speech) ───────────────────
 BANTZ_TTS_ENABLED=false
+# Sesi Danny'e zorla (eski lessac-medium yerine):
 BANTZ_TTS_MODEL=en_US-danny-low
 BANTZ_TTS_MODEL_PATH=
 BANTZ_TTS_SPEAKER=0
 BANTZ_TTS_RATE=1.0
 BANTZ_TTS_AUTO_BRIEFING=true
+# Her LLM cevabında konuşmasını açar:
 BANTZ_TTS_SPEAK_ALL_RESPONSES=false
+# Karanlık mekanik efekt (SoX pitch + reverb + overdrive):
 BANTZ_TTS_ANIMATRONIC_FILTER=false
 
 # ── Audio Ducking (#171 — lower other apps while TTS speaks) ────────────
@@ -152,6 +155,17 @@ BANTZ_AUDIO_DUCK_PCT=30
 BANTZ_WAKE_WORD_ENABLED=false
 BANTZ_PICOVOICE_ACCESS_KEY=
 BANTZ_WAKE_WORD_SENSITIVITY=0.5
+
+# ── Ghost Loop / STT (#36 — hands-free voice input) ─────────────────
+# Requires: pip install faster-whisper webrtcvad
+# Also requires wake word to be enabled (BANTZ_WAKE_WORD_ENABLED=true)
+BANTZ_GHOST_LOOP_ENABLED=false
+BANTZ_STT_ENABLED=false
+BANTZ_STT_MODEL=tiny
+BANTZ_STT_LANGUAGE=en
+BANTZ_STT_DEVICE=cpu
+BANTZ_VAD_SILENCE_MS=800
+BANTZ_VAD_AGGRESSIVENESS=2
 
 # ── Ambient Sound Analysis (#166 — passive env classification) ───────────
 # Piggybacks on wake word mic — requires BANTZ_WAKE_WORD_ENABLED=true

--- a/src/bantz/__main__.py
+++ b/src/bantz/__main__.py
@@ -925,6 +925,29 @@ async def _doctor() -> None:
     else:
         print(f"⚪ Wake Word: disabled  → BANTZ_WAKE_WORD_ENABLED=true")
 
+    # Ghost Loop / STT (#36)
+    if config.ghost_loop_enabled and config.stt_enabled:
+        try:
+            from bantz.agent.ghost_loop import ghost_loop as _gl
+            diag = _gl.diagnose()
+            stt_ok = diag["stt"].get("faster_whisper_available", False)
+            vad_ok = diag["voice_capture"].get("webrtcvad_available", False)
+            if stt_ok and vad_ok:
+                print(f"✅ Ghost Loop: ready (model={config.stt_model}, lang={config.stt_language}, vad_silence={config.vad_silence_ms}ms)")
+            else:
+                missing = []
+                if not stt_ok:
+                    missing.append("faster-whisper")
+                if not vad_ok:
+                    missing.append("webrtcvad")
+                print(f"❌ Ghost Loop: missing deps → pip install {' '.join(missing)}")
+        except Exception as exc:
+            print(f"❌ Ghost Loop: init failed — {exc}")
+    elif config.ghost_loop_enabled:
+        print(f"❌ Ghost Loop: enabled but BANTZ_STT_ENABLED=false")
+    else:
+        print(f"⚪ Ghost Loop: disabled  → BANTZ_GHOST_LOOP_ENABLED=true + BANTZ_STT_ENABLED=true")
+
     # Ambient Sound Analysis (#166)
     if config.ambient_enabled:
         if not config.wake_word_enabled:

--- a/src/bantz/agent/ghost_loop.py
+++ b/src/bantz/agent/ghost_loop.py
@@ -1,0 +1,190 @@
+"""
+Bantz — The Ghost Loop (#36)
+
+Hands-free voice interaction loop that ties together:
+  1. Wake word detection (Porcupine via ``wake_word.py``)
+  2. Voice capture with VAD (``voice_capture.py``)
+  3. Speech-to-text (``stt.py``)
+  4. Brain dispatch via EventBus
+
+Architecture (The Ghost Loop):
+    ┌───────────────────────────────────────────────────────────────┐
+    │  EventBus: "wake_word_detected"                              │
+    │       │                                                      │
+    │       ▼                                                      │
+    │  GhostLoop._on_wake_word()                                   │
+    │       │                                                      │
+    │       ├─ 1. Play earcon (acknowledge)                        │
+    │       ├─ 2. VoiceCapture.capture() [blocking, on thread]     │
+    │       ├─ 3. STTEngine.transcribe(pcm_bytes)                  │
+    │       ├─ 4. Emit "voice_input" to EventBus                   │
+    │       │     (TUI picks this up → displays + brain.process)   │
+    │       └─ 5. Loop back to idle (wake word listener continues) │
+    └───────────────────────────────────────────────────────────────┘
+
+The Ghost Loop runs as a daemon thread.  It subscribes to
+``wake_word_detected`` on the EventBus and chains the capture →
+transcribe → dispatch pipeline each time the wake word fires.
+
+No manual keybinds needed.  Fully hands-free.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+from typing import Optional
+
+from bantz.core.event_bus import bus, Event
+
+log = logging.getLogger("bantz.ghost_loop")
+
+
+class GhostLoop:
+    """Orchestrates the wake → capture → STT → dispatch cycle."""
+
+    def __init__(self) -> None:
+        self._running = False
+        self._busy = False  # True while capture+STT is in progress
+        self._total_transcriptions: int = 0
+        self._last_text: str = ""
+        self._thread_pool: Optional[threading.Thread] = None
+
+    # ── Public API ──────────────────────────────────────────────────────
+
+    def start(self) -> bool:
+        """Start the Ghost Loop — subscribe to wake_word_detected.
+
+        Returns True if started successfully.
+        """
+        if self._running:
+            return True
+
+        try:
+            from bantz.config import config
+            if not config.ghost_loop_enabled:
+                log.debug("Ghost Loop: disabled (BANTZ_GHOST_LOOP_ENABLED=false)")
+                return False
+            if not config.stt_enabled:
+                log.debug("Ghost Loop: STT disabled (BANTZ_STT_ENABLED=false)")
+                return False
+        except Exception:
+            return False
+
+        # Subscribe to wake word events
+        bus.on("wake_word_detected", self._on_wake_event)
+        self._running = True
+        log.info("Ghost Loop: active — waiting for wake word")
+        return True
+
+    def stop(self) -> None:
+        """Stop the Ghost Loop."""
+        if not self._running:
+            return
+        bus.off("wake_word_detected", self._on_wake_event)
+        self._running = False
+        log.info("Ghost Loop: stopped (total transcriptions: %d)",
+                 self._total_transcriptions)
+
+    @property
+    def running(self) -> bool:
+        return self._running
+
+    @property
+    def busy(self) -> bool:
+        return self._busy
+
+    def stats(self) -> dict:
+        return {
+            "running": self._running,
+            "busy": self._busy,
+            "total_transcriptions": self._total_transcriptions,
+            "last_text": self._last_text[:80] if self._last_text else "",
+        }
+
+    # ── Event handler ───────────────────────────────────────────────────
+
+    def _on_wake_event(self, event: Event) -> None:
+        """Called (on the bus dispatcher) when wake word is detected.
+
+        Spawns the capture → STT → dispatch pipeline on a background
+        thread to avoid blocking the event bus dispatcher.
+        """
+        if self._busy:
+            log.debug("Ghost Loop: already busy, ignoring wake word")
+            return
+
+        # Run the blocking pipeline on a separate thread
+        thread = threading.Thread(
+            target=self._capture_and_transcribe,
+            name="bantz-ghost-loop",
+            daemon=True,
+        )
+        thread.start()
+
+    # ── Pipeline (runs on background thread) ────────────────────────────
+
+    def _capture_and_transcribe(self) -> None:
+        """Blocking pipeline: capture audio → STT → emit to bus."""
+        self._busy = True
+
+        try:
+            # 1. Emit "listening" event so TUI can show indicator
+            bus.emit_threadsafe("ghost_loop_listening")
+
+            # 2. Capture audio with VAD
+            from bantz.agent.voice_capture import voice_capture
+            pcm_bytes = voice_capture.capture()
+
+            if not pcm_bytes:
+                log.info("Ghost Loop: no audio captured")
+                bus.emit_threadsafe("ghost_loop_idle")
+                return
+
+            # 3. Emit "transcribing" event
+            bus.emit_threadsafe("ghost_loop_transcribing")
+
+            # 4. Transcribe via faster-whisper
+            from bantz.agent.stt import stt_engine
+            text = stt_engine.transcribe(pcm_bytes)
+
+            if not text:
+                log.info("Ghost Loop: STT returned empty")
+                bus.emit_threadsafe("ghost_loop_idle")
+                return
+
+            self._total_transcriptions += 1
+            self._last_text = text
+            log.info("Ghost Loop: transcribed → \"%s\"", text[:80])
+
+            # 5. Dispatch as a voice input event
+            #    The TUI subscribes to this and feeds it to brain.process()
+            bus.emit_threadsafe("voice_input", text=text)
+
+        except Exception as exc:
+            log.error("Ghost Loop: pipeline error — %s", exc)
+        finally:
+            self._busy = False
+            try:
+                bus.emit_threadsafe("ghost_loop_idle")
+            except Exception:
+                pass
+
+    # ── Diagnostics ─────────────────────────────────────────────────────
+
+    def diagnose(self) -> dict:
+        """Diagnostic info for --doctor."""
+        from bantz.agent.voice_capture import voice_capture
+        from bantz.agent.stt import stt_engine
+
+        return {
+            "running": self._running,
+            "busy": self._busy,
+            "total_transcriptions": self._total_transcriptions,
+            "voice_capture": voice_capture.diagnose(),
+            "stt": stt_engine.diagnose(),
+        }
+
+
+# Module singleton
+ghost_loop = GhostLoop()

--- a/src/bantz/agent/stt.py
+++ b/src/bantz/agent/stt.py
@@ -1,0 +1,238 @@
+"""
+Bantz — Local STT via faster-whisper (#36, The Ghost Loop)
+
+Transcribes raw PCM audio to text using faster-whisper, a CTranslate2-
+accelerated Whisper implementation.  Runs completely offline on CPU
+(or GPU if available).
+
+Architecture:
+    ┌─────────────────────────────────────────────────────────┐
+    │                   STTEngine                             │
+    │                                                         │
+    │  1. Lazy-load model on first transcribe() call          │
+    │  2. Accept raw PCM bytes (16-bit, 16 kHz, mono)         │
+    │  3. Convert to float32 numpy array                      │
+    │  4. Run Whisper inference → segments                    │
+    │  5. Concatenate segment texts → return string           │
+    └─────────────────────────────────────────────────────────┘
+
+Model sizes (approximate, CPU):
+    tiny   — ~39 MB  — fast, good for English
+    base   — ~74 MB  — better accuracy
+    small  — ~244 MB — best quality for resource-constrained
+
+Dependencies:
+    pip install faster-whisper
+
+Graceful degradation: if faster-whisper is not installed,
+``transcribe()`` returns None and logs a warning.
+"""
+from __future__ import annotations
+
+import logging
+import tempfile
+import struct
+import wave
+from pathlib import Path
+from typing import Optional
+
+log = logging.getLogger("bantz.stt")
+
+# Audio format matching VoiceCapture output
+_SAMPLE_RATE = 16000
+_SAMPLE_WIDTH = 2  # 16-bit
+_CHANNELS = 1
+
+
+class STTEngine:
+    """Local speech-to-text via faster-whisper."""
+
+    def __init__(self) -> None:
+        self._model = None
+        self._model_name: str = ""
+        self._device: str = "cpu"
+        self._language: str = "en"
+        self._available: bool | None = None  # None = not checked yet
+
+    def _ensure_model(self) -> bool:
+        """Lazy-load the Whisper model on first use."""
+        if self._model is not None:
+            return True
+
+        if self._available is False:
+            return False  # previously failed
+
+        try:
+            from faster_whisper import WhisperModel
+        except ImportError:
+            log.warning("STT: faster-whisper not installed — pip install faster-whisper")
+            self._available = False
+            return False
+
+        try:
+            from bantz.config import config
+            self._model_name = config.stt_model
+            self._device = config.stt_device
+            self._language = config.stt_language
+        except Exception:
+            self._model_name = "tiny"
+            self._device = "cpu"
+            self._language = "en"
+
+        try:
+            log.info("STT: loading model '%s' on '%s'...", self._model_name, self._device)
+            self._model = WhisperModel(
+                self._model_name,
+                device=self._device,
+                compute_type="int8" if self._device == "cpu" else "float16",
+            )
+            self._available = True
+            log.info("STT: model '%s' loaded successfully", self._model_name)
+            return True
+        except Exception as exc:
+            log.error("STT: model load failed — %s", exc)
+            self._available = False
+            return False
+
+    def transcribe(self, pcm_bytes: bytes) -> Optional[str]:
+        """Transcribe raw PCM audio (16-bit, 16 kHz, mono) to text.
+
+        Args:
+            pcm_bytes: Raw PCM audio data from VoiceCapture.
+
+        Returns:
+            Transcribed text string, or None on failure.
+        """
+        if not pcm_bytes:
+            return None
+
+        if not self._ensure_model():
+            return None
+
+        # Convert raw PCM to a WAV file in a temp location
+        # (faster-whisper needs a file path or numpy array)
+        try:
+            import numpy as np
+        except ImportError:
+            log.warning("STT: numpy not available, falling back to WAV file")
+            return self._transcribe_via_wav(pcm_bytes)
+
+        # Convert PCM bytes to float32 numpy array
+        try:
+            samples = np.frombuffer(pcm_bytes, dtype=np.int16).astype(np.float32) / 32768.0
+        except Exception as exc:
+            log.error("STT: PCM to numpy conversion failed — %s", exc)
+            return None
+
+        return self._transcribe_array(samples)
+
+    def _transcribe_array(self, audio: "np.ndarray") -> Optional[str]:
+        """Run inference on a float32 numpy array."""
+        try:
+            segments, info = self._model.transcribe(
+                audio,
+                language=self._language,
+                beam_size=3,
+                vad_filter=True,
+                vad_parameters=dict(
+                    min_silence_duration_ms=300,
+                ),
+            )
+
+            # Collect all segment texts
+            texts = []
+            for segment in segments:
+                text = segment.text.strip()
+                if text:
+                    texts.append(text)
+
+            result = " ".join(texts).strip()
+
+            if result:
+                log.info("STT: transcribed %d chars (lang=%s, prob=%.2f)",
+                         len(result), info.language, info.language_probability)
+            else:
+                log.info("STT: no speech detected in audio")
+                return None
+
+            return result
+
+        except Exception as exc:
+            log.error("STT: transcription failed — %s", exc)
+            return None
+
+    def _transcribe_via_wav(self, pcm_bytes: bytes) -> Optional[str]:
+        """Fallback: write PCM to a temp WAV file, then transcribe."""
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
+                tmp_path = f.name
+                with wave.open(f, "wb") as wf:
+                    wf.setnchannels(_CHANNELS)
+                    wf.setsampwidth(_SAMPLE_WIDTH)
+                    wf.setframerate(_SAMPLE_RATE)
+                    wf.writeframes(pcm_bytes)
+
+            segments, info = self._model.transcribe(
+                tmp_path,
+                language=self._language,
+                beam_size=3,
+                vad_filter=True,
+            )
+
+            texts = []
+            for segment in segments:
+                text = segment.text.strip()
+                if text:
+                    texts.append(text)
+
+            result = " ".join(texts).strip()
+            if not result:
+                return None
+
+            log.info("STT: transcribed %d chars via WAV fallback", len(result))
+            return result
+
+        except Exception as exc:
+            log.error("STT: WAV fallback transcription failed — %s", exc)
+            return None
+        finally:
+            try:
+                Path(tmp_path).unlink(missing_ok=True)
+            except Exception:
+                pass
+
+    def available(self) -> bool:
+        """Check if STT is available (faster-whisper importable)."""
+        if self._available is not None:
+            return self._available
+        try:
+            import faster_whisper  # noqa: F401
+            self._available = True
+        except ImportError:
+            self._available = False
+        return self._available
+
+    def diagnose(self) -> dict:
+        """Diagnostic info for --doctor."""
+        result: dict = {
+            "faster_whisper_available": False,
+            "numpy_available": False,
+            "model": self._model_name or "(not loaded)",
+            "device": self._device,
+            "language": self._language,
+        }
+        try:
+            import faster_whisper  # noqa: F401
+            result["faster_whisper_available"] = True
+        except ImportError:
+            pass
+        try:
+            import numpy  # noqa: F401
+            result["numpy_available"] = True
+        except ImportError:
+            pass
+        return result
+
+
+# Module singleton
+stt_engine = STTEngine()

--- a/src/bantz/agent/tts.py
+++ b/src/bantz/agent/tts.py
@@ -158,6 +158,7 @@ class TTSEngine:
         self._aplay_path: str | None = None
         self._sox_path: str | None = None
         self._model_path: str | None = None
+        self._sample_rate: int = 22050  # read from model .onnx.json
         self._speaker: int = 0
         self._rate: float = 1.0
         self._playing: asyncio.subprocess.Process | None = None
@@ -246,6 +247,22 @@ class TTSEngine:
         self._model_path = model
         self._speaker = config.tts_speaker
         self._rate = config.tts_rate
+
+        # Read sample rate from model config (.onnx.json)
+        import json as _json
+        model_json = Path(model).with_suffix(".onnx.json")
+        if not model_json.exists():
+            model_json = Path(str(model) + ".json")
+        if model_json.exists():
+            try:
+                meta = _json.loads(model_json.read_text())
+                sr = meta.get("audio", {}).get("sample_rate", 22050)
+                self._sample_rate = int(sr)
+                log.info("TTS: model sample_rate=%d", self._sample_rate)
+            except Exception as exc:
+                log.warning("TTS: could not read model config — %s", exc)
+        else:
+            log.debug("TTS: no .onnx.json found, assuming 22050 Hz")
 
         # Discover sox for animatronic filter (#248)
         sox = shutil.which("sox")
@@ -433,7 +450,7 @@ class TTSEngine:
                 # Pipeline: stdin → sox (effects) → aplay
                 sox_proc = await asyncio.create_subprocess_exec(
                     self._sox_path,
-                    "-t", "raw", "-r", "22050", "-e", "signed",
+                    "-t", "raw", "-r", str(self._sample_rate), "-e", "signed",
                     "-b", "16", "-c", "1", "-",   # input spec
                     "-t", "raw", "-",               # output spec
                     "pitch", "-300",
@@ -446,7 +463,7 @@ class TTSEngine:
                 )
                 aplay_proc = await asyncio.create_subprocess_exec(
                     self._aplay_path,
-                    "-r", "22050",
+                    "-r", str(self._sample_rate),
                     "-f", "S16_LE",
                     "-t", "raw",
                     "-c", "1",
@@ -472,7 +489,7 @@ class TTSEngine:
                 # Direct: stdin → aplay
                 proc = await asyncio.create_subprocess_exec(
                     self._aplay_path,
-                    "-r", "22050",
+                    "-r", str(self._sample_rate),
                     "-f", "S16_LE",
                     "-t", "raw",
                     "-c", "1",

--- a/src/bantz/agent/voice_capture.py
+++ b/src/bantz/agent/voice_capture.py
@@ -1,0 +1,220 @@
+"""
+Bantz — Voice Capture with VAD (#36, The Ghost Loop)
+
+Records microphone audio and uses Voice Activity Detection (WebRTC VAD)
+to automatically stop recording when the user finishes speaking.
+
+Architecture:
+    ┌─────────────────────────────────────────────────────────┐
+    │               VoiceCapture                              │
+    │                                                         │
+    │  1. Open mic (PyAudio, 16 kHz mono)                     │
+    │  2. Feed frames to WebRTC VAD                           │
+    │  3. Accumulate voiced frames into buffer                │
+    │  4. When silence exceeds VAD_SILENCE_MS → stop          │
+    │  5. Return raw PCM bytes (16-bit 16 kHz mono)           │
+    └─────────────────────────────────────────────────────────┘
+
+The capture is synchronous (blocking) and designed to run on a
+background thread — never on the asyncio event loop.
+
+Dependencies:
+  - pyaudio (already installed for wake_word)
+  - webrtcvad (pip install webrtcvad)
+
+Graceful degradation: if either dependency is missing, ``capture()``
+returns None and logs a warning.
+"""
+from __future__ import annotations
+
+import logging
+import struct
+import time
+from typing import Optional
+
+log = logging.getLogger("bantz.voice_capture")
+
+# Audio parameters — must match WebRTC VAD requirements
+SAMPLE_RATE = 16000
+CHANNELS = 1
+SAMPLE_WIDTH = 2  # 16-bit
+FRAME_DURATION_MS = 30  # WebRTC VAD supports 10, 20, or 30 ms
+FRAME_SIZE = int(SAMPLE_RATE * FRAME_DURATION_MS / 1000)  # 480 samples
+
+# Maximum recording duration (safety limit)
+MAX_RECORD_SECONDS = 30.0
+
+
+class VoiceCapture:
+    """Record audio from the mic until user stops speaking (VAD)."""
+
+    def __init__(self) -> None:
+        self._pa = None  # PyAudio instance
+        self._vad = None  # WebRTC VAD instance
+
+    def _ensure_init(self) -> bool:
+        """Lazy-initialize PyAudio and WebRTC VAD. Returns True if ready."""
+        if self._vad is not None:
+            return True
+
+        try:
+            import webrtcvad
+        except ImportError:
+            log.warning("VoiceCapture: webrtcvad not installed — pip install webrtcvad")
+            return False
+
+        try:
+            from bantz.config import config
+            aggressiveness = config.vad_aggressiveness
+        except Exception:
+            aggressiveness = 2
+
+        # Clamp aggressiveness to valid range [0, 3]
+        aggressiveness = max(0, min(3, aggressiveness))
+
+        try:
+            self._vad = webrtcvad.Vad(aggressiveness)
+            log.info("VoiceCapture: VAD initialized (aggressiveness=%d)", aggressiveness)
+            return True
+        except Exception as exc:
+            log.error("VoiceCapture: VAD init failed — %s", exc)
+            return False
+
+    def capture(self) -> Optional[bytes]:
+        """Record audio until the user stops speaking.
+
+        Blocks the calling thread.  Returns raw PCM bytes (16-bit,
+        16 kHz, mono) or None on failure.
+
+        The recording starts immediately and ends after ``vad_silence_ms``
+        of continuous silence is detected.  A safety cap of 30 seconds
+        prevents infinite recording.
+        """
+        if not self._ensure_init():
+            return None
+
+        try:
+            import pyaudio
+        except ImportError:
+            log.warning("VoiceCapture: pyaudio not installed — pip install pyaudio")
+            return None
+
+        try:
+            from bantz.config import config
+            silence_ms = config.vad_silence_ms
+        except Exception:
+            silence_ms = 800
+
+        # Open microphone
+        pa = None
+        stream = None
+        try:
+            pa = pyaudio.PyAudio()
+            stream = pa.open(
+                rate=SAMPLE_RATE,
+                channels=CHANNELS,
+                format=pyaudio.paInt16,
+                input=True,
+                frames_per_buffer=FRAME_SIZE,
+            )
+        except Exception as exc:
+            log.error("VoiceCapture: mic open failed — %s", exc)
+            if stream:
+                try:
+                    stream.stop_stream()
+                    stream.close()
+                except Exception:
+                    pass
+            if pa:
+                try:
+                    pa.terminate()
+                except Exception:
+                    pass
+            return None
+
+        log.info("VoiceCapture: recording started (silence_threshold=%dms)", silence_ms)
+
+        voiced_frames: list[bytes] = []
+        silent_frames = 0
+        frames_for_silence = int(silence_ms / FRAME_DURATION_MS)
+        started_speaking = False
+        start_time = time.monotonic()
+
+        try:
+            while True:
+                # Safety timeout
+                elapsed = time.monotonic() - start_time
+                if elapsed > MAX_RECORD_SECONDS:
+                    log.info("VoiceCapture: hit max duration (%.0fs)", MAX_RECORD_SECONDS)
+                    break
+
+                # Read a frame
+                try:
+                    pcm_bytes = stream.read(FRAME_SIZE, exception_on_overflow=False)
+                except Exception as exc:
+                    log.warning("VoiceCapture: read error — %s", exc)
+                    break
+
+                # Feed to VAD
+                is_speech = self._vad.is_speech(pcm_bytes, SAMPLE_RATE)
+
+                if is_speech:
+                    started_speaking = True
+                    silent_frames = 0
+                    voiced_frames.append(pcm_bytes)
+                else:
+                    if started_speaking:
+                        # Still accumulate silent frames (natural pauses)
+                        voiced_frames.append(pcm_bytes)
+                        silent_frames += 1
+
+                        if silent_frames >= frames_for_silence:
+                            log.info(
+                                "VoiceCapture: silence detected after %.1fs",
+                                elapsed,
+                            )
+                            break
+                    # else: pre-speech silence, discard
+
+        finally:
+            try:
+                stream.stop_stream()
+                stream.close()
+            except Exception:
+                pass
+            try:
+                pa.terminate()
+            except Exception:
+                pass
+
+        if not voiced_frames:
+            log.info("VoiceCapture: no speech detected")
+            return None
+
+        audio_data = b"".join(voiced_frames)
+        duration = len(audio_data) / (SAMPLE_RATE * SAMPLE_WIDTH)
+        log.info("VoiceCapture: captured %.1fs of audio (%d bytes)",
+                 duration, len(audio_data))
+        return audio_data
+
+    def diagnose(self) -> dict:
+        """Diagnostic info for --doctor."""
+        result: dict = {
+            "webrtcvad_available": False,
+            "pyaudio_available": False,
+        }
+        try:
+            import webrtcvad  # noqa: F401
+            result["webrtcvad_available"] = True
+        except ImportError:
+            pass
+        try:
+            import pyaudio  # noqa: F401
+            result["pyaudio_available"] = True
+        except ImportError:
+            pass
+        return result
+
+
+# Module singleton
+voice_capture = VoiceCapture()

--- a/src/bantz/config.py
+++ b/src/bantz/config.py
@@ -166,6 +166,15 @@ class Config(BaseSettings):
     picovoice_access_key: str = Field("", alias="BANTZ_PICOVOICE_ACCESS_KEY")
     wake_word_sensitivity: float = Field(0.5, alias="BANTZ_WAKE_WORD_SENSITIVITY")
 
+    # ── Ghost Loop / STT (#36) ───────────────────────────────────────────
+    stt_enabled: bool = Field(False, alias="BANTZ_STT_ENABLED")
+    stt_model: str = Field("tiny", alias="BANTZ_STT_MODEL")
+    stt_language: str = Field("en", alias="BANTZ_STT_LANGUAGE")
+    stt_device: str = Field("cpu", alias="BANTZ_STT_DEVICE")
+    vad_silence_ms: int = Field(800, alias="BANTZ_VAD_SILENCE_MS")
+    vad_aggressiveness: int = Field(2, alias="BANTZ_VAD_AGGRESSIVENESS")
+    ghost_loop_enabled: bool = Field(False, alias="BANTZ_GHOST_LOOP_ENABLED")
+
     # ── Ambient Sound Analysis (#166) ────────────────────────────────────
     ambient_enabled: bool = Field(False, alias="BANTZ_AMBIENT_ENABLED")
     ambient_interval: int = Field(600, alias="BANTZ_AMBIENT_INTERVAL")

--- a/src/bantz/interface/tui/app.py
+++ b/src/bantz/interface/tui/app.py
@@ -120,6 +120,7 @@ class BantzApp(App):
         self._wire_brain_toast_hook()
         self._subscribe_event_bus()
         self._start_wake_word_listener()
+        self._start_ghost_loop()
         self.query_one("#chat-input", Input).focus()
 
     async def action_quit(self) -> None:
@@ -138,6 +139,12 @@ class BantzApp(App):
         try:
             from bantz.agent.wake_word import wake_listener
             wake_listener.stop()
+        except Exception:
+            pass
+        # Stop Ghost Loop (#36)
+        try:
+            from bantz.agent.ghost_loop import ghost_loop
+            ghost_loop.stop()
         except Exception:
             pass
         # Tear down EventBus subscriptions (#220)
@@ -1003,8 +1010,12 @@ class BantzApp(App):
         bus.on("wake_word_detected", self._bus_relay)
         bus.on("ambient_change", self._bus_relay)
         bus.on("health_alert", self._bus_relay)
+        bus.on("voice_input", self._bus_relay)
+        bus.on("ghost_loop_listening", self._bus_relay)
+        bus.on("ghost_loop_transcribing", self._bus_relay)
+        bus.on("ghost_loop_idle", self._bus_relay)
 
-        log.debug("EventBus → TUI bridge active (3 subscriptions)")
+        log.debug("EventBus → TUI bridge active (7 subscriptions)")
 
     def _relay_bus_event(self, event: Event) -> None:
         """Relay a single bus Event into the Textual message loop.
@@ -1026,6 +1037,10 @@ class BantzApp(App):
             bus.off("wake_word_detected", relay)
             bus.off("ambient_change", relay)
             bus.off("health_alert", relay)
+            bus.off("voice_input", relay)
+            bus.off("ghost_loop_listening", relay)
+            bus.off("ghost_loop_transcribing", relay)
+            bus.off("ghost_loop_idle", relay)
 
     def on_bantz_event_message(self, msg: BantzEventMessage) -> None:
         """Dispatch bus events to the appropriate TUI handler.
@@ -1041,6 +1056,14 @@ class BantzApp(App):
                 self._on_bus_ambient_change(event)
             elif name == "health_alert":
                 self._on_bus_health_alert(event)
+            elif name == "voice_input":
+                self._on_bus_voice_input(event)
+            elif name == "ghost_loop_listening":
+                self._on_bus_ghost_listening(event)
+            elif name == "ghost_loop_transcribing":
+                self._on_bus_ghost_transcribing(event)
+            elif name == "ghost_loop_idle":
+                self._on_bus_ghost_idle(event)
         except Exception:
             log.debug("on_bantz_event_message(%s) error", name, exc_info=True)
 
@@ -1070,6 +1093,58 @@ class BantzApp(App):
         title = event.data.get("title", "Health Alert")
         reason = event.data.get("reason", "")
         self.push_toast(title, reason, "warning")
+
+    # ── Ghost Loop handlers (#36) ─────────────────────────────────────
+
+    def _on_bus_voice_input(self, event: Event) -> None:
+        """Voice transcription arrived → display in chat + process."""
+        text = event.data.get("text", "").strip()
+        if not text:
+            return
+
+        chat = self.query_one("#chat-log", ChatLog)
+        chat.add_user(f"🎤 {text}")
+        chat.scroll_end()
+
+        # Process through brain (same path as typed input)
+        self._start_processing(text, chat)
+
+    def _on_bus_ghost_listening(self, event: Event) -> None:
+        """Ghost Loop is recording → show indicator."""
+        try:
+            chat = self.query_one("#chat-log", ChatLog)
+            chat.add_system("🎙️ Listening...")
+            chat.scroll_end()
+        except Exception:
+            pass
+
+    def _on_bus_ghost_transcribing(self, event: Event) -> None:
+        """Ghost Loop is running STT → show indicator."""
+        try:
+            chat = self.query_one("#chat-log", ChatLog)
+            chat.add_system("⏳ Transcribing...")
+            chat.scroll_end()
+        except Exception:
+            pass
+
+    def _on_bus_ghost_idle(self, event: Event) -> None:
+        """Ghost Loop returned to idle — no visual action needed."""
+        pass
+
+    def _start_ghost_loop(self) -> None:
+        """Start the Ghost Loop if enabled (#36)."""
+        try:
+            from bantz.config import config as _cfg
+            if not _cfg.ghost_loop_enabled or not _cfg.stt_enabled:
+                return
+
+            from bantz.agent.ghost_loop import ghost_loop
+            ok = ghost_loop.start()
+            if ok:
+                chat = self.query_one("#chat-log", ChatLog)
+                chat.add_system("Ghost Loop: hands-free voice active 👻")
+        except Exception as exc:
+            log.debug("Ghost Loop start failed: %s", exc)
 
     # ── Wake Word Listener (#165) ─────────────────────────────────────
 

--- a/tests/agent/test_ghost_loop.py
+++ b/tests/agent/test_ghost_loop.py
@@ -1,0 +1,576 @@
+"""
+Tests for the Ghost Loop, VoiceCapture, and STT modules (#36).
+
+Covers:
+  1. Config fields (ghost_loop, stt, vad)
+  2. VoiceCapture (VAD integration, mic handling, silence detection)
+  3. STTEngine (model loading, transcription, diagnostics)
+  4. GhostLoop orchestrator (start/stop, event flow, pipeline)
+  5. TUI integration (event subscriptions, voice_input handling)
+  6. .env.example completeness
+"""
+from __future__ import annotations
+
+import asyncio
+import struct
+import threading
+from unittest.mock import MagicMock, patch, AsyncMock
+
+import pytest
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 1. Config fields
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestGhostLoopConfig:
+    """Verify all Ghost Loop / STT config fields exist with correct defaults."""
+
+    def test_ghost_loop_enabled_field(self):
+        from bantz.config import Config
+        field = Config.model_fields["ghost_loop_enabled"]
+        assert field.default is False
+        assert field.alias == "BANTZ_GHOST_LOOP_ENABLED"
+
+    def test_stt_enabled_field(self):
+        from bantz.config import Config
+        field = Config.model_fields["stt_enabled"]
+        assert field.default is False
+        assert field.alias == "BANTZ_STT_ENABLED"
+
+    def test_stt_model_default(self):
+        from bantz.config import Config
+        field = Config.model_fields["stt_model"]
+        assert field.default == "tiny"
+        assert field.alias == "BANTZ_STT_MODEL"
+
+    def test_stt_language_default(self):
+        from bantz.config import Config
+        field = Config.model_fields["stt_language"]
+        assert field.default == "en"
+        assert field.alias == "BANTZ_STT_LANGUAGE"
+
+    def test_stt_device_default(self):
+        from bantz.config import Config
+        field = Config.model_fields["stt_device"]
+        assert field.default == "cpu"
+        assert field.alias == "BANTZ_STT_DEVICE"
+
+    def test_vad_silence_ms_default(self):
+        from bantz.config import Config
+        field = Config.model_fields["vad_silence_ms"]
+        assert field.default == 800
+        assert field.alias == "BANTZ_VAD_SILENCE_MS"
+
+    def test_vad_aggressiveness_default(self):
+        from bantz.config import Config
+        field = Config.model_fields["vad_aggressiveness"]
+        assert field.default == 2
+        assert field.alias == "BANTZ_VAD_AGGRESSIVENESS"
+
+    def test_all_ghost_fields_exist(self):
+        from bantz.config import Config
+        expected = [
+            "ghost_loop_enabled", "stt_enabled", "stt_model",
+            "stt_language", "stt_device", "vad_silence_ms",
+            "vad_aggressiveness",
+        ]
+        for name in expected:
+            assert name in Config.model_fields, f"Missing config field: {name}"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 2. VoiceCapture
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestVoiceCaptureConstants:
+    """Verify audio constants match WebRTC VAD requirements."""
+
+    def test_sample_rate(self):
+        from bantz.agent.voice_capture import SAMPLE_RATE
+        assert SAMPLE_RATE == 16000
+
+    def test_frame_duration(self):
+        from bantz.agent.voice_capture import FRAME_DURATION_MS
+        assert FRAME_DURATION_MS in (10, 20, 30)
+
+    def test_frame_size_matches(self):
+        from bantz.agent.voice_capture import SAMPLE_RATE, FRAME_DURATION_MS, FRAME_SIZE
+        expected = int(SAMPLE_RATE * FRAME_DURATION_MS / 1000)
+        assert FRAME_SIZE == expected
+
+    def test_max_record_seconds(self):
+        from bantz.agent.voice_capture import MAX_RECORD_SECONDS
+        assert MAX_RECORD_SECONDS > 0
+        assert MAX_RECORD_SECONDS <= 60
+
+
+class TestVoiceCaptureInit:
+    """Test VoiceCapture lazy initialization."""
+
+    def test_init_without_webrtcvad(self):
+        from bantz.agent.voice_capture import VoiceCapture
+        vc = VoiceCapture()
+        with patch.dict("sys.modules", {"webrtcvad": None}):
+            with patch("builtins.__import__", side_effect=ImportError("no webrtcvad")):
+                assert vc._ensure_init() is False
+
+    def test_init_with_webrtcvad(self):
+        from bantz.agent.voice_capture import VoiceCapture
+        mock_vad = MagicMock()
+        mock_webrtcvad = MagicMock()
+        mock_webrtcvad.Vad.return_value = mock_vad
+
+        vc = VoiceCapture()
+        with patch.dict("sys.modules", {"webrtcvad": mock_webrtcvad}):
+            with patch("bantz.agent.voice_capture.VoiceCapture._ensure_init") as m:
+                m.return_value = True
+                assert vc._ensure_init() is True
+
+    def test_capture_returns_none_without_deps(self):
+        from bantz.agent.voice_capture import VoiceCapture
+        vc = VoiceCapture()
+        with patch.object(vc, "_ensure_init", return_value=False):
+            assert vc.capture() is None
+
+    def test_capture_returns_none_without_pyaudio(self):
+        from bantz.agent.voice_capture import VoiceCapture
+        vc = VoiceCapture()
+        vc._vad = MagicMock()  # VAD is "ready"
+        with patch.dict("sys.modules", {"pyaudio": None}):
+            with patch("builtins.__import__", side_effect=ImportError("no pyaudio")):
+                result = vc.capture()
+                assert result is None
+
+
+class TestVoiceCaptureDiagnose:
+    """Test VoiceCapture.diagnose() output."""
+
+    def test_diagnose_keys(self):
+        from bantz.agent.voice_capture import VoiceCapture
+        vc = VoiceCapture()
+        diag = vc.diagnose()
+        assert "webrtcvad_available" in diag
+        assert "pyaudio_available" in diag
+
+    def test_diagnose_without_deps(self):
+        from bantz.agent.voice_capture import VoiceCapture
+        vc = VoiceCapture()
+        # When neither is installed, both should be False
+        # (actual result depends on env, so just check structure)
+        diag = vc.diagnose()
+        assert isinstance(diag["webrtcvad_available"], bool)
+        assert isinstance(diag["pyaudio_available"], bool)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 3. STTEngine
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestSTTEngineInit:
+    """Test STTEngine initialization and model loading."""
+
+    def test_init_defaults(self):
+        from bantz.agent.stt import STTEngine
+        engine = STTEngine()
+        assert engine._model is None
+        assert engine._available is None
+
+    def test_available_without_faster_whisper(self):
+        from bantz.agent.stt import STTEngine
+        engine = STTEngine()
+        with patch.dict("sys.modules", {"faster_whisper": None}):
+            with patch("builtins.__import__", side_effect=ImportError):
+                result = engine.available()
+                assert result is False
+                assert engine._available is False
+
+    def test_transcribe_returns_none_for_empty(self):
+        from bantz.agent.stt import STTEngine
+        engine = STTEngine()
+        assert engine.transcribe(b"") is None
+        assert engine.transcribe(None) is None
+
+    def test_transcribe_returns_none_without_model(self):
+        from bantz.agent.stt import STTEngine
+        engine = STTEngine()
+        engine._available = False
+        assert engine.transcribe(b"\x00" * 1000) is None
+
+
+class TestSTTEngineDiagnose:
+    """Test STTEngine.diagnose() output."""
+
+    def test_diagnose_keys(self):
+        from bantz.agent.stt import STTEngine
+        engine = STTEngine()
+        diag = engine.diagnose()
+        assert "faster_whisper_available" in diag
+        assert "numpy_available" in diag
+        assert "model" in diag
+        assert "device" in diag
+        assert "language" in diag
+
+    def test_diagnose_model_not_loaded(self):
+        from bantz.agent.stt import STTEngine
+        engine = STTEngine()
+        diag = engine.diagnose()
+        assert diag["model"] == "(not loaded)"
+
+
+class TestSTTEngineTranscribe:
+    """Test transcription pipeline with mocked model."""
+
+    def test_transcribe_with_mock_model(self):
+        from bantz.agent.stt import STTEngine
+        engine = STTEngine()
+
+        # Mock the model
+        mock_segment = MagicMock()
+        mock_segment.text = "Hello world"
+        mock_info = MagicMock()
+        mock_info.language = "en"
+        mock_info.language_probability = 0.98
+
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = ([mock_segment], mock_info)
+        engine._model = mock_model
+        engine._available = True
+        engine._language = "en"
+
+        # Create some fake PCM data
+        import numpy as np
+        pcm = np.zeros(16000, dtype=np.int16).tobytes()  # 1 second of silence
+
+        result = engine.transcribe(pcm)
+        assert result == "Hello world"
+        mock_model.transcribe.assert_called_once()
+
+    def test_transcribe_empty_result(self):
+        from bantz.agent.stt import STTEngine
+        engine = STTEngine()
+
+        mock_segment = MagicMock()
+        mock_segment.text = "   "
+        mock_info = MagicMock()
+        mock_info.language = "en"
+        mock_info.language_probability = 0.5
+
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = ([mock_segment], mock_info)
+        engine._model = mock_model
+        engine._available = True
+        engine._language = "en"
+
+        import numpy as np
+        pcm = np.zeros(16000, dtype=np.int16).tobytes()
+
+        result = engine.transcribe(pcm)
+        assert result is None
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 4. GhostLoop orchestrator
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestGhostLoopInit:
+    """Test GhostLoop initialization."""
+
+    def test_init_defaults(self):
+        from bantz.agent.ghost_loop import GhostLoop
+        gl = GhostLoop()
+        assert gl.running is False
+        assert gl.busy is False
+        assert gl._total_transcriptions == 0
+
+    def test_stats(self):
+        from bantz.agent.ghost_loop import GhostLoop
+        gl = GhostLoop()
+        stats = gl.stats()
+        assert stats["running"] is False
+        assert stats["busy"] is False
+        assert stats["total_transcriptions"] == 0
+        assert stats["last_text"] == ""
+
+
+class TestGhostLoopStartStop:
+    """Test GhostLoop start/stop lifecycle."""
+
+    def test_start_disabled_by_config(self):
+        from bantz.agent.ghost_loop import GhostLoop
+        gl = GhostLoop()
+        mock_cfg = MagicMock()
+        mock_cfg.ghost_loop_enabled = False
+        mock_cfg.stt_enabled = False
+        with patch("bantz.agent.ghost_loop.bus"):
+            with patch("bantz.config.config", mock_cfg):
+                assert gl.start() is False
+                assert gl.running is False
+
+    def test_start_enabled(self):
+        from bantz.agent.ghost_loop import GhostLoop
+        gl = GhostLoop()
+        mock_cfg = MagicMock()
+        mock_cfg.ghost_loop_enabled = True
+        mock_cfg.stt_enabled = True
+        mock_bus = MagicMock()
+        with patch("bantz.agent.ghost_loop.bus", mock_bus):
+            with patch("bantz.config.config", mock_cfg):
+                assert gl.start() is True
+                assert gl.running is True
+                mock_bus.on.assert_called_once_with(
+                    "wake_word_detected", gl._on_wake_event
+                )
+
+    def test_stop(self):
+        from bantz.agent.ghost_loop import GhostLoop
+        gl = GhostLoop()
+        gl._running = True
+        mock_bus = MagicMock()
+        with patch("bantz.agent.ghost_loop.bus", mock_bus):
+            gl.stop()
+            assert gl.running is False
+            mock_bus.off.assert_called_once()
+
+    def test_start_idempotent(self):
+        from bantz.agent.ghost_loop import GhostLoop
+        gl = GhostLoop()
+        gl._running = True
+        assert gl.start() is True
+
+
+class TestGhostLoopWakeEvent:
+    """Test wake event handling in Ghost Loop."""
+
+    def test_ignores_when_busy(self):
+        from bantz.agent.ghost_loop import GhostLoop
+        from bantz.core.event_bus import Event
+        gl = GhostLoop()
+        gl._busy = True
+        # Should not spawn a thread
+        with patch("threading.Thread") as mock_thread:
+            gl._on_wake_event(Event(name="wake_word_detected"))
+            mock_thread.assert_not_called()
+
+    def test_spawns_thread_when_idle(self):
+        from bantz.agent.ghost_loop import GhostLoop
+        from bantz.core.event_bus import Event
+        gl = GhostLoop()
+        gl._busy = False
+        with patch("bantz.agent.ghost_loop.threading.Thread") as mock_thread_cls:
+            mock_thread = MagicMock()
+            mock_thread_cls.return_value = mock_thread
+            gl._on_wake_event(Event(name="wake_word_detected"))
+            mock_thread_cls.assert_called_once()
+            mock_thread.start.assert_called_once()
+
+
+class TestGhostLoopPipeline:
+    """Test the capture → transcribe → dispatch pipeline."""
+
+    def test_pipeline_no_audio(self):
+        from bantz.agent.ghost_loop import GhostLoop
+        gl = GhostLoop()
+        mock_vc = MagicMock()
+        mock_vc.capture.return_value = None
+        mock_bus = MagicMock()
+        with patch("bantz.agent.ghost_loop.bus", mock_bus):
+            with patch("bantz.agent.voice_capture.voice_capture", mock_vc):
+                gl._capture_and_transcribe()
+        assert gl._busy is False
+        # Should have emitted listening + idle
+        calls = [c[0][0] for c in mock_bus.emit_threadsafe.call_args_list]
+        assert "ghost_loop_listening" in calls
+        assert "ghost_loop_idle" in calls
+
+    def test_pipeline_successful_transcription(self):
+        from bantz.agent.ghost_loop import GhostLoop
+        gl = GhostLoop()
+        mock_vc = MagicMock()
+        mock_vc.capture.return_value = b"\x00" * 16000
+        mock_stt = MagicMock()
+        mock_stt.transcribe.return_value = "Turn off the lights"
+        mock_bus = MagicMock()
+        with patch("bantz.agent.ghost_loop.bus", mock_bus):
+            with patch("bantz.agent.voice_capture.voice_capture", mock_vc):
+                with patch("bantz.agent.stt.stt_engine", mock_stt):
+                    gl._capture_and_transcribe()
+        assert gl._total_transcriptions == 1
+        assert gl._last_text == "Turn off the lights"
+        # Check voice_input was emitted
+        emit_calls = mock_bus.emit_threadsafe.call_args_list
+        voice_call = [c for c in emit_calls if c[0][0] == "voice_input"]
+        assert len(voice_call) == 1
+        assert voice_call[0][1]["text"] == "Turn off the lights"
+
+    def test_pipeline_stt_returns_none(self):
+        from bantz.agent.ghost_loop import GhostLoop
+        gl = GhostLoop()
+        mock_vc = MagicMock()
+        mock_vc.capture.return_value = b"\x00" * 16000
+        mock_stt = MagicMock()
+        mock_stt.transcribe.return_value = None
+        mock_bus = MagicMock()
+        with patch("bantz.agent.ghost_loop.bus", mock_bus):
+            with patch("bantz.agent.voice_capture.voice_capture", mock_vc):
+                with patch("bantz.agent.stt.stt_engine", mock_stt):
+                    gl._capture_and_transcribe()
+        assert gl._total_transcriptions == 0
+        # voice_input should NOT have been emitted
+        emit_names = [c[0][0] for c in mock_bus.emit_threadsafe.call_args_list]
+        assert "voice_input" not in emit_names
+
+
+class TestGhostLoopDiagnose:
+    """Test GhostLoop.diagnose() output."""
+
+    def test_diagnose_structure(self):
+        from bantz.agent.ghost_loop import GhostLoop
+        gl = GhostLoop()
+        with patch("bantz.agent.voice_capture.voice_capture") as mock_vc:
+            with patch("bantz.agent.stt.stt_engine") as mock_stt:
+                mock_vc.diagnose.return_value = {"webrtcvad_available": False, "pyaudio_available": False}
+                mock_stt.diagnose.return_value = {"faster_whisper_available": False}
+                diag = gl.diagnose()
+        assert "running" in diag
+        assert "voice_capture" in diag
+        assert "stt" in diag
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 5. TUI integration
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestTUIEventSubscriptions:
+    """Verify the TUI subscribes to Ghost Loop events."""
+
+    def test_subscribe_has_voice_events(self):
+        """_subscribe_event_bus must subscribe to ghost loop events."""
+        import inspect
+        from bantz.interface.tui.app import BantzApp
+        src = inspect.getsource(BantzApp._subscribe_event_bus)
+        assert 'bus.on("voice_input"' in src
+        assert 'bus.on("ghost_loop_listening"' in src
+        assert 'bus.on("ghost_loop_transcribing"' in src
+        assert 'bus.on("ghost_loop_idle"' in src
+
+    def test_unsubscribe_has_voice_events(self):
+        """_unsubscribe_event_bus must unsubscribe from ghost loop events."""
+        import inspect
+        from bantz.interface.tui.app import BantzApp
+        src = inspect.getsource(BantzApp._unsubscribe_event_bus)
+        assert 'bus.off("voice_input"' in src
+        assert 'bus.off("ghost_loop_listening"' in src
+        assert 'bus.off("ghost_loop_transcribing"' in src
+        assert 'bus.off("ghost_loop_idle"' in src
+
+    def test_event_dispatch_has_voice_input(self):
+        """on_bantz_event_message must dispatch voice_input events."""
+        import inspect
+        from bantz.interface.tui.app import BantzApp
+        src = inspect.getsource(BantzApp.on_bantz_event_message)
+        assert '"voice_input"' in src
+        assert '"ghost_loop_listening"' in src
+        assert '"ghost_loop_transcribing"' in src
+
+    def test_voice_input_handler_exists(self):
+        """BantzApp must have _on_bus_voice_input method."""
+        from bantz.interface.tui.app import BantzApp
+        assert hasattr(BantzApp, "_on_bus_voice_input")
+        assert callable(getattr(BantzApp, "_on_bus_voice_input"))
+
+    def test_ghost_listening_handler_exists(self):
+        from bantz.interface.tui.app import BantzApp
+        assert hasattr(BantzApp, "_on_bus_ghost_listening")
+
+    def test_ghost_transcribing_handler_exists(self):
+        from bantz.interface.tui.app import BantzApp
+        assert hasattr(BantzApp, "_on_bus_ghost_transcribing")
+
+    def test_start_ghost_loop_method_exists(self):
+        from bantz.interface.tui.app import BantzApp
+        assert hasattr(BantzApp, "_start_ghost_loop")
+
+    def test_on_mount_calls_start_ghost_loop(self):
+        """on_mount must call _start_ghost_loop."""
+        import inspect
+        from bantz.interface.tui.app import BantzApp
+        src = inspect.getsource(BantzApp.on_mount)
+        assert "_start_ghost_loop" in src
+
+    def test_action_quit_stops_ghost_loop(self):
+        """action_quit must stop the ghost loop."""
+        import inspect
+        from bantz.interface.tui.app import BantzApp
+        src = inspect.getsource(BantzApp.action_quit)
+        assert "ghost_loop" in src
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 6. --doctor support
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestDoctorGhostLoop:
+    """Verify --doctor includes Ghost Loop check."""
+
+    def test_doctor_has_ghost_loop_check(self):
+        import inspect
+        from bantz.__main__ import _doctor
+        src = inspect.getsource(_doctor)
+        assert "Ghost Loop" in src
+        assert "ghost_loop_enabled" in src
+        assert "stt_enabled" in src
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 7. .env.example completeness
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestEnvExampleCompleteness:
+    """All new config aliases must appear in .env.example."""
+
+    def test_ghost_loop_in_env_example(self):
+        from pathlib import Path
+        env_example = Path(__file__).resolve().parent.parent / ".env.example"
+        if not env_example.exists():
+            pytest.skip(".env.example not found")
+        content = env_example.read_text()
+        expected = [
+            "BANTZ_GHOST_LOOP_ENABLED",
+            "BANTZ_STT_ENABLED",
+            "BANTZ_STT_MODEL",
+            "BANTZ_STT_LANGUAGE",
+            "BANTZ_STT_DEVICE",
+            "BANTZ_VAD_SILENCE_MS",
+            "BANTZ_VAD_AGGRESSIVENESS",
+        ]
+        for alias in expected:
+            assert alias in content, f"{alias} missing from .env.example"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 8. Module singletons
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestModuleSingletons:
+    """Verify module-level singletons are importable."""
+
+    def test_voice_capture_singleton(self):
+        from bantz.agent.voice_capture import voice_capture
+        assert voice_capture is not None
+
+    def test_stt_engine_singleton(self):
+        from bantz.agent.stt import stt_engine
+        assert stt_engine is not None
+
+    def test_ghost_loop_singleton(self):
+        from bantz.agent.ghost_loop import ghost_loop
+        assert ghost_loop is not None

--- a/tests/agent/test_tts.py
+++ b/tests/agent/test_tts.py
@@ -1008,8 +1008,9 @@ class TestGlobalTTSConfig:
 
     def test_default_is_false(self):
         from bantz.config import Config
-        cfg = Config()
-        assert cfg.tts_speak_all_responses is False
+        # Check the Field default directly (immune to .env overrides)
+        field = Config.model_fields["tts_speak_all_responses"]
+        assert field.default is False
 
     def test_env_alias(self):
         """Config field has the correct BANTZ_ env alias."""
@@ -1034,8 +1035,9 @@ class TestAnimatronicConfig:
 
     def test_default_is_false(self):
         from bantz.config import Config
-        cfg = Config()
-        assert cfg.tts_animatronic_filter is False
+        # Check the Field default directly (immune to .env overrides)
+        field = Config.model_fields["tts_animatronic_filter"]
+        assert field.default is False
 
     def test_env_alias(self):
         from bantz.config import Config

--- a/tests/tui/test_event_bridge.py
+++ b/tests/tui/test_event_bridge.py
@@ -99,6 +99,10 @@ class TestSubscribeEventBus:
             assert test_bus.subscriber_count("wake_word_detected") == 1
             assert test_bus.subscriber_count("ambient_change") == 1
             assert test_bus.subscriber_count("health_alert") == 1
+            assert test_bus.subscriber_count("voice_input") == 1
+            assert test_bus.subscriber_count("ghost_loop_listening") == 1
+            assert test_bus.subscriber_count("ghost_loop_transcribing") == 1
+            assert test_bus.subscriber_count("ghost_loop_idle") == 1
 
     def test_calls_bind_loop(self):
         app = self._make_app()
@@ -136,11 +140,15 @@ class TestUnsubscribeEventBus:
         test_bus.bind_loop = MagicMock()
         with patch("bantz.interface.tui.app.bus", test_bus):
             app._subscribe_event_bus()
-            assert test_bus.subscriber_count() == 3
+            assert test_bus.subscriber_count() == 7
             app._unsubscribe_event_bus()
             assert test_bus.subscriber_count("wake_word_detected") == 0
             assert test_bus.subscriber_count("ambient_change") == 0
             assert test_bus.subscriber_count("health_alert") == 0
+            assert test_bus.subscriber_count("voice_input") == 0
+            assert test_bus.subscriber_count("ghost_loop_listening") == 0
+            assert test_bus.subscriber_count("ghost_loop_transcribing") == 0
+            assert test_bus.subscriber_count("ghost_loop_idle") == 0
 
     def test_safe_when_not_subscribed(self):
         """No crash if _unsubscribe called before _subscribe."""


### PR DESCRIPTION
## Summary

Implements **Issue #36** — full hands-free voice loop: wake word triggers mic capture with VAD-based silence detection, local STT via faster-whisper, and result dispatched as a standard user message through the EventBus.

## New Modules

| File | Purpose |
|------|---------|
| `agent/voice_capture.py` | PyAudio mic input + WebRTC VAD (16kHz, 30ms frames, silence detection) |
| `agent/stt.py` | faster-whisper (CTranslate2) local STT engine with lazy model loading |
| `agent/ghost_loop.py` | Orchestrator: wake → capture → STT → dispatch pipeline |

## Changes

- **config.py**: 7 new fields (`stt_enabled`, `stt_model`, `stt_language`, `stt_device`, `vad_silence_ms`, `vad_aggressiveness`, `ghost_loop_enabled`)
- **tui/app.py**: 4 new EventBus subscriptions (`voice_input`, `ghost_loop_listening`, `ghost_loop_transcribing`, `ghost_loop_idle`), voice messages shown with 🎤 prefix
- **__main__.py**: `--doctor` Ghost Loop diagnostics
- **tts.py**: Fix sample rate — read dynamically from `.onnx.json` (danny-low = 16kHz)
- **.env.example**: Ghost Loop config section

## Tests

- **51 new tests** across 8 test classes in `test_ghost_loop.py`
- **2731 total passed** (up from 2680 baseline)
- Event bridge tests updated for 7 subscriptions (was 3)

## Dependencies

`faster-whisper` and `webrtcvad` — graceful degradation when not installed (lazy imports with ImportError handling, same pattern as pvporcupine).

Closes #36