### PR TITLE
feat(tools): VisualClickTool — expose navigation pipeline to LLM (#185)

### DIFF
--- a/src/bantz/core/brain.py
+++ b/src/bantz/core/brain.py
@@ -101,6 +101,10 @@ class Brain:
             import bantz.tools.gui_action  # noqa: F401  (#123)
         except (ImportError, ModuleNotFoundError):
             pass
+        try:
+            import bantz.tools.visual_click  # noqa: F401  (#185)
+        except (ImportError, ModuleNotFoundError):
+            pass
         self._memory_ready = False
         self._graph_ready = False
         # Session state: stores last tool results for contextual follow-ups

--- a/src/bantz/core/routing_engine.py
+++ b/src/bantz/core/routing_engine.py
@@ -167,6 +167,30 @@ def quick_route(orig: str, en: str) -> dict | None:
     if re.search(r"clear\s+memory", both):
         return {"tool": "_clear_memory", "args": {}}
 
+    # ── Visual click / hover (#185) ───────────────────────────────────
+    # Matches: click/tap/double-click/right-click/hover + UI element name.
+    # Does NOT match: "press <key>" (keyboard), "click at X,Y" (coordinates).
+    if config.input_control_enabled:
+        m = re.search(
+            r"(?:click|tap|double[- ]?click|right[- ]?click|hover)\s+"
+            r"(?:the\s+|on\s+)?(.+?)(?:\s+button|\s+icon)?\s*$",
+            e,
+        )
+        if m:
+            target = m.group(1).strip()
+            # Reject coordinate patterns (handled by input_control tool)
+            if re.match(r"at\s+\d", target):
+                pass
+            else:
+                action = "click"
+                if re.match(r"double", e):
+                    action = "double_click"
+                elif re.match(r"right", e):
+                    action = "right_click"
+                elif re.match(r"hover", e):
+                    action = "hover"
+                return {"tool": "visual_click", "args": {"target": target, "action": action}}
+
     return None
 
 

--- a/src/bantz/tools/visual_click.py
+++ b/src/bantz/tools/visual_click.py
@@ -1,0 +1,135 @@
+"""Bantz v3 - VisualClickTool (#185 Phase 1: The Butler's Eyes)
+
+Exposes the unified navigation pipeline (Cache -> AT-SPI -> VLM) to the
+LLM as a callable tool.  The LLM can now say "click the Send button"
+and Bantz will find it on screen and physically click it.
+
+Supported actions: click, double_click, right_click, hover
+
+Safety: moderate (physically moves the mouse and performs clicks).
+PyAutoGUI FAILSAFE remains active -- slam mouse to corner (0,0) to abort.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from bantz.config import config
+from bantz.tools import BaseTool, ToolResult, registry
+
+log = logging.getLogger("bantz.tools.visual_click")
+
+# Action -> input_control function name mapping
+_ACTION_MAP = {
+    "click": "click",
+    "double_click": "double_click",
+    "right_click": "right_click",
+    "hover": "move_to",
+}
+
+
+class VisualClickTool(BaseTool):
+    name = "visual_click"
+    description = (
+        "Locate a UI element on the screen by description and perform a "
+        "mouse action (click, double_click, right_click, hover). "
+        "Uses spatial cache, AT-SPI accessibility tree, and VLM vision "
+        "in order of speed. Works on any visible application."
+    )
+    risk_level = "moderate"
+
+    async def execute(
+        self,
+        target: str = "",
+        action: str = "click",
+        app: str = "",
+        **kwargs: Any,
+    ) -> ToolResult:
+        """Find *target* on screen and perform *action*.
+
+        Args:
+            target: Human description of the UI element (e.g., "Send button").
+            action: One of click, double_click, right_click, hover.
+            app:    Optional application name hint (e.g., "firefox").
+        """
+        # ── Gate checks ───────────────────────────────────────────────
+        if not config.input_control_enabled:
+            return ToolResult(
+                success=False, output="",
+                error="Vision and input control are disabled. "
+                      "Enable BANTZ_INPUT_CONTROL_ENABLED in .env.",
+            )
+
+        if not target:
+            return ToolResult(
+                success=False, output="",
+                error="No target specified. Tell me what to click.",
+            )
+
+        action = action.lower().strip()
+        if action not in _ACTION_MAP:
+            return ToolResult(
+                success=False, output="",
+                error=f"Unknown action '{action}'. Supported: {', '.join(_ACTION_MAP)}.",
+            )
+
+        # ── Navigate (Cache -> AT-SPI -> VLM) ────────────────────────
+        from bantz.vision.navigator import navigator
+
+        nav_result = await navigator.navigate_to(
+            app_name=app,
+            element_label=target,
+        )
+
+        if not nav_result.found:
+            return ToolResult(
+                success=False,
+                output=(
+                    f"I peered through the glass pane but could not locate "
+                    f"'{target}', ma'am. Perhaps it is obscured."
+                ),
+                data=nav_result.to_dict(),
+            )
+
+        # ── Execute action at found coordinates ──────────────────────
+        cx, cy = nav_result.center
+
+        try:
+            import bantz.tools.input_control as ic
+            fn_name = _ACTION_MAP[action]
+            fn = getattr(ic, fn_name)
+            await fn(cx, cy)
+        except Exception as exc:
+            log.error("visual_click %s(%d, %d) failed: %s", action, cx, cy, exc)
+            return ToolResult(
+                success=False,
+                output=f"I found '{target}' but my hand slipped, ma'am: {exc}",
+                error=f"Input action failed: {exc}",
+                data=nav_result.to_dict(),
+            )
+
+        action_past = {
+            "click": "clicked",
+            "double_click": "double-clicked",
+            "right_click": "right-clicked",
+            "hover": "hovered over",
+        }
+        verb = action_past.get(action, f"{action}ed")
+
+        log.info(
+            "visual_click: %s '%s' at (%d, %d) via %s (conf=%.2f, %.0fms)",
+            verb, target, cx, cy,
+            nav_result.method, nav_result.confidence, nav_result.latency_ms,
+        )
+
+        return ToolResult(
+            success=True,
+            output=(
+                f"Located and {verb} the '{target}' on the glass pane, ma'am. "
+                f"Method: {nav_result.method}"
+            ),
+            data=nav_result.to_dict(),
+        )
+
+
+registry.register(VisualClickTool())

--- a/tests/tools/test_visual_click.py
+++ b/tests/tools/test_visual_click.py
@@ -1,0 +1,383 @@
+"""Tests for Issue #185 - VisualClickTool (The Butler's Eyes).
+
+Covers:
+  1. Successful visual click (navigate found + click executed)
+  2. Navigation failure (element not found) - Butler lore response
+  3. Action mapping (click, double_click, right_click, hover)
+  4. Input control disabled gate
+  5. Missing target parameter
+  6. Unknown action rejection
+  7. Input action failure (exception during click)
+  8. Quick route regex matching
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Helpers — mock NavResult
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@dataclass
+class MockNavResult:
+    """Lightweight NavResult stand-in for tests."""
+    found: bool
+    x: int = 0
+    y: int = 0
+    width: int = 0
+    height: int = 0
+    method: str = ""
+    confidence: float = 0.0
+    latency_ms: float = 0.0
+    app_name: str = ""
+    element_label: str = ""
+    role: str = ""
+    extra: dict = field(default_factory=dict)
+
+    @property
+    def center(self) -> tuple[int, int]:
+        if self.width and self.height:
+            return (self.x + self.width // 2, self.y + self.height // 2)
+        return (self.x, self.y)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "found": self.found,
+            "x": self.x, "y": self.y,
+            "method": self.method,
+            "confidence": self.confidence,
+        }
+
+
+def _nav_found(x=100, y=200, method="vlm", confidence=0.9):
+    return MockNavResult(
+        found=True, x=x, y=y, width=0, height=0,
+        method=method, confidence=confidence, latency_ms=42.0,
+    )
+
+
+def _nav_not_found():
+    return MockNavResult(found=False, method="none", latency_ms=1200.0)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 1. Successful visual click
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestVisualClickSuccess:
+    """Happy path: element found + action executed."""
+
+    @pytest.mark.asyncio
+    async def test_click_success(self):
+        from bantz.tools.visual_click import VisualClickTool
+
+        tool = VisualClickTool()
+        mock_click = AsyncMock()
+
+        with patch("bantz.tools.visual_click.config") as mock_config, \
+             patch("bantz.vision.navigator.navigator") as mock_nav:
+            mock_config.input_control_enabled = True
+            mock_nav.navigate_to = AsyncMock(return_value=_nav_found())
+
+            import bantz.tools.input_control as ic
+            original_click = getattr(ic, 'click', None)
+            ic.click = mock_click
+            try:
+                result = await tool.execute(target="Send button", action="click")
+            finally:
+                if original_click:
+                    ic.click = original_click
+
+        assert result.success is True
+        assert "clicked" in result.output.lower()
+        assert "Send button" in result.output
+        assert "vlm" in result.output.lower()
+        mock_click.assert_called_once_with(100, 200)
+
+    @pytest.mark.asyncio
+    async def test_hover_uses_move_to(self):
+        from bantz.tools.visual_click import VisualClickTool
+
+        tool = VisualClickTool()
+        mock_move = AsyncMock()
+
+        with patch("bantz.tools.visual_click.config") as mock_config, \
+             patch("bantz.vision.navigator.navigator") as mock_nav:
+            mock_config.input_control_enabled = True
+            mock_nav.navigate_to = AsyncMock(return_value=_nav_found(x=300, y=400))
+
+            import bantz.tools.input_control as ic
+            original = getattr(ic, 'move_to', None)
+            ic.move_to = mock_move
+            try:
+                result = await tool.execute(target="Settings icon", action="hover")
+            finally:
+                if original:
+                    ic.move_to = original
+
+        assert result.success is True
+        assert "hovered over" in result.output.lower()
+        mock_move.assert_called_once_with(300, 400)
+
+    @pytest.mark.asyncio
+    async def test_double_click(self):
+        from bantz.tools.visual_click import VisualClickTool
+
+        tool = VisualClickTool()
+        mock_dbl = AsyncMock()
+
+        with patch("bantz.tools.visual_click.config") as mock_config, \
+             patch("bantz.vision.navigator.navigator") as mock_nav:
+            mock_config.input_control_enabled = True
+            mock_nav.navigate_to = AsyncMock(return_value=_nav_found())
+
+            import bantz.tools.input_control as ic
+            original = getattr(ic, 'double_click', None)
+            ic.double_click = mock_dbl
+            try:
+                result = await tool.execute(target="file.txt", action="double_click")
+            finally:
+                if original:
+                    ic.double_click = original
+
+        assert result.success is True
+        assert "double-clicked" in result.output.lower()
+
+    @pytest.mark.asyncio
+    async def test_right_click(self):
+        from bantz.tools.visual_click import VisualClickTool
+
+        tool = VisualClickTool()
+        mock_rc = AsyncMock()
+
+        with patch("bantz.tools.visual_click.config") as mock_config, \
+             patch("bantz.vision.navigator.navigator") as mock_nav:
+            mock_config.input_control_enabled = True
+            mock_nav.navigate_to = AsyncMock(return_value=_nav_found())
+
+            import bantz.tools.input_control as ic
+            original = getattr(ic, 'right_click', None)
+            ic.right_click = mock_rc
+            try:
+                result = await tool.execute(target="desktop", action="right_click")
+            finally:
+                if original:
+                    ic.right_click = original
+
+        assert result.success is True
+        assert "right-clicked" in result.output.lower()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 2. Navigation failure — Butler lore
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestVisualClickFailure:
+    """Element not found — graceful Butler response."""
+
+    @pytest.mark.asyncio
+    async def test_not_found_returns_butler_lore(self):
+        from bantz.tools.visual_click import VisualClickTool
+
+        tool = VisualClickTool()
+
+        with patch("bantz.tools.visual_click.config") as mock_config, \
+             patch("bantz.vision.navigator.navigator") as mock_nav:
+            mock_config.input_control_enabled = True
+            mock_nav.navigate_to = AsyncMock(return_value=_nav_not_found())
+
+            result = await tool.execute(target="Invisible Button", action="click")
+
+        assert result.success is False
+        assert "could not locate" in result.output.lower()
+        assert "Invisible Button" in result.output
+
+    @pytest.mark.asyncio
+    async def test_not_found_includes_nav_data(self):
+        from bantz.tools.visual_click import VisualClickTool
+
+        tool = VisualClickTool()
+
+        with patch("bantz.tools.visual_click.config") as mock_config, \
+             patch("bantz.vision.navigator.navigator") as mock_nav:
+            mock_config.input_control_enabled = True
+            mock_nav.navigate_to = AsyncMock(return_value=_nav_not_found())
+
+            result = await tool.execute(target="Ghost", action="click")
+
+        assert result.data["found"] is False
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 3. Gate checks
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestVisualClickGates:
+    """Parameter validation and config gates."""
+
+    @pytest.mark.asyncio
+    async def test_input_control_disabled(self):
+        from bantz.tools.visual_click import VisualClickTool
+
+        tool = VisualClickTool()
+
+        with patch("bantz.tools.visual_click.config") as mock_config:
+            mock_config.input_control_enabled = False
+            result = await tool.execute(target="Button", action="click")
+
+        assert result.success is False
+        assert "disabled" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_missing_target(self):
+        from bantz.tools.visual_click import VisualClickTool
+
+        tool = VisualClickTool()
+
+        with patch("bantz.tools.visual_click.config") as mock_config:
+            mock_config.input_control_enabled = True
+            result = await tool.execute(target="", action="click")
+
+        assert result.success is False
+        assert "no target" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_unknown_action_rejected(self):
+        from bantz.tools.visual_click import VisualClickTool
+
+        tool = VisualClickTool()
+
+        with patch("bantz.tools.visual_click.config") as mock_config:
+            mock_config.input_control_enabled = True
+            result = await tool.execute(target="Button", action="smash")
+
+        assert result.success is False
+        assert "unknown action" in result.error.lower()
+        assert "smash" in result.error
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 4. Input action failure
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestVisualClickActionError:
+    """Input control raises an exception after navigation succeeds."""
+
+    @pytest.mark.asyncio
+    async def test_action_exception_caught(self):
+        from bantz.tools.visual_click import VisualClickTool
+
+        tool = VisualClickTool()
+
+        with patch("bantz.tools.visual_click.config") as mock_config, \
+             patch("bantz.vision.navigator.navigator") as mock_nav:
+            mock_config.input_control_enabled = True
+            mock_nav.navigate_to = AsyncMock(return_value=_nav_found())
+
+            import bantz.tools.input_control as ic
+            original = getattr(ic, 'click', None)
+            ic.click = AsyncMock(side_effect=OSError("Display not available"))
+            try:
+                result = await tool.execute(target="OK", action="click")
+            finally:
+                if original:
+                    ic.click = original
+
+        assert result.success is False
+        assert "hand slipped" in result.output.lower()
+        assert "Display not available" in result.output
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 5. Tool registration
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestVisualClickRegistration:
+    """Tool must be registered in the global registry."""
+
+    def test_tool_is_registered(self):
+        from bantz.tools.visual_click import registry
+        tool = registry.get("visual_click")
+        assert tool is not None
+        assert tool.name == "visual_click"
+        assert tool.risk_level == "moderate"
+
+    def test_schema_has_description(self):
+        from bantz.tools.visual_click import registry
+        tool = registry.get("visual_click")
+        schema = tool.schema()
+        assert "click" in schema["description"].lower() or "locate" in schema["description"].lower()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 6. Quick route regex matching (#185)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestVisualClickQuickRoute:
+    """Regex quick-route must match natural click/hover commands."""
+
+    def _route(self, text: str) -> dict | None:
+        from bantz.core.routing_engine import quick_route
+        with patch("bantz.core.routing_engine.config") as mock_config:
+            mock_config.input_control_enabled = True
+            return quick_route(text, text)
+
+    def test_click_the_send_button(self):
+        r = self._route("click the send button")
+        assert r is not None
+        assert r["tool"] == "visual_click"
+        assert r["args"]["target"] == "send"
+        assert r["args"]["action"] == "click"
+
+    def test_press_ok_not_matched(self):
+        """'press' is keyboard, not visual click — should NOT quick route."""
+        r = self._route("press ok")
+        assert r is None or r["tool"] != "visual_click"
+
+    def test_click_at_coords_not_matched(self):
+        """Coordinate-based clicks go to input_control, not visual_click."""
+        r = self._route("double click at 500, 300")
+        assert r is None or r["tool"] != "visual_click"
+
+    def test_hover_settings_icon(self):
+        r = self._route("hover the settings icon")
+        assert r is not None
+        assert r["tool"] == "visual_click"
+        assert r["args"]["action"] == "hover"
+
+    def test_double_click_file(self):
+        r = self._route("double click the file.txt")
+        assert r is not None
+        assert r["tool"] == "visual_click"
+        assert r["args"]["action"] == "double_click"
+
+    def test_right_click_desktop(self):
+        r = self._route("right click on desktop")
+        assert r is not None
+        assert r["tool"] == "visual_click"
+        assert r["args"]["action"] == "right_click"
+
+    def test_no_match_for_regular_text(self):
+        r = self._route("what is the weather today")
+        # Should NOT match visual_click
+        assert r is None or r["tool"] != "visual_click"
+
+    def test_disabled_config_no_route(self):
+        """When input_control_enabled=False, quick route should not match."""
+        from bantz.core.routing_engine import quick_route
+        with patch("bantz.core.routing_engine.config") as mock_config:
+            mock_config.input_control_enabled = False
+            r = quick_route("click the send button", "click the send button")
+        assert r is None or r["tool"] != "visual_click"

--- a/tests/tui/test_input_control.py
+++ b/tests/tui/test_input_control.py
@@ -389,10 +389,11 @@ class TestQuickRoute:
         assert r is None
 
     def test_click_the_still_goes_to_a11y(self):
-        """'click the Send button' should go to gui_action (unified pipeline), not input_control."""
+        """'click the Send button' now routes to visual_click (#185 unified pipeline)."""
         r = self._route("click the Send button in Firefox")
-        assert r is None
-        # #123: gui_action is the unified pipeline that wraps AT-SPI
+        # #185: visual_click is the new unified pipeline wrapping Navigator
+        assert r is not None
+        assert r["tool"] == "visual_click"
 
     def test_scroll_doesnt_match_random(self):
         r = self._route("what is a scrollbar?")


### PR DESCRIPTION
## Phase 1 of Computer Use: The Butler's Eyes

Exposes the unified navigation pipeline (Cache → AT-SPI → VLM) to the LLM as a callable tool.

### Changes
- **visual_click.py** — New tool (click, double_click, right_click, hover) via navigator pipeline
- **routing_engine.py** — Quick route regex for natural commands, excludes keyboard/coords
- **brain.py** — Import registration
- **20 tests** across 6 classes | 2848 passed total | 0 new failures

Closes #185