### PR TITLE
feat(filesystem): PDF reading, context bloat safeguard, binary rejection (#258)

### DIFF
--- a/src/bantz/tools/filesystem.py
+++ b/src/bantz/tools/filesystem.py
@@ -1,19 +1,50 @@
-"""
-Bantz v2 — Filesystem Tool
-File system operations: listing, reading, writing.
-Path security check — cannot go outside the home directory (by default).
+"""Bantz v2 - Filesystem Tool (#258: PDF support + binary rejection)
+
+File system operations: listing, reading (text + PDF), writing.
+Path security check - cannot go outside the home directory (by default).
 """
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 from typing import Any, Literal
 
 from bantz.tools import BaseTool, ToolResult, registry
 
-# Safe root — default is home directory
+log = logging.getLogger("bantz.filesystem")
+
+# Safe root - default is home directory
 SAFE_ROOT = Path.home()
-MAX_READ_BYTES = 50_000   # truncates files larger than 50KB
+MAX_READ_BYTES = 50_000   # truncates text files larger than 50KB
+MAX_PDF_CHARS = 25_000    # truncates PDF text to ~10-15 pages (#258)
+
+# Binary extensions that cannot be meaningfully read as text
+_BINARY_EXTENSIONS = frozenset({
+    ".exe", ".dll", ".so", ".dylib", ".bin",
+    ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".tiff", ".ico", ".webp",
+    ".mp3", ".wav", ".flac", ".ogg", ".aac", ".wma",
+    ".mp4", ".avi", ".mkv", ".mov", ".wmv", ".flv", ".webm",
+    ".zip", ".tar", ".gz", ".bz2", ".xz", ".7z", ".rar",
+    ".iso", ".img", ".dmg",
+    ".pyc", ".pyo", ".class", ".o",
+    ".db", ".sqlite", ".sqlite3",
+})
+
+# Lazy import for PyMuPDF - app must not crash if missing (#258)
+_fitz = None
+
+
+def _get_fitz():
+    """Lazy-load fitz (PyMuPDF). Returns module or None."""
+    global _fitz
+    if _fitz is None:
+        try:
+            import fitz  # type: ignore[import-untyped]
+            _fitz = fitz
+        except ImportError:
+            return None
+    return _fitz
 
 
 def _safe_path(raw: str) -> Path | None:
@@ -111,6 +142,22 @@ class FilesystemTool(BaseTool):
             return ToolResult(success=False, output="", error=f"File not found: {p}")
         if p.is_dir():
             return ToolResult(success=False, output="", error=f"This is a directory: {p}. Use 'ls'.")
+
+        suffix = p.suffix.lower()
+
+        # ── Binary file rejection (#258) ──────────────────────────────
+        if suffix in _BINARY_EXTENSIONS:
+            return ToolResult(
+                success=False,
+                output="Error: Cannot read binary file format as text.",
+                error=f"Unsupported binary format: {suffix}",
+            )
+
+        # ── PDF reading via PyMuPDF (#258) ────────────────────────────
+        if suffix == ".pdf":
+            return await self._read_pdf(p)
+
+        # ── Plain text reading ────────────────────────────────────────
         try:
             raw = p.read_bytes()
             truncated = len(raw) > MAX_READ_BYTES
@@ -124,6 +171,72 @@ class FilesystemTool(BaseTool):
             )
         except PermissionError:
             return ToolResult(success=False, output="", error=f"Permission denied: {p}")
+
+    # ── PDF reader (#258) ─────────────────────────────────────────────────
+
+    async def _read_pdf(self, p: Path) -> ToolResult:
+        """Extract text from PDF with context-bloat safeguard."""
+        fitz = _get_fitz()
+        if fitz is None:
+            return ToolResult(
+                success=False,
+                output="Error: PDF reading requires PyMuPDF. Install with: pip install pymupdf",
+                error="PyMuPDF (fitz) not installed.",
+            )
+
+        try:
+            doc = fitz.open(str(p))
+        except Exception as exc:
+            return ToolResult(
+                success=False, output="",
+                error=f"Failed to open PDF: {exc}",
+            )
+
+        # Encrypted / password-protected
+        if doc.is_encrypted:
+            doc.close()
+            return ToolResult(
+                success=False,
+                output="Error: PDF is password protected or encrypted.",
+                error="Encrypted PDF.",
+            )
+
+        # Extract text from all pages
+        try:
+            page_count = len(doc)
+            text = "\n".join(page.get_text() for page in doc)
+        finally:
+            doc.close()
+
+        # No readable text (scanned images only)
+        if not text.strip():
+            return ToolResult(
+                success=False,
+                output="Error: PDF contains no readable text (might be scanned images only).",
+                error="Empty PDF text.",
+            )
+
+        # Context bloat safeguard — truncate long PDFs
+        original_len = len(text)
+        truncated = original_len > MAX_PDF_CHARS
+        if truncated:
+            text = (
+                text[:MAX_PDF_CHARS]
+                + "\n\n[SYSTEM WARNING: File truncated due to length limits. "
+                "Only the beginning is shown.]"
+            )
+            log.warning("PDF %s truncated from %d to %d chars", p.name, original_len, MAX_PDF_CHARS)
+
+        return ToolResult(
+            success=True,
+            output=text,
+            data={
+                "path": str(p),
+                "pages": page_count,
+                "length": len(text),
+                "truncated": truncated,
+            },
+        )
 
     # ── write ─────────────────────────────────────────────────────────────
 

--- a/tests/tools/test_filesystem.py
+++ b/tests/tools/test_filesystem.py
@@ -1,0 +1,376 @@
+"""Tests for Issue #258 — PDF reading, context bloat safeguard, binary rejection.
+
+Covers:
+  1. PDF happy path (text extraction via mocked fitz)
+  2. Encrypted PDF → success=False
+  3. Empty PDF (scanned images) → success=False
+  4. Long PDF truncation at MAX_PDF_CHARS
+  5. Binary file rejection (.exe, .jpg, .zip, etc.)
+  6. PyMuPDF missing → graceful error
+  7. Plain text reading still works (regression check)
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch, PropertyMock
+
+import pytest
+
+from bantz.tools import ToolResult
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Helpers — mock fitz objects
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _make_mock_doc(pages_text: list[str], encrypted: bool = False):
+    """Build a mock fitz.Document with given page texts."""
+    mock_doc = MagicMock()
+    mock_doc.is_encrypted = encrypted
+    mock_doc.__len__ = lambda self: len(pages_text)
+
+    mock_pages = []
+    for text in pages_text:
+        page = MagicMock()
+        page.get_text.return_value = text
+        mock_pages.append(page)
+
+    mock_doc.__iter__ = lambda self: iter(mock_pages)
+    mock_doc.close = MagicMock()
+    return mock_doc
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 1. PDF happy path
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestPDFReading:
+    """PDF text extraction via PyMuPDF."""
+
+    @pytest.mark.asyncio
+    async def test_reads_pdf_text(self, tmp_path):
+        from bantz.tools.filesystem import FilesystemTool
+
+        pdf_file = tmp_path / "report.pdf"
+        pdf_file.write_bytes(b"%PDF-fake")
+
+        mock_doc = _make_mock_doc(["Page 1 content.", "Page 2 content."])
+        mock_fitz = MagicMock()
+        mock_fitz.open.return_value = mock_doc
+
+        tool = FilesystemTool()
+        with patch("bantz.tools.filesystem.SAFE_ROOT", tmp_path), \
+             patch("bantz.tools.filesystem._get_fitz", return_value=mock_fitz):
+            result = await tool.execute(action="read", path=str(pdf_file))
+
+        assert result.success is True
+        assert "Page 1 content." in result.output
+        assert "Page 2 content." in result.output
+        assert result.data["pages"] == 2
+        assert result.data["truncated"] is False
+
+    @pytest.mark.asyncio
+    async def test_pdf_page_count_in_data(self, tmp_path):
+        from bantz.tools.filesystem import FilesystemTool
+
+        pdf_file = tmp_path / "three_pages.pdf"
+        pdf_file.write_bytes(b"%PDF-fake")
+
+        mock_doc = _make_mock_doc(["A", "B", "C"])
+        mock_fitz = MagicMock()
+        mock_fitz.open.return_value = mock_doc
+
+        tool = FilesystemTool()
+        with patch("bantz.tools.filesystem.SAFE_ROOT", tmp_path), \
+             patch("bantz.tools.filesystem._get_fitz", return_value=mock_fitz):
+            result = await tool.execute(action="read", path=str(pdf_file))
+
+        assert result.data["pages"] == 3
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 2. Encrypted PDF
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestEncryptedPDF:
+    """Password-protected PDFs must return success=False."""
+
+    @pytest.mark.asyncio
+    async def test_encrypted_pdf_rejected(self, tmp_path):
+        from bantz.tools.filesystem import FilesystemTool
+
+        pdf_file = tmp_path / "secret.pdf"
+        pdf_file.write_bytes(b"%PDF-fake")
+
+        mock_doc = _make_mock_doc([], encrypted=True)
+        mock_fitz = MagicMock()
+        mock_fitz.open.return_value = mock_doc
+
+        tool = FilesystemTool()
+        with patch("bantz.tools.filesystem.SAFE_ROOT", tmp_path), \
+             patch("bantz.tools.filesystem._get_fitz", return_value=mock_fitz):
+            result = await tool.execute(action="read", path=str(pdf_file))
+
+        assert result.success is False
+        assert "password protected" in result.output.lower() or "encrypted" in result.output.lower()
+        mock_doc.close.assert_called_once()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 3. Empty PDF (scanned images)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestEmptyPDF:
+    """PDFs with no extractable text (image-only scans)."""
+
+    @pytest.mark.asyncio
+    async def test_empty_pdf_returns_failure(self, tmp_path):
+        from bantz.tools.filesystem import FilesystemTool
+
+        pdf_file = tmp_path / "scan.pdf"
+        pdf_file.write_bytes(b"%PDF-fake")
+
+        mock_doc = _make_mock_doc(["", "   ", ""])
+        mock_fitz = MagicMock()
+        mock_fitz.open.return_value = mock_doc
+
+        tool = FilesystemTool()
+        with patch("bantz.tools.filesystem.SAFE_ROOT", tmp_path), \
+             patch("bantz.tools.filesystem._get_fitz", return_value=mock_fitz):
+            result = await tool.execute(action="read", path=str(pdf_file))
+
+        assert result.success is False
+        assert "no readable text" in result.output.lower()
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_pdf_is_empty(self, tmp_path):
+        from bantz.tools.filesystem import FilesystemTool
+
+        pdf_file = tmp_path / "blank.pdf"
+        pdf_file.write_bytes(b"%PDF-fake")
+
+        mock_doc = _make_mock_doc(["\n\n", "\t  \n"])
+        mock_fitz = MagicMock()
+        mock_fitz.open.return_value = mock_doc
+
+        tool = FilesystemTool()
+        with patch("bantz.tools.filesystem.SAFE_ROOT", tmp_path), \
+             patch("bantz.tools.filesystem._get_fitz", return_value=mock_fitz):
+            result = await tool.execute(action="read", path=str(pdf_file))
+
+        assert result.success is False
+        assert "scanned images" in result.output.lower()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 4. PDF truncation (context bloat safeguard)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestPDFTruncation:
+    """Long PDFs must be truncated at MAX_PDF_CHARS."""
+
+    @pytest.mark.asyncio
+    async def test_long_pdf_truncated(self, tmp_path):
+        from bantz.tools.filesystem import FilesystemTool, MAX_PDF_CHARS
+
+        pdf_file = tmp_path / "thesis.pdf"
+        pdf_file.write_bytes(b"%PDF-fake")
+
+        giant_text = "A" * 50_000
+        mock_doc = _make_mock_doc([giant_text])
+        mock_fitz = MagicMock()
+        mock_fitz.open.return_value = mock_doc
+
+        tool = FilesystemTool()
+        with patch("bantz.tools.filesystem.SAFE_ROOT", tmp_path), \
+             patch("bantz.tools.filesystem._get_fitz", return_value=mock_fitz):
+            result = await tool.execute(action="read", path=str(pdf_file))
+
+        assert result.success is True
+        assert result.data["truncated"] is True
+        assert "[SYSTEM WARNING" in result.output
+        assert "truncated" in result.output.lower()
+        # Text before the warning should be exactly MAX_PDF_CHARS
+        warning_idx = result.output.index("\n\n[SYSTEM WARNING")
+        assert warning_idx == MAX_PDF_CHARS
+
+    @pytest.mark.asyncio
+    async def test_short_pdf_not_truncated(self, tmp_path):
+        from bantz.tools.filesystem import FilesystemTool, MAX_PDF_CHARS
+
+        pdf_file = tmp_path / "short.pdf"
+        pdf_file.write_bytes(b"%PDF-fake")
+
+        mock_doc = _make_mock_doc(["Short content."])
+        mock_fitz = MagicMock()
+        mock_fitz.open.return_value = mock_doc
+
+        tool = FilesystemTool()
+        with patch("bantz.tools.filesystem.SAFE_ROOT", tmp_path), \
+             patch("bantz.tools.filesystem._get_fitz", return_value=mock_fitz):
+            result = await tool.execute(action="read", path=str(pdf_file))
+
+        assert result.success is True
+        assert result.data["truncated"] is False
+        assert "[SYSTEM WARNING" not in result.output
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 5. Binary file rejection
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestBinaryRejection:
+    """Non-text binary files must be rejected with success=False."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("ext", [".exe", ".jpg", ".zip", ".mp3", ".mp4", ".dll", ".sqlite"])
+    async def test_binary_extensions_rejected(self, tmp_path, ext):
+        from bantz.tools.filesystem import FilesystemTool
+
+        bin_file = tmp_path / f"file{ext}"
+        bin_file.write_bytes(b"\x00\x01\x02\x03")
+
+        tool = FilesystemTool()
+        with patch("bantz.tools.filesystem.SAFE_ROOT", tmp_path):
+            result = await tool.execute(action="read", path=str(bin_file))
+
+        assert result.success is False
+        assert "binary" in result.output.lower()
+
+    @pytest.mark.asyncio
+    async def test_text_file_not_rejected(self, tmp_path):
+        from bantz.tools.filesystem import FilesystemTool
+
+        txt_file = tmp_path / "readme.txt"
+        txt_file.write_text("Hello world", encoding="utf-8")
+
+        tool = FilesystemTool()
+        with patch("bantz.tools.filesystem.SAFE_ROOT", tmp_path):
+            result = await tool.execute(action="read", path=str(txt_file))
+
+        assert result.success is True
+        assert "Hello world" in result.output
+
+    @pytest.mark.asyncio
+    async def test_unknown_extension_reads_as_text(self, tmp_path):
+        """Unknown extensions (e.g., .cfg, .log) should still be read as text."""
+        from bantz.tools.filesystem import FilesystemTool
+
+        cfg_file = tmp_path / "config.cfg"
+        cfg_file.write_text("key=value", encoding="utf-8")
+
+        tool = FilesystemTool()
+        with patch("bantz.tools.filesystem.SAFE_ROOT", tmp_path):
+            result = await tool.execute(action="read", path=str(cfg_file))
+
+        assert result.success is True
+        assert "key=value" in result.output
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 6. PyMuPDF missing
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestFitzMissing:
+    """Graceful error when PyMuPDF is not installed."""
+
+    @pytest.mark.asyncio
+    async def test_fitz_missing_returns_helpful_error(self, tmp_path):
+        from bantz.tools.filesystem import FilesystemTool
+
+        pdf_file = tmp_path / "doc.pdf"
+        pdf_file.write_bytes(b"%PDF-fake")
+
+        tool = FilesystemTool()
+        with patch("bantz.tools.filesystem.SAFE_ROOT", tmp_path), \
+             patch("bantz.tools.filesystem._get_fitz", return_value=None):
+            result = await tool.execute(action="read", path=str(pdf_file))
+
+        assert result.success is False
+        assert "pymupdf" in result.output.lower() or "pip install" in result.output.lower()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 7. PDF fitz.open failure
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestPDFOpenFailure:
+    """Corrupted PDFs that fitz can't open."""
+
+    @pytest.mark.asyncio
+    async def test_corrupt_pdf_returns_error(self, tmp_path):
+        from bantz.tools.filesystem import FilesystemTool
+
+        pdf_file = tmp_path / "corrupt.pdf"
+        pdf_file.write_bytes(b"%PDF-fake")
+
+        mock_fitz = MagicMock()
+        mock_fitz.open.side_effect = RuntimeError("not a valid PDF")
+
+        tool = FilesystemTool()
+        with patch("bantz.tools.filesystem.SAFE_ROOT", tmp_path), \
+             patch("bantz.tools.filesystem._get_fitz", return_value=mock_fitz):
+            result = await tool.execute(action="read", path=str(pdf_file))
+
+        assert result.success is False
+        assert "Failed to open PDF" in result.error
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 8. Regression — plain text still works
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestPlainTextRegression:
+    """Ensure the new PDF/binary logic doesn't break normal text reading."""
+
+    @pytest.mark.asyncio
+    async def test_read_python_file(self, tmp_path):
+        from bantz.tools.filesystem import FilesystemTool
+
+        py_file = tmp_path / "script.py"
+        py_file.write_text("print('hello')", encoding="utf-8")
+
+        tool = FilesystemTool()
+        with patch("bantz.tools.filesystem.SAFE_ROOT", tmp_path):
+            result = await tool.execute(action="read", path=str(py_file))
+
+        assert result.success is True
+        assert "print('hello')" in result.output
+
+    @pytest.mark.asyncio
+    async def test_read_json_file(self, tmp_path):
+        from bantz.tools.filesystem import FilesystemTool
+
+        json_file = tmp_path / "data.json"
+        json_file.write_text('{"key": "value"}', encoding="utf-8")
+
+        tool = FilesystemTool()
+        with patch("bantz.tools.filesystem.SAFE_ROOT", tmp_path):
+            result = await tool.execute(action="read", path=str(json_file))
+
+        assert result.success is True
+        assert '"key"' in result.output
+
+    @pytest.mark.asyncio
+    async def test_large_text_file_truncated(self, tmp_path):
+        from bantz.tools.filesystem import FilesystemTool, MAX_READ_BYTES
+
+        big_file = tmp_path / "big.txt"
+        big_file.write_text("X" * 100_000, encoding="utf-8")
+
+        tool = FilesystemTool()
+        with patch("bantz.tools.filesystem.SAFE_ROOT", tmp_path):
+            result = await tool.execute(action="read", path=str(big_file))
+
+        assert result.success is True
+        assert result.data["truncated"] is True
+        assert "truncated" in result.output.lower()


### PR DESCRIPTION
Fixes #258 - PDF Hallucination Prevention

## Changes

### PDF Reading (PyMuPDF)
- Lazy-import fitz with graceful fallback if missing
- Text extraction via fitz.open() + page.get_text()
- Encrypted PDF -> success=False with clear message
- Empty PDF (scanned images) -> success=False

### Context Bloat Safeguard
- MAX_PDF_CHARS = 25000 (~10-15 pages)
- Truncated PDFs get [SYSTEM WARNING] footer
- Prevents token overflow / API bloat

### Binary File Rejection
- 30+ binary extensions blocked (.exe, .jpg, .zip, .mp3, .mp4, etc.)
- Unknown extensions still read as text (no false positives)

## Tests
- 21 new tests, 2828 total passed
- Covers: happy path, encrypted, empty, truncation, binary rejection, fitz missing, corrupt PDF, plain text regression

Closes #258