### PR TITLE
fix(executor): circuit breaker — short-circuit on step failure

### DIFF
--- a/src/bantz/agent/executor.py
+++ b/src/bantz/agent/executor.py
@@ -4,8 +4,8 @@ Bantz v3 — Plan-and-Solve Executor (#187)
 "The Butler Carries Out His Itinerary"
 
 Executes a list of PlanSteps sequentially, passing context from one step
-to the next.  If a step fails, the executor notes it and continues with
-remaining steps (graceful degradation).
+to the next.  If a step fails, the executor **short-circuits**: remaining
+steps are marked as aborted (circuit breaker, #255).
 
 Usage:
     from bantz.agent.executor import plan_executor
@@ -79,6 +79,25 @@ class PlanExecutionResult:
 class PlanExecutor:
     """Runs plan steps sequentially, threading context between them."""
 
+    _FAILURE_MARKERS = re.compile(
+        r"(?i)^(Error:|Failed:|HTTP [45]\d\d\b|Traceback \(most recent)",
+    )
+
+    @staticmethod
+    def _is_step_failure(sr: StepResult) -> bool:
+        """Determine whether a StepResult represents a real failure.
+
+        A step is failed if:
+        - ``sr.success`` is False (tool reported failure), OR
+        - The output text starts with well-known error markers even when
+          the tool incorrectly claimed success (e.g. web_search #256).
+        """
+        if not sr.success:
+            return True
+        if sr.output and PlanExecutor._FAILURE_MARKERS.search(sr.output):
+            return True
+        return False
+
     async def run(
         self,
         steps: list[Any],  # list[PlanStep] from planner.py
@@ -90,7 +109,8 @@ class PlanExecutor:
 
         - Output from step N is stored and injected into step N+1 when
           step N+1 declares ``depends_on: N``.
-        - If a step fails, execution continues with remaining steps.
+        - **Circuit breaker (#255):** If a step fails, execution stops
+          immediately.  All remaining steps are marked as aborted.
         - ``on_step_start`` is an optional async callback for progress updates.
         - ``llm_fn`` is an async callable used by the virtual ``process_text``
           tool.  Signature: ``await llm_fn(messages) -> str``.
@@ -99,7 +119,7 @@ class PlanExecutor:
         # Rich context store: step_number → {"params": {...}, "output": "..."}
         context_store: dict[int, dict[str, Any]] = {}
 
-        for plan_step in steps:
+        for step_idx, plan_step in enumerate(steps):
             step_num = plan_step.step
             tool_name = plan_step.tool
             params = dict(plan_step.params)  # shallow copy
@@ -126,6 +146,18 @@ class PlanExecutor:
                     "output": sr.output[:2000] if sr.success else "",
                 }
                 result.step_results.append(sr)
+                # ── Circuit breaker: abort remaining steps on failure ──
+                if self._is_step_failure(sr):
+                    log.warning(
+                        "Circuit breaker tripped at step %d [%s] — "
+                        "aborting %d remaining step(s)",
+                        step_num, tool_name, len(steps) - step_idx - 1,
+                    )
+                    self._abort_remaining(
+                        steps[step_idx + 1:], step_num, result, context_store,
+                    )
+                    result.aborted = True
+                    break
                 continue
 
             # Look up tool
@@ -144,8 +176,16 @@ class PlanExecutor:
                     "output": "",
                 }
                 result.step_results.append(sr)
-                log.warning("Plan step %d: tool '%s' not found", step_num, tool_name)
-                continue
+                log.warning(
+                    "Circuit breaker tripped at step %d: tool '%s' not found "
+                    "— aborting %d remaining step(s)",
+                    step_num, tool_name, len(steps) - step_idx - 1,
+                )
+                self._abort_remaining(
+                    steps[step_idx + 1:], step_num, result, context_store,
+                )
+                result.aborted = True
+                break
 
             # Execute
             try:
@@ -173,7 +213,7 @@ class PlanExecutor:
                     tool=tool_name,
                     description=description,
                     success=False,
-                    output="",
+                    output=f"Error: {exc}",
                     error=str(exc),
                 )
                 context_store[step_num] = {
@@ -185,7 +225,49 @@ class PlanExecutor:
 
             result.step_results.append(sr)
 
+            # ── Circuit breaker: abort remaining steps on failure ──
+            if self._is_step_failure(sr):
+                log.warning(
+                    "Circuit breaker tripped at step %d [%s] — "
+                    "aborting %d remaining step(s)",
+                    step_num, tool_name, len(steps) - step_idx - 1,
+                )
+                self._abort_remaining(
+                    steps[step_idx + 1:], step_num, result, context_store,
+                )
+                result.aborted = True
+                break
+
         return result
+
+    @staticmethod
+    def _abort_remaining(
+        remaining_steps: list[Any],
+        failed_step_num: int,
+        result: PlanExecutionResult,
+        context_store: dict[int, dict[str, Any]],
+    ) -> None:
+        """Mark all *remaining_steps* as aborted due to upstream failure."""
+        abort_msg = (
+            f"[ABORTED DUE TO UPSTREAM FAILURE: Step {failed_step_num} failed]"
+        )
+        for ps in remaining_steps:
+            sr = StepResult(
+                step_number=ps.step,
+                tool=ps.tool,
+                description=ps.description,
+                success=False,
+                output=abort_msg,
+                error=abort_msg,
+            )
+            context_store[ps.step] = {
+                "params": dict(ps.params),
+                "output": "",
+            }
+            result.step_results.append(sr)
+            log.info(
+                "Plan step %d [%s]: %s", ps.step, ps.tool, abort_msg,
+            )
 
     # ── Virtual tool: process_text ───────────────────────────────────────
 

--- a/tests/agent/test_executor.py
+++ b/tests/agent/test_executor.py
@@ -260,3 +260,203 @@ class TestReplacePlaceholders:
             "{step_99_output}", {}, {}, tool_name=""
         )
         assert result == "{step_99_output}"
+
+
+# ── Circuit breaker / short-circuit tests (#255) ─────────────────────────────
+
+
+class TestCircuitBreaker:
+    """Verify that executor short-circuits on step failure."""
+
+    @staticmethod
+    def _make_step(step: int, tool: str, description: str = "", **params):
+        """Create a lightweight PlanStep-like object."""
+        from dataclasses import dataclass, field as dc_field
+        from typing import Any as _Any
+
+        @dataclass
+        class _FakeStep:
+            step: int
+            tool: str
+            params: dict[str, _Any] = dc_field(default_factory=dict)
+            description: str = ""
+            depends_on: int | None = None
+
+        return _FakeStep(step=step, tool=tool, params=params, description=description)
+
+    @pytest.mark.asyncio
+    async def test_short_circuit_on_step_failure(self):
+        """Step 1 succeeds, Step 2 fails → Step 3 is NEVER called and aborted."""
+        from unittest.mock import AsyncMock, patch, MagicMock
+        from bantz.tools import ToolResult
+
+        # Build 3-step plan
+        steps = [
+            self._make_step(1, "web_search", "Search the web", query="test"),
+            self._make_step(2, "read_url", "Read the page", url="{step_1_output}"),
+            self._make_step(3, "send_email", "Email results", body="{step_2_output}"),
+        ]
+
+        # Mock tools
+        mock_web_search = MagicMock()
+        mock_web_search.execute = AsyncMock(
+            return_value=ToolResult(success=True, output="https://example.com")
+        )
+        mock_read_url = MagicMock()
+        mock_read_url.execute = AsyncMock(
+            return_value=ToolResult(success=False, output="", error="HTTP 403 Forbidden")
+        )
+        mock_send_email = MagicMock()
+        mock_send_email.execute = AsyncMock(
+            return_value=ToolResult(success=True, output="Sent!")
+        )
+
+        tool_map = {
+            "web_search": mock_web_search,
+            "read_url": mock_read_url,
+            "send_email": mock_send_email,
+        }
+
+        with patch("bantz.agent.executor.registry") as mock_registry:
+            mock_registry.get = lambda name: tool_map.get(name)
+            executor = PlanExecutor()
+            result = await executor.run(steps)
+
+        # Step 1 executed and succeeded
+        assert result.step_results[0].success is True
+        assert result.step_results[0].tool == "web_search"
+
+        # Step 2 executed and failed
+        assert result.step_results[1].success is False
+        assert result.step_results[1].tool == "read_url"
+
+        # Step 3 was NEVER called
+        mock_send_email.execute.assert_not_called()
+
+        # Step 3 output is the abort message
+        assert result.step_results[2].success is False
+        assert result.step_results[2].output == (
+            "[ABORTED DUE TO UPSTREAM FAILURE: Step 2 failed]"
+        )
+
+        # Overall result
+        assert result.aborted is True
+        assert result.total == 3
+        assert result.succeeded == 1
+
+    @pytest.mark.asyncio
+    async def test_short_circuit_on_exception(self):
+        """Step that raises an exception triggers circuit breaker."""
+        from unittest.mock import AsyncMock, patch, MagicMock
+        from bantz.tools import ToolResult
+
+        steps = [
+            self._make_step(1, "web_search", "Search", query="q"),
+            self._make_step(2, "save_file", "Save", path="f.txt"),
+        ]
+
+        mock_web_search = MagicMock()
+        mock_web_search.execute = AsyncMock(
+            side_effect=ConnectionError("Ollama is down")
+        )
+        mock_save_file = MagicMock()
+        mock_save_file.execute = AsyncMock(
+            return_value=ToolResult(success=True, output="Saved")
+        )
+
+        tool_map = {"web_search": mock_web_search, "save_file": mock_save_file}
+
+        with patch("bantz.agent.executor.registry") as mock_registry:
+            mock_registry.get = lambda name: tool_map.get(name)
+            result = await PlanExecutor().run(steps)
+
+        assert result.step_results[0].success is False
+        assert "Ollama is down" in result.step_results[0].error
+        mock_save_file.execute.assert_not_called()
+        assert "[ABORTED" in result.step_results[1].output
+        assert result.aborted is True
+
+    @pytest.mark.asyncio
+    async def test_short_circuit_on_error_marker_in_output(self):
+        """Tool claims success=True but output starts with 'Error:' → tripped."""
+        from unittest.mock import AsyncMock, patch, MagicMock
+        from bantz.tools import ToolResult
+
+        steps = [
+            self._make_step(1, "web_search", "Search", query="q"),
+            self._make_step(2, "read_url", "Read", url="x"),
+        ]
+
+        mock_web_search = MagicMock()
+        mock_web_search.execute = AsyncMock(
+            return_value=ToolResult(
+                success=True,
+                output="Error: No results found for query",
+            )
+        )
+        mock_read_url = MagicMock()
+        mock_read_url.execute = AsyncMock(
+            return_value=ToolResult(success=True, output="page content")
+        )
+
+        tool_map = {"web_search": mock_web_search, "read_url": mock_read_url}
+
+        with patch("bantz.agent.executor.registry") as mock_registry:
+            mock_registry.get = lambda name: tool_map.get(name)
+            result = await PlanExecutor().run(steps)
+
+        # web_search "succeeded" per tool but output has Error: marker
+        assert result.step_results[0].output.startswith("Error:")
+        mock_read_url.execute.assert_not_called()
+        assert "[ABORTED" in result.step_results[1].output
+        assert result.aborted is True
+
+    @pytest.mark.asyncio
+    async def test_all_steps_succeed_no_abort(self):
+        """When all steps succeed, no short-circuit occurs."""
+        from unittest.mock import AsyncMock, patch, MagicMock
+        from bantz.tools import ToolResult
+
+        steps = [
+            self._make_step(1, "web_search", "Search", query="q"),
+            self._make_step(2, "read_url", "Read", url="u"),
+        ]
+
+        mock_web_search = MagicMock()
+        mock_web_search.execute = AsyncMock(
+            return_value=ToolResult(success=True, output="https://example.com")
+        )
+        mock_read_url = MagicMock()
+        mock_read_url.execute = AsyncMock(
+            return_value=ToolResult(success=True, output="Page content here")
+        )
+
+        tool_map = {"web_search": mock_web_search, "read_url": mock_read_url}
+
+        with patch("bantz.agent.executor.registry") as mock_registry:
+            mock_registry.get = lambda name: tool_map.get(name)
+            result = await PlanExecutor().run(steps)
+
+        assert result.aborted is False
+        assert result.all_success is True
+        assert result.total == 2
+        mock_web_search.execute.assert_called_once()
+        mock_read_url.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_tool_not_found_triggers_circuit_breaker(self):
+        """Missing tool in registry triggers circuit breaker."""
+        steps = [
+            self._make_step(1, "nonexistent_tool", "Do something"),
+            self._make_step(2, "web_search", "Search", query="q"),
+        ]
+
+        from unittest.mock import patch
+        with patch("bantz.agent.executor.registry") as mock_registry:
+            mock_registry.get = lambda name: None
+            result = await PlanExecutor().run(steps)
+
+        assert result.step_results[0].success is False
+        assert "not found" in result.step_results[0].error
+        assert "[ABORTED" in result.step_results[1].output
+        assert result.aborted is True

--- a/tests/agent/test_planner.py
+++ b/tests/agent/test_planner.py
@@ -342,7 +342,7 @@ class TestPlanExecutor:
 
     @pytest.mark.asyncio
     async def test_handles_step_failure_gracefully(self):
-        """One step fails → execution continues, summary shows partial."""
+        """One step fails → circuit breaker aborts remaining steps (#255)."""
         from bantz.agent.planner import PlanStep
         from bantz.agent.executor import PlanExecutor
 
@@ -370,10 +370,13 @@ class TestPlanExecutor:
 
             result = await executor.run(steps)
 
-        assert result.succeeded == 1
+        # Circuit breaker: step 1 failed → step 2 aborted, never executed
+        assert result.succeeded == 0
         assert result.total == 2
+        assert result.aborted is True
         assert result.all_success is False
-        assert "1 of 2" in result.summary()
+        mock_weather.assert_not_called()
+        assert "[ABORTED" in result.step_results[1].output
 
     @pytest.mark.asyncio
     async def test_unknown_tool_doesnt_crash(self):


### PR DESCRIPTION
## Problem (Issue #255)

When Step 1 of a multi-step plan failed, the executor blindly continued executing Step 2, Step 3, etc. with empty/broken context. This caused cascading errors and confused the LLM into hallucinating results from steps that never had valid input.

**Example from real session:** web_search returned an error → read_url ran with empty URL → process_text got garbage → LLM fabricated a summary from nothing.

## Solution

### Circuit Breaker in `PlanExecutor.run()`
- After each step, `_is_step_failure(sr)` evaluates whether the step truly failed:
  - `sr.success == False` (tool reported failure)
  - Output starts with `Error:`, `Failed:`, `HTTP 4xx/5xx`, or `Traceback` — catches tools that lie about success (#256)
- On failure: **BREAK** the loop immediately
- `_abort_remaining()` fills all downstream steps with: `[ABORTED DUE TO UPSTREAM FAILURE: Step N failed]`
- `PlanExecutionResult.aborted = True` signals the brain that the plan was short-circuited
- Tool-not-found also triggers the circuit breaker (was: continue)
- Exceptions in `tool.execute()` now include `Error: {exc}` in output for consistent detection

### Tests (5 new + 1 updated)
- `test_short_circuit_on_step_failure` — 3-step plan, step 2 fails → step 3 NEVER called, abort message in output
- `test_short_circuit_on_exception` — ConnectionError triggers breaker
- `test_short_circuit_on_error_marker_in_output` — success=True but output starts with `Error:`
- `test_all_steps_succeed_no_abort` — happy path, no short-circuit
- `test_tool_not_found_triggers_circuit_breaker` — missing tool aborts remaining
- Updated `test_handles_step_failure_gracefully` in test_planner.py to match new behavior

## Test Results
```
2739 passed (baseline 2734 + 5 new), 0 regressions
3 pre-existing failures (unrelated)
```

Closes #255