### PR TITLE
fix(prompt): Computer Use Authorization — stop LLM refusal (#185)

### DIFF
--- a/src/bantz/core/prompt_builder.py
+++ b/src/bantz/core/prompt_builder.py
@@ -54,7 +54,9 @@ researching it using your tools. Act as if you are sending a telegram to the arc
    Do NOT invent class names. Do NOT guess what classes they have.
 4. If the user asks about specific emails or contacts — say "Let me check your mail" and STOP.
 5. If unsure about factual data, say you will look into it. NEVER guess or make up data.
-6. For desktop/app questions: use ONLY the Desktop Context above. If no desktop context is provided, say you can't detect apps right now.
+6. For desktop/app questions: refer to the Desktop Context above for running app names. However, \
+if the user asks you to CLICK, HOVER, or interact with a specific UI element, do NOT rely on the text-based \
+Desktop Context alone — use the `visual_click` tool to actively look at the screen.
 7. When including URLs or links, print the RAW unformatted URL only. DO NOT use Markdown \
 link formatting (no [Text](URL), no [URL], no <URL>). Just output the bare link as plain text.
 Respond in English. Plain text only.\
@@ -71,6 +73,31 @@ RULES:
 3. ~/Desktop, ~/Downloads, ~/Documents — use standard paths
 4. NEVER: sudo, nano, vim, brace expansion, interactive commands
 5. NEVER invent extra files or directories\
+"""
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Computer-Use Authorization (injected when input_control_enabled)
+# ═══════════════════════════════════════════════════════════════════════════
+
+COMPUTER_USE_AUTHORIZATION = """
+
+COMPUTER USE & PHYSICAL INTERACTION AUTHORIZATION:
+You are fully equipped and AUTHORIZED to physically interact with the user's \
+screen using the `visual_click` tool. You are NOT just a chat assistant — you \
+are an active operator who can see and touch the glass pane (screen).
+- NO REFUSALS: NEVER refuse a request to click, hover, or interact with the \
+screen by claiming you cannot interact with machines, that you only provide \
+guidance, or that you are just an attendant. When the user asks you to click \
+or interact with something on screen, YOU DO IT.
+- VISUAL GROUNDING: Do NOT rely solely on the text-based 'Desktop Context' \
+(running apps list) to determine whether a UI element exists. A menu item, \
+button, or icon may be perfectly visible on screen even if it does not appear \
+in the Desktop Context text. You MUST call the `visual_click` tool to actively \
+look at and interact with the screen.
+- When the user says 'click X', 'open X menu', 'hover over X', or any similar \
+phrase, immediately call the `visual_click` tool with the target description. \
+Do not philosophize, do not explain what they could do instead — act.\
 """
 
 
@@ -106,6 +133,10 @@ def build_chat_system(ctx: "BantzContext", tc: dict) -> str:
         deep_memory=ctx.deep_memory,
         formality_hint=ctx.formality_hint,
     )
+    # Inject computer-use authorization when input control is active
+    from bantz.config import config
+    if config.input_control_enabled:
+        rendered += COMPUTER_USE_AUTHORIZATION
     # Append one-shot feedback injection if present
     if ctx.feedback_hint:
         rendered += ctx.feedback_hint

--- a/tests/core/test_prompt_builder.py
+++ b/tests/core/test_prompt_builder.py
@@ -35,6 +35,7 @@ except ImportError:
 from bantz.core.prompt_builder import (
     CHAT_SYSTEM,
     COMMAND_SYSTEM,
+    COMPUTER_USE_AUTHORIZATION,
     build_chat_system,
     is_refusal,
 )
@@ -136,6 +137,54 @@ class TestBuildChatSystem:
         tc = {}  # no prompt_hint key
         result = build_chat_system(ctx, tc)
         assert "Bantz" in result  # renders fine with empty time_hint
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Computer-Use Authorization (#185)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestComputerUseAuthorization:
+    """System prompt gets the physical-interaction authorization block."""
+
+    def _make_ctx(self, **overrides) -> BantzContext:
+        defaults = dict(
+            graph_context="", vector_context="", deep_memory="",
+            desktop_context="", persona_state="", formality_hint="",
+            style_hint="", profile_hint="", feedback_hint="",
+        )
+        defaults.update(overrides)
+        return BantzContext(**defaults)
+
+    def test_authorization_constant_has_key_directives(self):
+        assert "AUTHORIZED" in COMPUTER_USE_AUTHORIZATION
+        assert "visual_click" in COMPUTER_USE_AUTHORIZATION
+        assert "NO REFUSALS" in COMPUTER_USE_AUTHORIZATION
+        assert "VISUAL GROUNDING" in COMPUTER_USE_AUTHORIZATION
+
+    def test_authorization_injected_when_input_control_enabled(self):
+        from unittest.mock import patch
+        ctx = self._make_ctx()
+        tc = {"prompt_hint": ""}
+        with patch("bantz.config.config") as mock_config:
+            mock_config.input_control_enabled = True
+            result = build_chat_system(ctx, tc)
+        assert "AUTHORIZED" in result
+        assert "visual_click" in result
+
+    def test_authorization_absent_when_input_control_disabled(self):
+        from unittest.mock import patch
+        ctx = self._make_ctx()
+        tc = {"prompt_hint": ""}
+        with patch("bantz.config.config") as mock_config:
+            mock_config.input_control_enabled = False
+            result = build_chat_system(ctx, tc)
+        assert "COMPUTER USE" not in result
+        assert "AUTHORIZED" not in result
+
+    def test_rule_6_no_longer_blocks_visual_grounding(self):
+        """Rule 6 should NOT say 'use ONLY the Desktop Context'."""
+        assert "use ONLY the Desktop Context" not in CHAT_SYSTEM
 
 
 # ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Fiziksel Yetki Belgesi

Llama 3.1 "Ben bir uşağım, ekrana dokunmak benim işim değil" diyerek visual_click'i çağırmayı reddediyordu.

### Kök Sebepler
1. **Kural #6**: "use ONLY the Desktop Context" — LLM'e ekrana hiç bakma diyordu
2. **Yetki yok**: Prompt'ta fiziksel etkileşim izni verilmemişti → RLHF güvenlik duvarı devreye giriyordu

### Değişiklikler
- **Kural #6 yeniden yazıldı**: Desktop Context bilgi amaçlı, ama click/hover isteklerinde visual_click kullanılacak
- **COMPUTER_USE_AUTHORIZATION**: input_control_enabled ise system prompt'a ekleniyor:
  - AUTHORIZED: Ekrana dokunma yetkisi açıkça verildi
  - NO REFUSALS: "Ben sadece rehberlik ederim" reddi yasaklandı
  - VISUAL GROUNDING: Text-based Desktop Context'e güvenme, gözlerini (visual_click) kullan
- **4 yeni test**: Authorization içeriği, enabled/disabled toggle, rule 6 düzeltmesi

```
2850 passed | 0 new failures
```