### PR TITLE
fix(voice): TTS animatronic pipe + Ghost Loop mic contention

### DIFF
--- a/src/bantz/agent/ghost_loop.py
+++ b/src/bantz/agent/ghost_loop.py
@@ -129,6 +129,13 @@ class GhostLoop:
         self._busy = True
 
         try:
+            # 0. Pause wake word listener to release the mic
+            try:
+                from bantz.agent.wake_word import wake_listener
+                wake_listener.pause()
+            except Exception as exc:
+                log.debug("Ghost Loop: could not pause wake word — %s", exc)
+
             # 1. Emit "listening" event so TUI can show indicator
             bus.emit_threadsafe("ghost_loop_listening")
 
@@ -165,6 +172,12 @@ class GhostLoop:
             log.error("Ghost Loop: pipeline error — %s", exc)
         finally:
             self._busy = False
+            # Resume wake word listener so it re-acquires the mic
+            try:
+                from bantz.agent.wake_word import wake_listener
+                wake_listener.resume()
+            except Exception:
+                pass
             try:
                 bus.emit_threadsafe("ghost_loop_idle")
             except Exception:

--- a/src/bantz/agent/tts.py
+++ b/src/bantz/agent/tts.py
@@ -447,12 +447,15 @@ class TTSEngine:
 
         try:
             if use_sox:
-                # Pipeline: stdin → sox (effects) → aplay
+                # Two-stage: stdin → sox (effects) → memory → aplay
+                # NOTE: asyncio.StreamReader can't be passed as stdin
+                # to another subprocess, so we collect sox output first.
                 sox_proc = await asyncio.create_subprocess_exec(
                     self._sox_path,
                     "-t", "raw", "-r", str(self._sample_rate), "-e", "signed",
                     "-b", "16", "-c", "1", "-",   # input spec
-                    "-t", "raw", "-",               # output spec
+                    "-t", "raw", "-r", str(self._sample_rate), "-e", "signed",
+                    "-b", "16", "-c", "1", "-",   # output spec (explicit)
                     "pitch", "-300",
                     "reverb", "50",
                     "overdrive", "10",
@@ -461,30 +464,32 @@ class TTSEngine:
                     stderr=asyncio.subprocess.DEVNULL,
                     env=env,
                 )
