### PR TITLE
fix(core): People Pleaser guard — stop silent error→hallucination pipeline

### DIFF
--- a/src/bantz/core/brain.py
+++ b/src/bantz/core/brain.py
@@ -261,6 +261,7 @@ class Brain:
         # recent_history feeds coreference resolution (#212) so the
         # planner can resolve pronouns like "him", "it", "that file".
         recent_history = data_layer.conversations.context(n=6)
+        planner_error: str | None = None
         try:
             from bantz.agent.planner import planner_agent
             if planner_agent.is_complex(en_input, recent_history=recent_history):
@@ -273,7 +274,8 @@ class Brain:
                     self._fire_embeddings()
                     return plan_result
         except Exception as exc:
-            log.debug("Planner check failed: %s — falling through", exc)
+            log.warning("Planner check failed: %s — propagating to LLM", exc)
+            planner_error = f"Multi-step planner failed: {exc}"
 
         # ── Quick-route → internal dispatch (#228) ──────────────────────
         quick = self._quick_route(user_input, en_input)
@@ -296,12 +298,22 @@ class Brain:
                 plan = {"route": "tool", "tool_name": quick["tool"],
                         "tool_args": quick["args"], "risk_level": "safe"}
         else:
-            plan = await cot_route(
+            plan, routing_error = await cot_route(
                 en_input, registry.all_schemas(),
                 recent_history=recent_history,
             )
+
+            # Merge planner_error if cot_route had no error of its own
+            if routing_error is None and planner_error is not None:
+                routing_error = planner_error
+
             if plan is None:
-                stream = self._chat_stream(en_input, tc)
+                # (#253) If routing_error is set, a tool was attempted
+                # but failed.  Inject a system alert so the LLM does NOT
+                # hallucinate tool success.
+                stream = self._chat_stream(
+                    en_input, tc, system_alert=routing_error,
+                )
                 return BrainResult(
                     response="", tool_used=None, stream=stream,
                 )
@@ -427,11 +439,20 @@ class Brain:
         except Exception as exc:
             return f"(Ollama error: {exc})"
 
-    async def _chat_stream(self, en_input: str, tc: dict) -> AsyncIterator[str]:
+    async def _chat_stream(
+        self, en_input: str, tc: dict,
+        *, system_alert: str | None = None,
+    ) -> AsyncIterator[str]:
         """
         Streaming chat — yields tokens as they arrive from LLM.
         Post-processing (strip_markdown) runs on accumulated text at consumer side.
         Context gathering is concurrent via memory_injector.inject (#227).
+
+        Args:
+            system_alert: (#253) When a tool routing / planner attempt
+                failed, this carries the error description.  It is
+                injected into the system prompt so the LLM honestly
+                reports the failure instead of hallucinating success.
         """
         history = data_layer.conversations.context(n=12)
         prior = history[:-1] if (history and history[-1]["role"] == "user") else history
@@ -442,8 +463,24 @@ class Brain:
         self._feedback_ctx = ""  # clear after consumption
         await _inject_memory(ctx, en_input)
 
+        system_content = _build_chat_system(ctx, tc)
+
+        # (#253) People-Pleaser guard: inject routing failure context
+        if system_alert:
+            system_content += (
+                "\n\n[SYSTEM ALERT: You just attempted to use a tool to "
+                "fulfill the user's request, but your internal routing/JSON "
+                f"generation failed with error: {system_alert}. "
+                "DO NOT pretend you completed the task. DO NOT fabricate "
+                "data, emails, search results, or file contents. "
+                "Apologize to the user in your butler persona and explain "
+                "that a technical difficulty prevented you from completing "
+                "the request. Suggest they try again or rephrase.]"
+            )
+            log.warning("People-Pleaser guard activated: %s", system_alert)
+
         messages = [
-            {"role": "system", "content": _build_chat_system(ctx, tc)},
+            {"role": "system", "content": system_content},
             *prior,
             {"role": "user", "content": en_input},
         ]

--- a/src/bantz/core/intent.py
+++ b/src/bantz/core/intent.py
@@ -173,16 +173,20 @@ async def cot_route(
     *,
     recent_history: list[dict] | None = None,
     confidence_threshold: float = 0.4,
-) -> dict | None:
+) -> tuple[dict | None, str | None]:
     """
     Chain-of-Thought routing via Ollama.
 
-    Returns a plan dict compatible with ``brain.process()``:
+    Returns ``(plan, routing_error)``:
 
-        {"route", "tool_name", "tool_args", "risk_level", "chain", "confidence"}
-
-    Returns *None* when routing fails (model refusal, parse error, or very
-    low confidence) — the caller should fall back to chat.
+    - ``(plan_dict, None)``     — successful routing (tool or chat).
+    - ``(None, None)``          — pure chat / refusal / low confidence
+                                  (no tool was attempted).
+    - ``(None, error_string)``  — a tool route was *attempted* but JSON
+                                  parsing or validation failed.  The
+                                  caller **must not** silently fall back
+                                  to chat — it should inform the user
+                                  (#253 People-Pleaser fix).
 
     Args:
         recent_history: Last few conversation turns (user/assistant dicts)
@@ -215,22 +219,23 @@ async def cot_route(
 
         if _is_refusal(raw):
             log.warning("CoT refused (attempt 1): %.100s", raw)
-            return None
+            return None, None
 
         _log_thinking(raw)
         plan = _extract_json(raw)
 
         if plan.get("confidence", 0.8) < confidence_threshold:
             log.info("CoT low confidence (%.2f) — falling back", plan["confidence"])
-            return None
+            return None, None
 
-        return plan
+        return plan, None
 
     except (json.JSONDecodeError, AttributeError) as exc:
-        log.debug("CoT JSON parse failed (attempt 1): %s — raw: %.200s", exc, raw)
+        log.warning("CoT JSON parse failed (attempt 1): %s — raw: %.200s", exc, raw)
+        # Fall through to attempt 2
     except Exception as exc:
         log.warning("CoT error (attempt 1): %s", exc)
-        return None
+        return None, f"CoT routing error: {exc}"
 
     # ── Attempt 2: retry with correction ───────────────────────────────────
     try:
@@ -248,8 +253,8 @@ async def cot_route(
         raw2 = await ollama.chat(messages)
         _log_thinking(raw2, tag="retry")
         plan = _extract_json(raw2)
-        return plan
+        return plan, None
 
     except Exception as exc:
-        log.debug("CoT parse failed (attempt 2): %s", exc)
-        return None
+        log.warning("CoT parse failed (attempt 2): %s", exc)
+        return None, f"Intent routing failed after 2 attempts: {exc}"

--- a/tests/core/test_intent.py
+++ b/tests/core/test_intent.py
@@ -36,11 +36,12 @@ class TestCotRouteBasic:
 
         with patch("bantz.core.intent.ollama") as mock_llm:
             mock_llm.chat = AsyncMock(return_value=llm_response)
-            plan = await cot_route("What is the weather in Istanbul?", [
+            plan, error = await cot_route("What is the weather in Istanbul?", [
                 {"name": "weather", "description": "Check weather", "risk_level": "safe"},
             ])
 
         assert plan is not None
+        assert error is None
         assert plan["tool_name"] == "weather"
         assert plan["tool_args"]["city"] == "Istanbul"
 
@@ -58,9 +59,10 @@ class TestCotRouteBasic:
 
         with patch("bantz.core.intent.ollama") as mock_llm:
             mock_llm.chat = AsyncMock(return_value=llm_response)
-            plan = await cot_route("Hello there!", [])
+            plan, error = await cot_route("Hello there!", [])
 
         assert plan is not None
+        assert error is None
         assert plan["route"] == "chat"
 
     @pytest.mark.asyncio
@@ -69,9 +71,10 @@ class TestCotRouteBasic:
 
         with patch("bantz.core.intent.ollama") as mock_llm:
             mock_llm.chat = AsyncMock(return_value="Sorry, I can't assist with that.")
-            plan = await cot_route("do something bad", [])
+            plan, error = await cot_route("do something bad", [])
 
         assert plan is None
+        assert error is None  # refusal is not a routing error
 
     @pytest.mark.asyncio
     async def test_returns_none_on_low_confidence(self):
@@ -87,10 +90,11 @@ class TestCotRouteBasic:
 
         with patch("bantz.core.intent.ollama") as mock_llm:
             mock_llm.chat = AsyncMock(return_value=llm_response)
-            plan = await cot_route("maybe delete everything", [],
+            plan, error = await cot_route("maybe delete everything", [],
                                    confidence_threshold=0.4)
 
         assert plan is None
+        assert error is None  # low confidence is not a routing error
 
     @pytest.mark.asyncio
     async def test_handles_thinking_block(self):
@@ -110,11 +114,12 @@ class TestCotRouteBasic:
 
         with patch("bantz.core.intent.ollama") as mock_llm:
             mock_llm.chat = AsyncMock(return_value=llm_response)
-            plan = await cot_route("weather in London", [
+            plan, error = await cot_route("weather in London", [
                 {"name": "weather", "description": "Check weather", "risk_level": "safe"},
             ])
 
         assert plan is not None
+        assert error is None
         assert plan["tool_name"] == "weather"
 
 
@@ -152,13 +157,14 @@ class TestCotRouteWithHistory:
 
         with patch("bantz.core.intent.ollama") as mock_llm:
             mock_llm.chat = capture_chat
-            await cot_route(
+            plan, error = await cot_route(
                 "Yes, send it to him",
                 [{"name": "gmail", "description": "Send email", "risk_level": "safe"}],
                 recent_history=history,
             )
 
         assert len(captured_messages) >= 1
+        assert error is None
         system_content = captured_messages[0]["content"]
         assert "RECENT CONVERSATION" in system_content
         assert "john@example.com" in system_content
@@ -182,7 +188,7 @@ class TestCotRouteWithHistory:
 
         with patch("bantz.core.intent.ollama") as mock_llm:
             mock_llm.chat = capture_chat
-            await cot_route("hello", [], recent_history=None)
+            plan, error = await cot_route("hello", [], recent_history=None)
 
         system_content = captured_messages[0]["content"]
         assert "RECENT CONVERSATION" not in system_content
@@ -206,7 +212,7 @@ class TestCotRouteWithHistory:
 
         with patch("bantz.core.intent.ollama") as mock_llm:
             mock_llm.chat = capture_chat
-            await cot_route("hello", [], recent_history=[])
+            plan, error = await cot_route("hello", [], recent_history=[])
 
         system_content = captured_messages[0]["content"]
         assert "RECENT CONVERSATION" not in system_content
@@ -313,6 +319,75 @@ class TestBackwardCompat:
         with patch("bantz.core.intent.ollama") as mock_llm:
             mock_llm.chat = AsyncMock(return_value=llm_response)
             # Old call signature — no recent_history
-            plan = await cot_route("hello", [])
+            plan, error = await cot_route("hello", [])
 
         assert plan is not None
+        assert error is None
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 6. People-Pleaser guard — malformed JSON returns error (#253)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestPeoplePleaser:
+    """cot_route returns error string instead of silent None on JSON failures."""
+
+    @pytest.mark.asyncio
+    async def test_malformed_json_both_attempts_returns_error(self):
+        """When both LLM attempts return garbage, (None, error_string) is returned."""
+        from bantz.core.intent import cot_route
+
+        with patch("bantz.core.intent.ollama") as mock_llm:
+            # Both attempts return non-JSON garbage
+            mock_llm.chat = AsyncMock(return_value="Sure! I'll send that email right away!")
+            plan, error = await cot_route("send email to john", [
+                {"name": "gmail", "description": "Send email", "risk_level": "safe"},
+            ])
+
+        assert plan is None
+        assert error is not None
+        assert "failed" in error.lower() or "error" in error.lower()
+
+    @pytest.mark.asyncio
+    async def test_malformed_json_first_attempt_recovers(self):
+        """When 1st attempt fails but 2nd returns valid JSON, success."""
+        from bantz.core.intent import cot_route
+
+        call_count = 0
+
+        async def flaky_chat(messages):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return "Hmm, let me think about that..."  # garbage
+            return json.dumps({
+                "route": "tool",
+                "tool_name": "gmail",
+                "tool_args": {"action": "compose", "to": "john"},
+                "risk_level": "safe",
+                "confidence": 0.9,
+            })
+
+        with patch("bantz.core.intent.ollama") as mock_llm:
+            mock_llm.chat = flaky_chat
+            plan, error = await cot_route("send email to john", [
+                {"name": "gmail", "description": "Send email", "risk_level": "safe"},
+            ])
+
+        assert plan is not None
+        assert error is None
+        assert plan["tool_name"] == "gmail"
+
+    @pytest.mark.asyncio
+    async def test_generic_exception_returns_error(self):
+        """Non-JSON exceptions (e.g. network) return error string."""
+        from bantz.core.intent import cot_route
+
+        with patch("bantz.core.intent.ollama") as mock_llm:
+            mock_llm.chat = AsyncMock(side_effect=ConnectionError("Ollama is down"))
+            plan, error = await cot_route("check weather", [])
+
+        assert plan is None
+        assert error is not None
+        assert "Ollama is down" in error

--- a/tests/core/test_rlhf_feedback.py
+++ b/tests/core/test_rlhf_feedback.py
@@ -268,8 +268,8 @@ class TestSentimentInterceptProcess:
         b._to_en = AsyncMock(return_value="good job on that")
         b._quick_route = MagicMock(return_value=None)
 
-        # Mock cot_route to return None → chat path
-        with patch("bantz.core.brain.cot_route", new_callable=AsyncMock, return_value=None), \
+        # Mock cot_route to return (None, None) → chat path
+        with patch("bantz.core.brain.cot_route", new_callable=AsyncMock, return_value=(None, None)), \
              patch("bantz.core.brain.time_ctx") as mock_tc, \
              patch("bantz.core.brain.data_layer") as mock_dl, \
              patch("bantz.agent.affinity_engine.affinity_engine") as mock_ae:


### PR DESCRIPTION
## Problem (Issue #253)

When cot_route() failed (JSON parse error, Ollama timeout, etc.), it returned None and brain.py silently fell through to _chat_stream with zero context about the failure. The LLM then hallucinated tool success — fabricating emails sent, search results, file contents.

This was the root cause of the People Pleaser Syndrome observed in session analysis: every tool failure became a confident lie.

## Solution

### 1. cot_route() return type → tuple[dict|None, str|None]
- (plan, None) = routing success
- (None, None) = legitimate chat (refusal/low confidence — not an error)
- (None, error_msg) = tool routing failed — error must be surfaced

### 2. brain.py system alert injection
- Unpacks the tuple: plan, routing_error = await cot_route(...)
- When routing_error is set, injects [SYSTEM ALERT] into the chat system prompt
- Alert instructs the LLM: DO NOT pretend task completion, DO NOT fabricate data

### 3. Silent swallow removal
- Planner exception: log.debug → log.warning + error captured to variable
- Planner error merged into routing_error when both fail

### 4. Tests
- 3 new tests in TestPeoplePleaser class
- All existing tests updated for tuple return signature

## Test Results
2734 passed (baseline 2731 + 3 new), 0 regressions

Closes #253