### PR TITLE
fix(web_search): error classification, session-scoped state, Circuit Breaker integration (#256)

### DIFF
--- a/src/bantz/tools/web_search.py
+++ b/src/bantz/tools/web_search.py
@@ -1,9 +1,10 @@
-"""
-Bantz v2 — Web Search Tool
-DuckDuckGo-based internet search with TTL caching, source URL tracking,
-and result deduplication.
+"""Bantz v2 - Web Search Tool (#256)
 
-Implements #79 (web_search tool) and #65 (caching + source tracking).
+DuckDuckGo-based internet search with TTL caching, source URL tracking,
+result deduplication, and proper error classification.
+
+Implements #79 (web_search tool), #65 (caching + source tracking),
+and #256 (silent failure fix + global mutable state removal).
 """
 from __future__ import annotations
 
@@ -11,6 +12,7 @@ import hashlib
 import logging
 import re
 import time
+from collections import OrderedDict
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -19,6 +21,21 @@ import httpx
 from bantz.tools import BaseTool, ToolResult, registry
 
 log = logging.getLogger("bantz.web_search")
+
+
+# ── SearchOutcome ───────────────────────────────────────────────────────────────────
+
+@dataclass
+class SearchOutcome:
+    """Result of a search attempt with error classification.
+
+    Distinguishes genuine “zero hits” (infrastructure worked, no matches)
+    from infrastructure failures (network error, 403/429 block, timeout).
+    This feeds into the Circuit Breaker (PR #260) via success=False.
+    """
+    results: list[dict] = field(default_factory=list)
+    source: str = "none"                 # "api", "html", "both", "none"
+    infrastructure_error: str | None = None  # None = infra OK
 
 # ── Cache ──────────────────────────────────────────────────────────────────────
 
@@ -80,9 +97,37 @@ class _SearchCache:
 # Global cache instance
 _cache = _SearchCache()
 
-# ── Session state for follow-ups ───────────────────────────────────────────────
+# ── Session-scoped last results (bounded LRU) ───────────────────────────────────
 
-_last_results: list[dict] = []
+_MAX_SESSIONS = 20
+
+
+class _LastResultsStore:
+    """Bounded dict keyed by session_id to avoid memory leaks.
+
+    When the tool is a singleton, naively storing results per session
+    without cleanup leads to unbounded growth.  This class uses an
+    OrderedDict capped at ``_MAX_SESSIONS`` entries (LRU eviction).
+    """
+
+    def __init__(self, maxsize: int = _MAX_SESSIONS) -> None:
+        self._store: OrderedDict[str, list[dict]] = OrderedDict()
+        self._maxsize = maxsize
+
+    def get(self, session_id: str) -> list[dict]:
+        results = self._store.get(session_id, [])
+        if results:
+            self._store.move_to_end(session_id)
+        return results
+
+    def put(self, session_id: str, results: list[dict]) -> None:
+        self._store[session_id] = results
+        self._store.move_to_end(session_id)
+        while len(self._store) > self._maxsize:
+            self._store.popitem(last=False)
+
+
+_last_results_store = _LastResultsStore()
 
 
 # ── DuckDuckGo search ─────────────────────────────────────────────────────────
@@ -90,13 +135,16 @@ _last_results: list[dict] = []
 TIMEOUT = 10.0
 
 
-async def _ddg_search(query: str, max_results: int = 8) -> list[dict]:
+async def _ddg_search(query: str, max_results: int = 8) -> SearchOutcome:
     """
     Search DuckDuckGo via the HTML lite endpoint + instant answer API.
-    Returns list of {"title": ..., "url": ..., "snippet": ...}
+    Returns a SearchOutcome with results and error classification.
     """
     results: list[dict] = []
     seen_urls: set[str] = set()
+    api_error: str | None = None
+    html_error: str | None = None
+    source = "none"
 
     # Method 1: DuckDuckGo Instant Answer API (fast, structured)
     try:
@@ -146,8 +194,18 @@ async def _ddg_search(query: str, max_results: int = 8) -> list[dict]:
                             })
                             seen_urls.add(sub["FirstURL"])
 
+            source = "api"
+
+    except httpx.HTTPStatusError as exc:
+        code = exc.response.status_code
+        api_error = f"HTTP {code} ({_classify_http_error(code)})"
+        log.warning("DDG API failed: %s", api_error)
+    except httpx.TimeoutException:
+        api_error = "timeout"
+        log.warning("DDG API timed out")
     except Exception as exc:
-        log.debug("DDG instant answer failed: %s", exc)
+        api_error = f"{type(exc).__name__}: {exc}"
+        log.warning("DDG API failed: %s", api_error)
 
     # Method 2: DuckDuckGo HTML lite (fallback for web results)
     if len(results) < 3:
@@ -162,8 +220,6 @@ async def _ddg_search(query: str, max_results: int = 8) -> list[dict]:
                 html = resp.text
 
                 # Parse results from HTML lite page
-                # Each result block: <a rel="nofollow" class="result__a" href="...">title</a>
-                # Snippet: <a class="result__snippet" ...>text</a>
                 links = re.findall(
                     r'class="result__a"[^>]*href="([^"]+)"[^>]*>(.+?)</a>',
                     html,
@@ -184,7 +240,6 @@ async def _ddg_search(query: str, max_results: int = 8) -> list[dict]:
                     if url in seen_urls:
                         continue
 
-                    # Clean HTML tags from title and snippet
                     clean_title = re.sub(r"<[^>]+>", "", title).strip()
                     clean_snippet = ""
                     if i < len(snippets):
@@ -198,10 +253,49 @@ async def _ddg_search(query: str, max_results: int = 8) -> list[dict]:
                     })
                     seen_urls.add(url)
 
-        except Exception as exc:
-            log.debug("DDG HTML lite failed: %s", exc)
+                source = "both" if source == "api" else "html"
 
-    return results[:max_results]
+        except httpx.HTTPStatusError as exc:
+            code = exc.response.status_code
+            html_error = f"HTTP {code} ({_classify_http_error(code)})"
+            log.warning("DDG HTML failed: %s", html_error)
+        except httpx.TimeoutException:
+            html_error = "timeout"
+            log.warning("DDG HTML timed out")
+        except Exception as exc:
+            html_error = f"{type(exc).__name__}: {exc}"
+            log.warning("DDG HTML failed: %s", html_error)
+
+    # Build infrastructure error string if BOTH methods failed
+    infra_error: str | None = None
+    if not results and (api_error or html_error):
+        parts = []
+        if api_error:
+            parts.append(f"API: {api_error}")
+        if html_error:
+            parts.append(f"HTML: {html_error}")
+        infra_error = " | ".join(parts)
+
+    return SearchOutcome(
+        results=results[:max_results],
+        source=source,
+        infrastructure_error=infra_error,
+    )
+
+
+def _classify_http_error(code: int) -> str:
+    """Human-readable classification of HTTP error codes."""
+    if code == 403:
+        return "bot-blocked"
+    if code == 429:
+        return "rate-limited"
+    if code == 503:
+        return "service-unavailable"
+    if 400 <= code < 500:
+        return "client-error"
+    if 500 <= code < 600:
+        return "server-error"
+    return "unknown"
 
 
 def _deduplicate(new_results: list[dict], recent: list[dict]) -> list[dict]:
@@ -272,36 +366,43 @@ class WebSearchTool(BaseTool):
         - query: search query string
         - index: if > 0, return details about the Nth result from last search
         """
-        global _last_results
+        # Session key for scoped last-results storage
+        session_id = kwargs.get("session_id", "_default")
 
         if not query and not index:
             return ToolResult(success=False, output="", error="No search query provided")
 
         # Follow-up: "tell me more about the first/second result"
-        if index and _last_results:
-            idx = index - 1
-            if 0 <= idx < len(_last_results):
-                r = _last_results[idx]
-                detail = (
-                    f"Result #{index}: {r.get('title', '')}\n"
-                    f"URL: {r.get('url', '')}\n"
-                    f"Source: {r.get('source', '')}\n\n"
-                    f"{r.get('snippet', 'No additional details available.')}"
-                )
+        if index:
+            last_results = _last_results_store.get(session_id)
+            if last_results:
+                idx = index - 1
+                if 0 <= idx < len(last_results):
+                    r = last_results[idx]
+                    detail = (
+                        f"Result #{index}: {r.get('title', '')}\n"
+                        f"URL: {r.get('url', '')}\n"
+                        f"Source: {r.get('source', '')}\n\n"
+                        f"{r.get('snippet', 'No additional details available.')}"
+                    )
+                    return ToolResult(
+                        success=True,
+                        output=detail,
+                        data={"result": r, "index": index},
+                    )
                 return ToolResult(
-                    success=True,
-                    output=detail,
-                    data={"result": r, "index": index},
+                    success=False, output="",
+                    error=f"No result at index {index}. Last search had {len(last_results)} results.",
                 )
             return ToolResult(
                 success=False, output="",
-                error=f"No result at index {index}. Last search had {len(_last_results)} results.",
+                error="No previous search results in this session.",
             )
 
         # Check cache
         cached_results = _cache.get(query)
         if cached_results is not None:
-            _last_results = cached_results
+            _last_results_store.put(session_id, cached_results)
             output = _format_results(cached_results, query, cached=True)
             return ToolResult(
                 success=True,
@@ -310,31 +411,42 @@ class WebSearchTool(BaseTool):
             )
 
         # Fresh search
-        try:
-            results = await _ddg_search(query)
-        except Exception as exc:
-            return ToolResult(success=False, output="", error=f"Search failed: {exc}")
+        outcome = await _ddg_search(query)
 
-        if not results:
+        # Infrastructure failure → success=False (feeds Circuit Breaker)
+        if outcome.infrastructure_error and not outcome.results:
+            return ToolResult(
+                success=False,
+                output="",
+                error=f"Search engine unreachable or blocked: {outcome.infrastructure_error}",
+            )
+
+        # Genuine zero hits (infra worked, no matches)
+        if not outcome.results:
             return ToolResult(
                 success=True,
                 output=f"No results found for: {query}",
-                data={"results": [], "count": 0},
+                data={"results": [], "count": 0, "source": outcome.source},
             )
 
         # Deduplicate against recent results
         recent = _cache.recent_results()
-        results = _deduplicate(results, recent)
+        results = _deduplicate(outcome.results, recent)
 
-        # Store in cache + session state
+        # Store in cache + session-scoped state
         _cache.put(query, results)
-        _last_results = results
+        _last_results_store.put(session_id, results)
 
         output = _format_results(results, query, cached=False)
         return ToolResult(
             success=True,
             output=output,
-            data={"results": results, "cached": False, "count": len(results)},
+            data={
+                "results": results,
+                "cached": False,
+                "count": len(results),
+                "source": outcome.source,
+            },
         )
 
 

--- a/tests/tools/test_web_search.py
+++ b/tests/tools/test_web_search.py
@@ -1,7 +1,10 @@
-"""Tests for web_search URL deduplication and formatting."""
+"""Tests for web_search URL deduplication, formatting, error handling (#256)."""
 from __future__ import annotations
 
 import re
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
 import pytest
 
 
@@ -107,3 +110,285 @@ class TestDDGSearchDedup:
         from bantz.tools.web_search import _format_results
         src = inspect.getsource(_format_results)
         assert "seen_urls" in src
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# SearchOutcome dataclass
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestSearchOutcome:
+    """Verify the SearchOutcome dataclass structure."""
+
+    def test_defaults(self):
+        from bantz.tools.web_search import SearchOutcome
+        o = SearchOutcome()
+        assert o.results == []
+        assert o.source == "none"
+        assert o.infrastructure_error is None
+
+    def test_with_error(self):
+        from bantz.tools.web_search import SearchOutcome
+        o = SearchOutcome(results=[], source="none", infrastructure_error="API: timeout | HTML: HTTP 403 (bot-blocked)")
+        assert o.infrastructure_error is not None
+        assert "403" in o.infrastructure_error
+
+    def test_successful_search(self):
+        from bantz.tools.web_search import SearchOutcome
+        o = SearchOutcome(results=[{"title": "a"}], source="api")
+        assert o.results
+        assert o.infrastructure_error is None
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# _classify_http_error
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestClassifyHTTPError:
+    """Verify HTTP error code classification."""
+
+    def _classify(self, code):
+        from bantz.tools.web_search import _classify_http_error
+        return _classify_http_error(code)
+
+    def test_403_bot_blocked(self):
+        assert self._classify(403) == "bot-blocked"
+
+    def test_429_rate_limited(self):
+        assert self._classify(429) == "rate-limited"
+
+    def test_503_unavailable(self):
+        assert self._classify(503) == "service-unavailable"
+
+    def test_500_server_error(self):
+        assert self._classify(500) == "server-error"
+
+    def test_400_client_error(self):
+        assert self._classify(400) == "client-error"
+
+    def test_unknown(self):
+        assert self._classify(301) == "unknown"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# _LastResultsStore (session-scoped LRU)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestLastResultsStore:
+    """Verify the bounded session-scoped results store."""
+
+    def _store(self, maxsize=3):
+        from bantz.tools.web_search import _LastResultsStore
+        return _LastResultsStore(maxsize=maxsize)
+
+    def test_put_get(self):
+        s = self._store()
+        s.put("sess1", [{"title": "a"}])
+        assert len(s.get("sess1")) == 1
+
+    def test_get_empty(self):
+        s = self._store()
+        assert s.get("nonexistent") == []
+
+    def test_lru_eviction(self):
+        s = self._store(maxsize=2)
+        s.put("s1", [{"title": "a"}])
+        s.put("s2", [{"title": "b"}])
+        s.put("s3", [{"title": "c"}])  # evicts s1
+        assert s.get("s1") == []
+        assert len(s.get("s2")) == 1
+        assert len(s.get("s3")) == 1
+
+    def test_access_refreshes_lru(self):
+        s = self._store(maxsize=2)
+        s.put("s1", [{"title": "a"}])
+        s.put("s2", [{"title": "b"}])
+        s.get("s1")  # refresh s1, making s2 oldest
+        s.put("s3", [{"title": "c"}])  # evicts s2
+        assert len(s.get("s1")) == 1
+        assert s.get("s2") == []
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# _ddg_search error classification
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestDDGSearchErrorHandling:
+    """Verify _ddg_search returns proper SearchOutcome on failures."""
+
+    @pytest.mark.asyncio
+    async def test_both_methods_timeout(self):
+        """When both API and HTML time out, returns infrastructure_error."""
+        from bantz.tools.web_search import _ddg_search
+
+        async def timeout_get(*args, **kwargs):
+            raise httpx.ReadTimeout("read timed out")
+
+        mock_client = AsyncMock()
+        mock_client.get = timeout_get
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            outcome = await _ddg_search("test query")
+
+        assert outcome.results == []
+        assert outcome.infrastructure_error is not None
+        assert "timeout" in outcome.infrastructure_error.lower()
+
+    @pytest.mark.asyncio
+    async def test_api_403_html_403(self):
+        """When both methods return 403, error includes bot-blocked."""
+        from bantz.tools.web_search import _ddg_search
+
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        mock_response.headers = {}
+
+        async def forbidden_get(*args, **kwargs):
+            raise httpx.HTTPStatusError(
+                "403 Forbidden", request=MagicMock(), response=mock_response
+            )
+
+        mock_client = AsyncMock()
+        mock_client.get = forbidden_get
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            outcome = await _ddg_search("blocked query")
+
+        assert outcome.results == []
+        assert outcome.infrastructure_error is not None
+        assert "403" in outcome.infrastructure_error
+        assert "bot-blocked" in outcome.infrastructure_error
+
+    @pytest.mark.asyncio
+    async def test_api_429_rate_limited(self):
+        """429 rate-limit is classified correctly."""
+        from bantz.tools.web_search import _ddg_search
+
+        mock_response = MagicMock()
+        mock_response.status_code = 429
+
+        async def limited_get(*args, **kwargs):
+            raise httpx.HTTPStatusError(
+                "429 Too Many Requests", request=MagicMock(), response=mock_response
+            )
+
+        mock_client = AsyncMock()
+        mock_client.get = limited_get
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            outcome = await _ddg_search("rate limited")
+
+        assert "rate-limited" in (outcome.infrastructure_error or "")
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# WebSearchTool.execute() — Circuit Breaker integration
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestExecuteErrorHandling:
+    """Verify execute() returns success=False on infra failures."""
+
+    @pytest.mark.asyncio
+    async def test_infra_failure_returns_success_false(self):
+        """Infra error → success=False (Circuit Breaker triggers)."""
+        from bantz.tools.web_search import WebSearchTool, SearchOutcome
+
+        tool = WebSearchTool()
+        outcome = SearchOutcome(
+            results=[], source="none",
+            infrastructure_error="API: timeout | HTML: HTTP 403 (bot-blocked)",
+        )
+
+        with patch("bantz.tools.web_search._ddg_search", return_value=outcome), \
+             patch("bantz.tools.web_search._cache") as mock_cache:
+            mock_cache.get.return_value = None
+            result = await tool.execute(query="test")
+
+        assert result.success is False
+        assert "unreachable or blocked" in result.error
+        assert "403" in result.error
+
+    @pytest.mark.asyncio
+    async def test_genuine_zero_hits_returns_success_true(self):
+        """Zero results but no infra error → success=True."""
+        from bantz.tools.web_search import WebSearchTool, SearchOutcome
+
+        tool = WebSearchTool()
+        outcome = SearchOutcome(results=[], source="both", infrastructure_error=None)
+
+        with patch("bantz.tools.web_search._ddg_search", return_value=outcome), \
+             patch("bantz.tools.web_search._cache") as mock_cache:
+            mock_cache.get.return_value = None
+            result = await tool.execute(query="xyzzy nonexistent gibberish")
+
+        assert result.success is True
+        assert "No results found" in result.output
+        assert result.data["count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_successful_search_has_source(self):
+        """Successful search includes source in data."""
+        from bantz.tools.web_search import WebSearchTool, SearchOutcome
+
+        tool = WebSearchTool()
+        outcome = SearchOutcome(
+            results=[{"title": "Py", "url": "https://python.org", "snippet": "s", "source": "DDG"}],
+            source="api",
+        )
+
+        with patch("bantz.tools.web_search._ddg_search", return_value=outcome), \
+             patch("bantz.tools.web_search._cache") as mock_cache:
+            mock_cache.get.return_value = None
+            mock_cache.recent_results.return_value = []
+            result = await tool.execute(query="python")
+
+        assert result.success is True
+        assert result.data["source"] == "api"
+        assert result.data["count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_session_scoped_follow_up(self):
+        """Follow-up index uses session-scoped store, not global."""
+        from bantz.tools.web_search import WebSearchTool, _last_results_store
+
+        tool = WebSearchTool()
+        _last_results_store.put("sess_A", [
+            {"title": "R1", "url": "https://r1.com", "snippet": "s1", "source": "DDG"},
+        ])
+        _last_results_store.put("sess_B", [
+            {"title": "R2", "url": "https://r2.com", "snippet": "s2", "source": "DDG"},
+        ])
+
+        result_a = await tool.execute(index=1, session_id="sess_A")
+        assert result_a.success is True
+        assert "R1" in result_a.output
+
+        result_b = await tool.execute(index=1, session_id="sess_B")
+        assert result_b.success is True
+        assert "R2" in result_b.output
+
+    @pytest.mark.asyncio
+    async def test_no_previous_results_error(self):
+        """Follow-up with no previous results returns helpful error."""
+        from bantz.tools.web_search import WebSearchTool
+
+        tool = WebSearchTool()
+        result = await tool.execute(index=1, session_id="fresh_session_xyz")
+        assert result.success is False
+        assert "No previous search results" in result.error
+
+    @pytest.mark.asyncio
+    async def test_no_global_last_results(self):
+        """Module no longer has a global _last_results list."""
+        import bantz.tools.web_search as mod
+        assert not hasattr(mod, "_last_results") or not isinstance(getattr(mod, "_last_results", None), list)


### PR DESCRIPTION
Fixes #256 - Silent Search Failure + Global Mutable State

- SearchOutcome dataclass for typed search results
- Session-scoped _LastResultsStore (LRU, max 20) replacing global _last_results
- HTTP error classification: 403 bot-blocked, 429 rate-limited, 503 unavailable
- Circuit Breaker integration: infra failure -> success=False, zero hits -> success=True
- 31 tests (22 new)

Closes #256