-                aplay_proc = await asyncio.create_subprocess_exec(
+                self._sox_proc = sox_proc
+                processed, _ = await asyncio.wait_for(
+                    sox_proc.communicate(input=wav_data),
+                    timeout=30.0,
+                )
+                self._sox_proc = None
+
+                if not processed:
+                    log.warning("TTS: sox produced no output")
+                    return
+
+                # Play processed audio via aplay
+                proc = await asyncio.create_subprocess_exec(
                     self._aplay_path,
                     "-r", str(self._sample_rate),
                     "-f", "S16_LE",
                     "-t", "raw",
                     "-c", "1",
-                    stdin=sox_proc.stdout,
+                    stdin=asyncio.subprocess.PIPE,
                     stdout=asyncio.subprocess.DEVNULL,
                     stderr=asyncio.subprocess.DEVNULL,
                     env=env,
                 )
-                self._sox_proc = sox_proc
-                self._playing = aplay_proc
-
-                # Feed wav data to sox and close its stdin
-                sox_proc.stdin.write(wav_data)
-                await sox_proc.stdin.drain()
-                sox_proc.stdin.close()
-
-                # Wait for both processes to finish
-                await aplay_proc.wait()
-                await sox_proc.wait()
+                self._playing = proc
+                await proc.communicate(input=processed)
                 self._playing = None
-                self._sox_proc = None
             else:
                 # Direct: stdin → aplay
                 proc = await asyncio.create_subprocess_exec(

--- a/src/bantz/agent/wake_word.py
+++ b/src/bantz/agent/wake_word.py
@@ -72,6 +72,7 @@ class WakeWordListener:
         self._stop = threading.Event()
         self._on_wake: Optional[Callable[[], None]] = None
         self._running = False
+        self._paused = False
         self._last_trigger: float = 0.0
         self._total_detections: int = 0
 
@@ -139,6 +140,43 @@ class WakeWordListener:
         log.info("Wake word listener stopped (total detections: %d)",
                  self._total_detections)
 
+    # ── Pause / Resume (for Ghost Loop mic sharing) ─────────────────────
+
+    def pause(self) -> None:
+        """Temporarily release the microphone so another module can use it.
+
+        The wake word thread keeps running but ``stream.read()`` will
+        raise after we close the stream — the loop catches that and
+        sleeps until ``resume()`` re-opens the stream.
+        """
+        if not self._running:
+            return
+        self._paused = True
+        if self._audio_stream:
+            try:
+                self._audio_stream.stop_stream()
+                self._audio_stream.close()
+            except Exception:
+                pass
+            self._audio_stream = None
+        if self._pa:
+            try:
+                self._pa.terminate()
+            except Exception:
+                pass
+            self._pa = None
+        log.info("Wake word: paused (mic released for voice capture)")
+
+    def resume(self) -> None:
+        """Re-open the microphone after a pause."""
+        if not self._running:
+            return
+        self._paused = False
+        if self._init_audio():
+            log.info("Wake word: resumed (mic re-acquired)")
+        else:
+            log.error("Wake word: could not re-acquire mic after pause")
+
     def diagnose(self) -> dict:
         """Return diagnostic info for --doctor."""
         result: dict = {
@@ -201,6 +239,14 @@ class WakeWordListener:
             pass
 
         while not self._stop.is_set():
+            # While paused, sleep and skip audio reads
+            if self._paused or self._audio_stream is None:
+                time.sleep(0.05)
+                # Re-acquire stream reference after resume()
+                if not self._paused and self._audio_stream is not None:
+                    stream = self._audio_stream
+                continue
+
             try:
                 pcm_bytes = stream.read(frame_length, exception_on_overflow=False)
                 pcm = struct.unpack_from(f"{frame_length}h", pcm_bytes)
@@ -248,6 +294,9 @@ class WakeWordListener:
             except Exception as exc:
                 if self._stop.is_set():
                     break
+                if self._paused:
+                    # Stream was closed by pause() — just loop back
+                    continue
                 log.warning("Wake word: audio read error — %s", exc)
                 time.sleep(0.1)
 

--- a/tests/agent/test_tts.py
+++ b/tests/agent/test_tts.py
@@ -1147,20 +1147,16 @@ class TestPlayPipeline:
         eng = TTSEngine()
         eng._aplay_path = "/usr/bin/aplay"
         eng._sox_path = "/usr/bin/sox"
+        eng._sample_rate = 16000
 
-        # Mock sox process with stdin/stdout pipes
-        mock_sox = MagicMock()
-        mock_sox.stdout = MagicMock()
-        mock_sox.stdin = MagicMock()
-        mock_sox.stdin.write = MagicMock()
-        mock_sox.stdin.drain = AsyncMock()
-        mock_sox.stdin.close = MagicMock()
-        mock_sox.wait = AsyncMock(return_value=0)
+        # Mock sox process (two-stage: sox → memory → aplay)
+        mock_sox = AsyncMock()
+        mock_sox.communicate = AsyncMock(return_value=(b"\x00" * 100, b""))
         mock_sox.returncode = 0
 
         # Mock aplay process
-        mock_aplay = MagicMock()
-        mock_aplay.wait = AsyncMock(return_value=0)
+        mock_aplay = AsyncMock()
+        mock_aplay.communicate = AsyncMock(return_value=(b"", b""))
         mock_aplay.returncode = 0
 
         call_count = {"n": 0}
@@ -1177,7 +1173,7 @@ class TestPlayPipeline:
 
             await eng._play(b"\x00" * 100)
 
-        # Two subprocesses: sox + aplay
+        # Two subprocesses: sox + aplay (two-stage pipeline)
         assert mock_exec_fn.call_count == 2
         sox_cmd = mock_exec_fn.call_args_list[0][0]
         aplay_cmd = mock_exec_fn.call_args_list[1][0]


### PR DESCRIPTION
## Fixes

### 1. TTS Animatronic Filter — Silent Playback
`asyncio.StreamReader` (from `sox_proc.stdout`) was passed as `stdin` to the aplay subprocess. Unlike `subprocess.Popen`, `asyncio.create_subprocess_exec` does NOT accept a StreamReader as stdin — it silently fails and no audio plays.

**Fix**: Two-stage pipeline — sox processes audio into memory, then aplay receives it via `communicate()`. Also added explicit output format spec (`-r -e -b -c`) to sox to prevent sample rate drift from `pitch` effect.

### 2. Ghost Loop — Mic Not Captured
Wake word listener holds the PyAudio mic stream open continuously. When Ghost Loop's VoiceCapture tries to open a second stream on the same ALSA device, it fails or gets silence.

**Fix**: Added `pause()`/`resume()` to `WakeWordListener`. Ghost Loop now pauses the wake word listener before capturing audio and resumes it after (in `finally` block so it always resumes).

The listen loop handles the paused state gracefully — sleeps instead of reading, and re-acquires the stream reference after resume.

## Tests
2731 passed, no regressions.