### PR TITLE
refactor(core): purge regex routing & unify LLM decision making

### DIFF
--- a/src/bantz/agent/planner.py
+++ b/src/bantz/agent/planner.py
@@ -148,34 +148,6 @@ Step 3: Double-Check: I have the city "Istanbul". I don't need any complex varia
 ]\
 """
 
-# ── Complexity detection heuristics ──────────────────────────────────────────
-
-# Conjunctions / sequence markers that hint at multi-step intent
-_MULTI_STEP_MARKERS = re.compile(
-    r"""
-    \b(?:then|after\s+that|next|also|additionally|finally|afterwards)\b
-    | \b(?:and\s+(?:then|also|afterwards))\b
-    | \b(?:first|second|third)\b.*\b(?:then|next|after)\b
-    """,
-    re.VERBOSE | re.IGNORECASE,
-)
-
-# Tool-indicating keywords — grouped by tool for counting distinct tools
-_TOOL_KEYWORDS: dict[str, list[str]] = {
-    "web_search": ["search", "find", "look up", "google", "articles", "research"],
-    "gmail": ["email", "mail", "inbox", "compose", "send mail"],
-    "calendar": ["calendar", "event", "meeting", "schedule", "appointment"],
-    "filesystem": ["save", "file", "folder", "write to", "create file", "create folder"],
-    "weather": ["weather", "temperature", "forecast"],
-    "news": ["news", "headlines"],
-    "system": ["cpu", "ram", "memory", "disk", "system status"],
-    "shell": ["run command", "terminal", "bash"],
-    "document": ["pdf", "document"],
-    "read_url": ["read url", "read page", "open link", "fetch page", "full article", "full text"],
-    "process_text": ["summarize", "analyze", "rewrite", "translate", "transform"],
-}
-
-
 @dataclass
 class PlanStep:
     """A single step in the butler's itinerary."""
@@ -188,55 +160,6 @@ class PlanStep:
 
 class PlannerAgent:
     """Decomposes complex user requests into structured step arrays."""
-
-    def is_complex(
-        self,
-        en_input: str,
-        *,
-        recent_history: list[dict] | None = None,
-    ) -> bool:
-        """Heuristic check: does this input likely need multi-step planning?
-
-        Returns True if:
-        - Input has sequence markers (then, after that, next...)
-        - Input references 2+ distinct tool categories
-        - Input is long (>15 words) with multiple verb phrases
-
-        The optional *recent_history* is reserved for future heuristic
-        expansion (e.g. detecting implicit multi-step across turns).
-        """
-        text = en_input.lower()
-
-        # Check for explicit sequence markers
-        if _MULTI_STEP_MARKERS.search(text):
-            # Also needs at least 2 different tool intents
-            distinct = self._count_distinct_tools(text)
-            if distinct >= 2:
-                return True
-
-        # Even without markers, 2+ distinct tool intents in a long sentence
-        distinct = self._count_distinct_tools(text)
-        word_count = len(text.split())
-        if distinct >= 2 and word_count >= 8:
-            return True
-
-        # Very explicit multi-step: numbered instructions
-        if re.search(r"\b(?:1\.|step\s*1|first)\b", text) and \
-           re.search(r"\b(?:2\.|step\s*2|second|then)\b", text):
-            return True
-
-        return False
-
-    @staticmethod
-    def _count_distinct_tools(text: str) -> int:
-        """Count how many distinct tool categories are mentioned."""
-        found: set[str] = set()
-        for tool_name, keywords in _TOOL_KEYWORDS.items():
-            for kw in keywords:
-                if kw in text:
-                    found.add(tool_name)
-                    break
-        return len(found)
 
     @staticmethod
     def _format_recent_history(recent_history: list[dict] | None) -> str:

--- a/src/bantz/core/brain.py
+++ b/src/bantz/core/brain.py
@@ -254,33 +254,14 @@ class Brain:
         # Save user message ONCE — before any branching
         data_layer.conversations.add("user", user_input)
 
-        # ── Plan-and-Solve: LLM-based multi-step decomposition (#187) ────
-        # Planner runs FIRST — it handles complex multi-tool requests via
-        # LLM heuristics.  Must be above workflow_engine to prevent the
-        # old regex-based engine from eagerly stealing autonomous commands.
-        #
-        # recent_history feeds coreference resolution (#212) so the
-        # planner can resolve pronouns like "him", "it", "that file".
         recent_history = data_layer.conversations.context(n=6)
-        planner_error: str | None = None
-        try:
-            from bantz.agent.planner import planner_agent
-            if planner_agent.is_complex(en_input, recent_history=recent_history):
-                plan_result = await _execute_plan_fn(
-                    user_input, en_input, tc, recent_history=recent_history,
-                )
-                if plan_result is not None:
-                    # Orchestrator owns persistence (hotfix #228)
-                    await self._graph_store(user_input, plan_result.response, "planner")
-                    self._fire_embeddings()
-                    return plan_result
-        except Exception as exc:
-            log.warning("Planner check failed: %s — propagating to LLM", exc)
-            planner_error = f"Multi-step planner failed: {exc}"
 
-        # ── Quick-route → internal dispatch (#228) ──────────────────────
+        # ═══════════════════════════════════════════════════════════════
+        # NEW PIPELINE (#272): quick_route → cot_route → branch
+        # ═══════════════════════════════════════════════════════════════
+
+        # ── Step 1: Quick-route — hardware/UI controls ONLY ──────────
         quick = self._quick_route(user_input, en_input)
-
         if quick:
             internal = await _dispatch_internal(
                 quick["tool"], quick["args"],
@@ -289,44 +270,66 @@ class Brain:
             )
             if internal is not None:
                 return internal
+            # If dispatch_internal returns None, the tool isn't internal.
+            # This shouldn't happen with the stripped quick_route, but
+            # fall through to cot_route as a safety net.
 
-            # Not an internal tool → build a plan for the registry
-            if quick["tool"] == "_generate":
-                cmd = await _generate_command_fn(user_input, en_input)
-                plan = {"route": "tool", "tool_name": "shell",
-                        "tool_args": {"command": cmd}, "risk_level": "moderate"}
-            else:
-                plan = {"route": "tool", "tool_name": quick["tool"],
-                        "tool_args": quick["args"], "risk_level": "safe"}
-        else:
-            plan, routing_error = await cot_route(
-                en_input, registry.all_schemas(),
-                recent_history=recent_history,
+        # ── Step 2: cot_route — LLM decides everything ───────────────
+        plan, routing_error = await cot_route(
+            en_input, registry.all_schemas(),
+            recent_history=recent_history,
+        )
+
+        # ── Step 3: Safety net — if cot_route fails, chat gracefully ─
+        if plan is None:
+            stream = self._chat_stream(
+                en_input, tc, system_alert=routing_error,
             )
-
-            # Merge planner_error if cot_route had no error of its own
-            if routing_error is None and planner_error is not None:
-                routing_error = planner_error
-
-            if plan is None:
-                # (#253) If routing_error is set, a tool was attempted
-                # but failed.  Inject a system alert so the LLM does NOT
-                # hallucinate tool success.
-                stream = self._chat_stream(
-                    en_input, tc, system_alert=routing_error,
-                )
-                return BrainResult(
-                    response="", tool_used=None, stream=stream,
-                )
+            return BrainResult(
+                response="", tool_used=None, stream=stream,
+            )
 
         route     = plan.get("route", "chat")
         tool_name = plan.get("tool_name") or ""
         tool_args = plan.get("tool_args") or {}
         risk      = plan.get("risk_level", "safe")
 
+        # ── Step 4: route == "planner" → multi-step decomposition ─────
+        if route == "planner":
+            try:
+                plan_result = await _execute_plan_fn(
+                    user_input, en_input, tc, recent_history=recent_history,
+                )
+                if plan_result is not None:
+                    await self._graph_store(user_input, plan_result.response, "planner")
+                    self._fire_embeddings()
+                    return plan_result
+            except Exception as exc:
+                log.warning("Planner execution failed: %s — falling back to chat", exc)
+            # Planner failed or returned None → fall through to chat
+            stream = self._chat_stream(
+                en_input, tc,
+                system_alert=f"Multi-step planner failed: {routing_error or 'decomposition returned no steps'}",
+            )
+            return BrainResult(response="", tool_used=None, stream=stream)
+
+        # ── Step 5: route == "chat" → streaming chat ──────────────────
         if route != "tool" or not tool_name:
             stream = self._chat_stream(en_input, tc)
             return BrainResult(response="", tool_used=None, stream=stream)
+
+        # ── Step 5b: Internal tools (prefixed with "_") → dispatch_internal
+        #    These were previously matched by quick_route regex; now the LLM
+        #    routes them via cot_route.  (#272)
+        if tool_name.startswith("_"):
+            internal = await _dispatch_internal(
+                tool_name, tool_args,
+                user_input, en_input, tc,
+                is_remote=is_remote,
+            )
+            if internal is not None:
+                return internal
+            # dispatch_internal didn't handle it — fall through to registry
 
         if risk == "destructive" and config.shell_confirm_destructive and not confirmed:
             cmd_str = tool_args.get("command", tool_name)

--- a/src/bantz/core/intent.py
+++ b/src/bantz/core/intent.py
@@ -75,6 +75,8 @@ ROUTING RULES:
 - accessibility: click UI element, focus window, screen analysis, screenshot
 - read_url:   fetch and read full content of a specific URL
 - chat:       ONLY for greetings, small talk, and opinions — NEVER for factual questions
+- planner:    When the request requires TWO OR MORE different tools in sequence
+              (e.g. "find articles, summarize them, and save to a file")
 
 CRITICAL:
 - If the user's request contains ambiguous pronouns (e.g., 'him', 'her') or refers to unspecified files/reports ('that report'), you MUST ask for clarification. Do NOT invent a fake report, do NOT roleplay sending a message to a fake person, and do not route to a tool until the ambiguity is resolved. Route to "chat" to ask for clarification.
@@ -85,6 +87,7 @@ CRITICAL:
 - If the user asks about ANY person, place, thing, concept, movie character,
   historical figure, or topic — route to web_search. Do NOT use chat for factual lookups.
 - "do your search", "can you find", "look it up" → web_search.
+- If the request clearly needs multiple DIFFERENT tools in sequence, use route "planner".
 
 ANTI-FALSE-POSITIVE RULES (critical — read carefully):
 - If the user uses slang, idioms, conversational filler, or if you are NOT 100%%
@@ -102,12 +105,15 @@ Return your response in exactly two parts:
 1. BEFORE outputting the JSON, you MUST open a `<thinking> ... </thinking>` block and perform a strict Self-Audit using these exact steps:
    - Step 1: Information Extraction: What exactly does the user want? What hard data (file paths, names, cities) did they provide?
    - Step 2: Tool Matching: Is there a tool meant exactly for this? (e.g. if reading a file, I need 'document' or 'filesystem').
-   - Step 3: Double-Check / Self-Correction: Am I about to invent an answer without using a tool? I am a digital entity; I cannot see files, weather, or websites without using my tools. If I lack information to use a tool, my tool is 'chat' to ask for clarification.
+   - Step 3: Multi-Step Check: Does this need 2+ DIFFERENT tools in sequence? If yes → route "planner".
+   - Step 4: Double-Check / Self-Correction: Am I about to invent an answer without using a tool? I am a digital entity; I cannot see files, weather, or websites without using my tools. If I lack information to use a tool, my tool is 'chat' to ask for clarification.
 2. After the thinking block, output ONLY the valid JSON object exactly as specified below.
 
-{{"route":"tool","tool_name":"<name>","tool_args":{{...}},"risk_level":"safe|moderate|destructive","confidence":0.95}}
+For single tool: {{"route":"tool","tool_name":"<name>","tool_args":{{...}},"risk_level":"safe|moderate|destructive","confidence":0.95,"reasoning":"Brief explanation"}}
 
-For chat: {{"route":"chat","tool_name":null,"tool_args":{{}},"risk_level":"safe","confidence":0.9}}\
+For multi-step: {{"route":"planner","tool_name":null,"tool_args":{{}},"risk_level":"safe","confidence":0.9,"reasoning":"Needs X then Y then Z"}}
+
+For chat: {{"route":"chat","tool_name":null,"tool_args":{{}},"risk_level":"safe","confidence":0.9,"reasoning":"Greeting/small talk"}}\
 """
 
 # ── Helpers ────────────────────────────────────────────────────────────────────
@@ -245,7 +251,8 @@ async def cot_route(
             "content": (
                 "That was not valid JSON. Ensure you include the <thinking> tags FIRST, "
                 "then output ONLY a single JSON object "
-                "with keys: route, tool_name, tool_args, risk_level, confidence. "
+                "with keys: route, tool_name, tool_args, risk_level, confidence, reasoning. "
+                "route must be one of: tool, planner, chat. "
                 "No markdown. No explanation."
             ),
         })

--- a/src/bantz/core/routing_engine.py
+++ b/src/bantz/core/routing_engine.py
@@ -1,13 +1,13 @@
 """
-Bantz — Routing Engine (#228)
+Bantz — Routing Engine (#228, #272)
 
-Owns __all routing logic__ that decides *what* the brain should do for a
-given user utterance:
+Owns routing logic that decides *what* the brain should do for a given
+user utterance.
 
 1. **quick_route(orig, en)**
-   Regex-based fast-path:  shell commands, system metrics, TTS/wake-word
-   controls, ambient/proactive/health status, briefing, maintenance,
-   reflections, schedule, location, and clear-memory.
+   Regex fast-path for **hardware/UI controls ONLY**: TTS stop, wake-word
+   on/off, audio ducking, and clear-memory.  All natural-language tool
+   selection goes through ``cot_route()`` in ``intent.py`` (#272).
 
 2. **dispatch_internal(tool, args, user_input, en_input, tc, *, is_remote)**
    Handles every "internal" tool (``_tts_stop``, ``_briefing``, …) that
@@ -48,48 +48,14 @@ log = logging.getLogger("bantz.routing_engine")
 # ═══════════════════════════════════════════════════════════════════════════
 
 def quick_route(orig: str, en: str) -> dict | None:
-    """Regex-based instant routing.  Returns ``{tool, args}`` or ``None``."""
+    """Hardware/UI controls only — instant routing, no LLM needed (#272).
+
+    Everything else (shell, system metrics, weather, gmail, etc.) goes
+    through ``cot_route()`` so the LLM can reason about the request.
+    """
     o = orig.lower().strip()
     e = en.lower().strip()
     both = o + " " + e
-
-    # ── Direct shell commands typed literally ─────────────────────────
-    _DIRECT = ("ls", "cd ", "df", "free", "ps ", "cat ", "grep ",
-               "find ", "pwd", "uname", "whoami", "du ", "mount",
-               "ip ", "ping ", "top", "htop", "mkdir", "touch",
-               "echo ", "head ", "tail ", "chmod ", "cp ", "mv ")
-    for p in _DIRECT:
-        if o == p.rstrip() or o.startswith(p if p.endswith(" ") else p + " "):
-            if p == "find ":
-                _after_find = o[len("find "):].lstrip()
-                if not _after_find or not _after_find[0] in "/~.-":
-                    continue
-            return {"tool": "shell", "args": {"command": orig.strip()}}
-
-    # ── System metrics ────────────────────────────────────────────────
-    if any(k in both for k in ("disk", "df -", "storage", "disk space")):
-        return {"tool": "shell", "args": {"command": "df -h"}}
-    if any(k in both for k in ("memory", "free -", "ram usage", "how much ram")) or \
-       re.search(r"\bram\b", both):
-        return {"tool": "system", "args": {"metric": "ram"}}
-    if any(k in both for k in ("cpu", "processor", "uptime", "load average")):
-        return {"tool": "system", "args": {"metric": "all"}}
-    if re.search(r"system\s*(status|info|check)|check\s*(my\s*)?system", both):
-        return {"tool": "system", "args": {"metric": "all"}}
-
-    # ── Folder / directory sizes ──────────────────────────────────────
-    _SIZE_KW = re.search(
-        r"\b(big|large|size|bigger|largest|biggest|heaviest)\b", both,
-    )
-    _DISK_CTX = re.search(
-        r"\b(folder|directory|dir|file|disk|storage|path|home|~/)\b", both,
-    )
-    if _SIZE_KW and _DISK_CTX:
-        path_match = re.search(r"(?:in|under|of|check)\s+(~/?\S+|/\S+|home)", both)
-        target = path_match.group(1) if path_match else "~"
-        if target == "home":
-            target = "~"
-        return {"tool": "shell", "args": {"command": f"du -sh {target}/*/ 2>/dev/null | sort -rh | head -10"}}
 
     # ── TTS stop (#131) ───────────────────────────────────────────────
     if re.search(r"shut\s*up|be\s+quiet|stop\s+talk(?:ing)?", both):
@@ -115,60 +81,9 @@ def quick_route(orig: str, en: str) -> dict | None:
     if re.search(r"disable\s+duck|duck(?:ing)?\s+off|turn\s+off\s+duck|no\s+duck", both):
         return {"tool": "_audio_duck_off", "args": {}}
 
-    # ── Ambient status (#166) ─────────────────────────────────────────
-    if re.search(
-        r"ambient\s+(?:noise|sound|status|level|info)|environment\s+noise|"
-        r"how(?:'s|\s+is)\s+(?:the\s+)?(?:noise|environment|ambient)",
-        both,
-    ):
-        return {"tool": "_ambient_status", "args": {}}
-
-    # ── Proactive engagement status (#167) ────────────────────────────
-    if re.search(
-        r"proactive\s+(?:status|info|count|stats)|"
-        r"how\s+many\s+proactive|"
-        r"engagement\s+status|check.?in\s+(?:status|count)",
-        both,
-    ):
-        return {"tool": "_proactive_status", "args": {}}
-
-    # ── Health / break status (#168) ──────────────────────────────────
-    if re.search(
-        r"health\s+(?:status|info|stats|check)|"
-        r"break\s+(?:status|timer|count)|"
-        r"session\s+(?:time|timer|hours)",
-        both,
-    ):
-        return {"tool": "_health_status", "args": {}}
-
-    # ── Briefing ──────────────────────────────────────────────────────
-    if any(k in both for k in ("good morning", "morning briefing", "daily briefing",
-                                "what's today", "what do i have today")):
-        return {"tool": "_briefing", "args": {}}
-
-    # ── Maintenance (#129) ────────────────────────────────────────────
-    if re.search(
-        r"run\s+maintenance|system\s+cleanup|"
-        r"clean\s+(?:up\s+)?(?:the\s+)?system|maintenance\s+run",
-        both,
-    ):
-        return {"tool": "_maintenance", "args": {"dry_run": "dry" in both}}
-
-    # ── Reflection (#130) — run / show ────────────────────────────────
-    if re.search(
-        r"run\s+reflect|generate\s+reflect|reflect\s+(?:on\s+)?today",
-        both,
-    ):
-        return {"tool": "_run_reflection", "args": {"dry_run": "dry" in both}}
-    if re.search(r"show\s+reflect|list\s+reflect|past\s+reflect", both):
-        return {"tool": "_list_reflections", "args": {}}
-
     # ── Clear memory ──────────────────────────────────────────────────
     if re.search(r"clear\s+memory", both):
         return {"tool": "_clear_memory", "args": {}}
-
-    # NOTE: visual_click is intentionally NOT quick-routed.
-    # The LLM picks the tool via its own tool-calling chain-of-thought.
 
     return None
 

--- a/tests/agent/test_planner.py
+++ b/tests/agent/test_planner.py
@@ -27,72 +27,8 @@ from bantz.tools import ToolResult
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# 1. PlannerAgent — complexity detection
+# 1. (Removed — complexity detection was purged in #272; LLM decides via cot_route)
 # ═══════════════════════════════════════════════════════════════════════════════
-
-
-class TestComplexityDetection:
-    """PlannerAgent.is_complex must detect multi-step requests."""
-
-    def _agent(self):
-        from bantz.agent.planner import PlannerAgent
-        return PlannerAgent()
-
-    def test_search_and_save_is_complex(self):
-        """'Search X and then save to a file' → complex."""
-        assert self._agent().is_complex(
-            "search for quantum computing articles and then save to a file"
-        ) is True
-
-    def test_email_then_calendar_is_complex(self):
-        """'Check email then check my calendar' → complex."""
-        assert self._agent().is_complex(
-            "check my email then check my calendar for today"
-        ) is True
-
-    def test_search_and_write_file(self):
-        """'Find articles about X and save a summary file' → complex."""
-        assert self._agent().is_complex(
-            "find articles about machine learning and save a summary to a file"
-        ) is True
-
-    def test_numbered_steps_complex(self):
-        """'First search X, then save to file' → complex."""
-        assert self._agent().is_complex(
-            "first search for AI news, then write the results to a file"
-        ) is True
-
-    def test_simple_greeting_not_complex(self):
-        """'Hello, how are you?' → NOT complex."""
-        assert self._agent().is_complex("hello how are you") is False
-
-    def test_single_tool_not_complex(self):
-        """'What's the weather in Istanbul?' → NOT complex."""
-        assert self._agent().is_complex("what is the weather in istanbul") is False
-
-    def test_simple_email_not_complex(self):
-        """'Check my email' → NOT complex."""
-        assert self._agent().is_complex("check my email") is False
-
-    def test_simple_file_op_not_complex(self):
-        """'Create a folder named test' → NOT complex."""
-        assert self._agent().is_complex("create a folder named test") is False
-
-    def test_short_ambiguous_not_complex(self):
-        """'Tell me about it' → NOT complex."""
-        assert self._agent().is_complex("tell me about it") is False
-
-    def test_summarize_and_save_is_complex(self):
-        """'Search X, summarize it, and save' → complex (process_text keyword)."""
-        assert self._agent().is_complex(
-            "search for AI news, summarize it, and save to a file"
-        ) is True
-
-    def test_translate_and_write_is_complex(self):
-        """'Translate this text and write to a file' → complex."""
-        assert self._agent().is_complex(
-            "translate the document results and write to a file"
-        ) is True
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -619,7 +555,7 @@ class TestBrainPlannerIntegration:
              patch("bantz.core.routing_engine.ollama") as ollama_re, \
              patch("bantz.core.brain.cot_route") as mock_cot:
 
-            mock_planner.is_complex = MagicMock(return_value=True)
+            mock_cot.return_value = ({"route": "planner", "tool_name": None, "tool_args": {}, "risk_level": "safe", "confidence": 0.9, "reasoning": "Multi-step request."}, None)
             mock_planner.decompose = AsyncMock(return_value=plan_steps)
             mock_planner.format_itinerary = MagicMock(
                 return_value="Allow me a moment...\n1. Search\n2. Save")
@@ -655,11 +591,37 @@ class TestBrainPlannerIntegration:
 
     @pytest.mark.asyncio
     async def test_simple_request_bypasses_planner(self):
-        """Simple single-tool request should NOT trigger planner."""
-        from bantz.agent.planner import PlannerAgent
+        """Simple single-tool request should NOT trigger planner (cot_route returns 'tool')."""
+        with patch("bantz.core.brain.cot_route") as mock_cot, \
+             patch("bantz.core.brain.data_layer") as mock_dal, \
+             patch("bantz.core.routing_engine.data_layer") as dal_re, \
+             patch("bantz.core.brain.ollama") as mock_ollama, \
+             patch("bantz.core.routing_engine.ollama") as ollama_re:
 
-        agent = PlannerAgent()
-        assert agent.is_complex("what is the weather in istanbul") is False
+            mock_cot.return_value = ({"route": "tool", "tool_name": "weather", "tool_args": {"city": "istanbul"}, "risk_level": "safe", "confidence": 0.95, "reasoning": "Single tool."}, None)
+            mock_dal.conversations = MagicMock()
+            dal_re.conversations = MagicMock()
+            mock_ollama.chat = AsyncMock(return_value="")
+            ollama_re.chat = AsyncMock(return_value="")
+
+            from bantz.core.brain import Brain
+            brain = Brain.__new__(Brain)
+            brain._memory_ready = True
+            brain._graph_ready = True
+            brain._feedback_ctx = ""
+            brain._last_messages = []
+            brain._last_events = []
+            brain._last_draft = None
+            brain._is_remote = False
+            brain._bridge = None
+            brain._to_en = AsyncMock(return_value="what is the weather in istanbul")
+            brain._graph_store = AsyncMock()
+            brain._fire_embeddings = MagicMock()
+
+            result = await brain.process("what is the weather in istanbul")
+
+        # Should NOT route to planner
+        assert result.tool_used != "planner"
 
     @pytest.mark.asyncio
     async def test_planner_takes_priority_over_workflow_engine(self):
@@ -688,9 +650,10 @@ class TestBrainPlannerIntegration:
              patch("bantz.core.routing_engine.data_layer") as dal_re, \
              patch("bantz.core.brain.ollama") as mock_ollama, \
              patch("bantz.core.routing_engine.ollama") as ollama_re, \
-             patch("bantz.core.workflow.workflow_engine") as mock_wf:
+             patch("bantz.core.workflow.workflow_engine") as mock_wf, \
+             patch("bantz.core.brain.cot_route") as mock_cot:
 
-            mock_planner.is_complex = MagicMock(return_value=True)
+            mock_cot.return_value = ({"route": "planner", "tool_name": None, "tool_args": {}, "risk_level": "safe", "confidence": 0.9, "reasoning": "Multi-step request."}, None)
             mock_planner.decompose = AsyncMock(return_value=plan_steps)
             mock_planner.format_itinerary = MagicMock(return_value="Plan...")
             mock_executor.run = AsyncMock(return_value=exec_result)
@@ -1355,27 +1318,8 @@ class TestProcessTextCitation:
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# 13. read_url in _TOOL_KEYWORDS
+# 13. (Removed — _TOOL_KEYWORDS purged in #272; LLM decides via cot_route)
 # ═══════════════════════════════════════════════════════════════════════════════
-
-
-class TestReadUrlKeywords:
-    """read_url keywords for complexity detection."""
-
-    def _agent(self):
-        from bantz.agent.planner import PlannerAgent
-        return PlannerAgent()
-
-    def test_read_url_keywords_in_dict(self):
-        from bantz.agent.planner import _TOOL_KEYWORDS
-        assert "read_url" in _TOOL_KEYWORDS
-        assert any("read" in kw for kw in _TOOL_KEYWORDS["read_url"])
-
-    def test_open_link_and_save_is_complex(self):
-        """'open link and save' → complex (read_url + filesystem)."""
-        assert self._agent().is_complex(
-            "open link https://example.com and save the full article to a file"
-        ) is True
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -1508,14 +1452,4 @@ class TestFormatRecentHistoryPlanner:
         user_line = [l for l in lines if "user:" in l][0]
         assert len(user_line) <= 210  # "  user: " + 200 chars
 
-    def test_is_complex_accepts_recent_history_kwarg(self):
-        """is_complex() accepts recent_history keyword without error."""
-        from bantz.agent.planner import PlannerAgent
 
-        agent = PlannerAgent()
-        history = [{"role": "user", "content": "Send email to John"}]
-        # Should not raise — result doesn't matter, just kwarg acceptance
-        agent.is_complex(
-            "search for articles and then save to a file",
-            recent_history=history,
-        )

--- a/tests/agent/test_proactive.py
+++ b/tests/agent/test_proactive.py
@@ -406,26 +406,26 @@ class TestProactiveBrainRoutes:
 
     def test_proactive_status(self):
         r = self._route("proactive status")
-        assert r and r["tool"] == "_proactive_status"
+        assert r is None
 
     def test_proactive_count(self):
         r = self._route("proactive count")
-        assert r and r["tool"] == "_proactive_status"
+        assert r is None
 
     def test_engagement_status(self):
         r = self._route("engagement status")
-        assert r and r["tool"] == "_proactive_status"
+        assert r is None
 
     def test_proaktif_durum(self):
         assert True
 
     def test_how_many_proactive(self):
         r = self._route("how many proactive messages today")
-        assert r and r["tool"] == "_proactive_status"
+        assert r is None
 
     def test_check_in_status(self):
         r = self._route("check-in status")
-        assert r and r["tool"] == "_proactive_status"
+        assert r is None
 
 
 class TestProactiveBrainHandler:
@@ -461,11 +461,14 @@ class TestProactiveBrainHandler:
         mock_dl = MagicMock()
         mock_dl.kv = mock_kv
 
+        cot_return = ({"route": "tool", "tool_name": "_proactive_status", "tool_args": {}, "risk_level": "safe", "confidence": 0.9, "reasoning": "User wants proactive status."}, None)
+
         with patch("bantz.core.brain.data_layer", mock_dl), \
              patch("bantz.core.routing_engine.data_layer", mock_dl), \
              patch("bantz.core.brain.config") as cfg, \
              patch("bantz.core.routing_engine.config") as cfg_re, \
-             patch("bantz.agent.affinity_engine.affinity_engine", mock_rl):
+             patch("bantz.agent.affinity_engine.affinity_engine", mock_rl), \
+             patch("bantz.core.brain.cot_route", new_callable=AsyncMock, return_value=cot_return):
             cfg.proactive_enabled = True
             cfg.proactive_max_daily = 1
             cfg.proactive_interval_hours = 3.0

--- a/tests/agent/test_tts.py
+++ b/tests/agent/test_tts.py
@@ -597,8 +597,8 @@ class TestBrainTTSRoutes:
         assert True
 
     def test_briefing_still_works(self):
-        """Ensure briefing route still works."""
-        assert self._qr("good morning")["tool"] == "_briefing"
+        """Briefing removed from quick_route (#272), now routed via cot_route."""
+        assert self._qr("good morning") is None
 
     def test_unrelated_not_tts(self):
         """Normal conversation should not trigger TTS stop."""
@@ -706,6 +706,8 @@ class TestBrainBriefingWithTTS:
 
         mock_conv = MagicMock()
 
+        cot_return = ({"route": "tool", "tool_name": "_briefing", "tool_args": {}, "risk_level": "safe", "confidence": 0.9, "reasoning": "User wants morning briefing."}, None)
+
         with patch("bantz.core.brain.data_layer") as mock_dl, \
              patch("bantz.core.routing_engine.data_layer") as dl_re, \
              patch("bantz.core.briefing.briefing", mock_briefing), \
@@ -713,7 +715,8 @@ class TestBrainBriefingWithTTS:
              patch.object(b, "_to_en", new_callable=AsyncMock, return_value="good morning"), \
              patch.object(b, "_ensure_memory"), \
              patch.object(b, "_ensure_graph", new_callable=AsyncMock), \
-             patch("bantz.core.brain.time_ctx") as mock_tc:
+             patch("bantz.core.brain.time_ctx") as mock_tc, \
+             patch("bantz.core.brain.cot_route", new_callable=AsyncMock, return_value=cot_return):
             mock_tc.snapshot.return_value = MagicMock()
             mock_dl.conversations = mock_conv
             dl_re.conversations = MagicMock()
@@ -735,6 +738,8 @@ class TestBrainBriefingWithTTS:
 
         mock_conv = MagicMock()
 
+        cot_return = ({"route": "tool", "tool_name": "_briefing", "tool_args": {}, "risk_level": "safe", "confidence": 0.9, "reasoning": "User wants morning briefing."}, None)
+
         with patch("bantz.core.brain.data_layer") as mock_dl, \
              patch("bantz.core.routing_engine.data_layer") as dl_re, \
              patch("bantz.core.briefing.briefing", mock_briefing), \
@@ -742,7 +747,8 @@ class TestBrainBriefingWithTTS:
              patch.object(b, "_to_en", new_callable=AsyncMock, return_value="good morning"), \
              patch.object(b, "_ensure_memory"), \
              patch.object(b, "_ensure_graph", new_callable=AsyncMock), \
-             patch("bantz.core.brain.time_ctx") as mock_tc:
+             patch("bantz.core.brain.time_ctx") as mock_tc, \
+             patch("bantz.core.brain.cot_route", new_callable=AsyncMock, return_value=cot_return):
             mock_tc.snapshot.return_value = MagicMock()
             mock_dl.conversations = mock_conv
             dl_re.conversations = MagicMock()

--- a/tests/core/test_brain_integrations.py
+++ b/tests/core/test_brain_integrations.py
@@ -26,48 +26,47 @@ def _run(coro):
 # ═══════════════════════════════════════════════════════════════════════════
 
 class TestQuickRouteMaintenanceReflection:
-    """Ensure _quick_route returns correct pseudo-tool for maintenance & reflection."""
+    """After #272: quick_route no longer matches maintenance, reflection,
+    or briefing — those are now routed by LLM via cot_route."""
 
     @staticmethod
     def _qr(orig: str, en: str | None = None):
         from bantz.core.brain import Brain
         return Brain._quick_route(orig, en or orig)
 
-    # ── Maintenance triggers ──────────────────────────────────────────
+    # ── Maintenance triggers → now return None (#272) ─────────────────
 
     def test_run_maintenance(self):
-        assert self._qr("run maintenance")["tool"] == "_maintenance"
+        assert self._qr("run maintenance") is None
 
     def test_run_maintenance_dry(self):
-        r = self._qr("run maintenance dry")
-        assert r["tool"] == "_maintenance"
-        assert r["args"]["dry_run"] is True
+        assert self._qr("run maintenance dry") is None
 
     def test_sistemi_temizle(self):
         assert True
 
     def test_system_cleanup(self):
-        assert self._qr("system cleanup")["tool"] == "_maintenance"
+        assert self._qr("system cleanup") is None
 
     def test_clean_up_system(self):
-        assert self._qr("clean up the system")["tool"] == "_maintenance"
+        assert self._qr("clean up the system") is None
 
     def test_bakim_yap(self):
         assert True
 
     def test_maintenance_run(self):
-        assert self._qr("maintenance run")["tool"] == "_maintenance"
+        assert self._qr("maintenance run") is None
 
-    # ── Reflection triggers: list ─────────────────────────────────────
+    # ── Reflection triggers → now return None (#272) ──────────────────
 
     def test_show_reflections(self):
-        assert self._qr("show reflections")["tool"] == "_list_reflections"
+        assert self._qr("show reflections") is None
 
     def test_list_reflections(self):
-        assert self._qr("list reflections")["tool"] == "_list_reflections"
+        assert self._qr("list reflections") is None
 
     def test_past_reflections(self):
-        assert self._qr("past reflections")["tool"] == "_list_reflections"
+        assert self._qr("past reflections") is None
 
     def test_dunku_ozet(self):
         assert True
@@ -75,29 +74,25 @@ class TestQuickRouteMaintenanceReflection:
     def test_gecmis_ozetler(self):
         assert True
 
-    # ── Reflection triggers: run ──────────────────────────────────────
-
     def test_run_reflection(self):
-        assert self._qr("run reflection")["tool"] == "_run_reflection"
+        assert self._qr("run reflection") is None
 
     def test_run_reflection_dry(self):
-        r = self._qr("run reflection dry")
-        assert r["tool"] == "_run_reflection"
-        assert r["args"]["dry_run"] is True
+        assert self._qr("run reflection dry") is None
 
     def test_yansima_yap(self):
         assert True
 
     def test_generate_reflection(self):
-        assert self._qr("generate reflection")["tool"] == "_run_reflection"
+        assert self._qr("generate reflection") is None
 
     def test_reflect_on_today(self):
-        assert self._qr("reflect on today")["tool"] == "_run_reflection"
+        assert self._qr("reflect on today") is None
 
     def test_bugunu_ozetle(self):
         assert True
 
-    # ── Non-matches (should NOT trigger maintenance/reflection) ───────
+    # ── Non-matches (still no match) ──────────────────────────────────
 
     def test_maintain_focus_not_maintenance(self):
         r = self._qr("maintain my focus please")
@@ -108,8 +103,9 @@ class TestQuickRouteMaintenanceReflection:
         r = self._qr("let me reflect on this idea for a moment")
         assert r is None or r["tool"] != "_run_reflection"
 
-    def test_briefing_still_works(self):
-        assert self._qr("good morning")["tool"] == "_briefing"
+    def test_briefing_removed(self):
+        """Briefing is now routed via LLM, not regex (#272)."""
+        assert self._qr("good morning") is None
 
     def test_reminder_still_works(self):
         assert True
@@ -413,10 +409,20 @@ class TestProcessRLWiring:
         # Spy on _rl_reward_hook  
         b._rl_reward_hook = MagicMock()
 
+        cot_plan = {
+            "route": "tool",
+            "tool_name": "weather",
+            "tool_args": {"city": "Istanbul"},
+            "risk_level": "safe",
+            "confidence": 0.95,
+            "reasoning": "User wants weather.",
+        }
+
         with patch("bantz.core.brain.time_ctx") as mock_tc, \
              patch("bantz.core.brain.data_layer") as mock_dl, \
              patch("bantz.core.brain.registry") as mock_reg, \
-             patch("bantz.core.brain.cot_route", new_callable=AsyncMock) as mock_cot, \
+             patch("bantz.core.brain.cot_route", new_callable=AsyncMock,
+                   return_value=(cot_plan, None)), \
              patch.object(b, "_finalize", mock_finalize), \
              patch.object(b, "_finalize_stream", AsyncMock(return_value=None)):
 
@@ -425,12 +431,7 @@ class TestProcessRLWiring:
             mock_dl.conversations = MagicMock()
             mock_reg.get.return_value = mock_tool
 
-            # quick_route returns weather tool
-            from bantz.core.brain import Brain
-            with patch.object(Brain, "_quick_route", return_value={
-                "tool": "weather", "args": {"city": "Istanbul"}
-            }):
-                result = _run(b.process("weather"))
+            result = _run(b.process("weather"))
 
         b._rl_reward_hook.assert_called_once_with("weather", mock_result)
 
@@ -440,7 +441,11 @@ class TestProcessRLWiring:
 # ═══════════════════════════════════════════════════════════════════════════
 
 class TestProcessMaintenanceReflectionRouting:
-    """Verify process() actually dispatches to maintenance/reflection handlers."""
+    """Verify process() dispatches maintenance/reflection via cot_route→dispatch_internal (#272).
+
+    Since quick_route no longer matches these, cot_route must return a
+    ``route: "tool"`` plan pointing to the internal tool name.
+    """
 
     def _make_brain(self):
         from bantz.core.brain import Brain
@@ -459,9 +464,20 @@ class TestProcessMaintenanceReflectionRouting:
         b._ensure_graph = AsyncMock()
         b._to_en = AsyncMock(return_value="run maintenance")
 
+        cot_plan = {
+            "route": "tool",
+            "tool_name": "_maintenance",
+            "tool_args": {"dry_run": False},
+            "risk_level": "safe",
+            "confidence": 0.95,
+            "reasoning": "User wants to run system maintenance.",
+        }
+
         with patch("bantz.core.brain.time_ctx") as mock_tc, \
              patch("bantz.core.brain.data_layer") as mock_dl, \
              patch("bantz.core.routing_engine.data_layer") as dl_re, \
+             patch("bantz.core.brain.cot_route", new_callable=AsyncMock,
+                   return_value=(cot_plan, None)), \
              patch("bantz.core.routing_engine.handle_maintenance",
                    new_callable=AsyncMock,
                    return_value="🔧 Maintenance: all ok") as mock_maint:
@@ -469,10 +485,7 @@ class TestProcessMaintenanceReflectionRouting:
             mock_dl.conversations = MagicMock()
             dl_re.conversations = MagicMock()
 
-            # workflow_engine.detect returns [] (no workflow)
-            with patch("bantz.core.workflow.workflow_engine") as mock_wf:
-                mock_wf.detect.return_value = []
-                result = _run(b.process("run maintenance"))
+            result = _run(b.process("run maintenance"))
 
         assert result.tool_used == "maintenance"
         assert "Maintenance" in result.response
@@ -483,18 +496,27 @@ class TestProcessMaintenanceReflectionRouting:
         b._ensure_graph = AsyncMock()
         b._to_en = AsyncMock(return_value="show reflections")
 
+        cot_plan = {
+            "route": "tool",
+            "tool_name": "_list_reflections",
+            "tool_args": {},
+            "risk_level": "safe",
+            "confidence": 0.9,
+            "reasoning": "User wants to see past reflections.",
+        }
+
         with patch("bantz.core.brain.time_ctx") as mock_tc, \
              patch("bantz.core.brain.data_layer") as mock_dl, \
              patch("bantz.core.routing_engine.data_layer") as dl_re, \
+             patch("bantz.core.brain.cot_route", new_callable=AsyncMock,
+                   return_value=(cot_plan, None)), \
              patch("bantz.core.routing_engine.handle_list_reflections",
                    return_value="🤔 Recent reflections:\n  • 2025-07-14") as mock_refl:
             mock_tc.snapshot.return_value = {"prompt_hint": ""}
             mock_dl.conversations = MagicMock()
             dl_re.conversations = MagicMock()
 
-            with patch("bantz.core.workflow.workflow_engine") as mock_wf:
-                mock_wf.detect.return_value = []
-                result = _run(b.process("show reflections"))
+            result = _run(b.process("show reflections"))
 
         assert result.tool_used == "reflection"
         assert "2025-07-14" in result.response
@@ -505,9 +527,20 @@ class TestProcessMaintenanceReflectionRouting:
         b._ensure_graph = AsyncMock()
         b._to_en = AsyncMock(return_value="run reflection")
 
+        cot_plan = {
+            "route": "tool",
+            "tool_name": "_run_reflection",
+            "tool_args": {},
+            "risk_level": "safe",
+            "confidence": 0.9,
+            "reasoning": "User wants to generate a reflection.",
+        }
+
         with patch("bantz.core.brain.time_ctx") as mock_tc, \
              patch("bantz.core.brain.data_layer") as mock_dl, \
              patch("bantz.core.routing_engine.data_layer") as dl_re, \
+             patch("bantz.core.brain.cot_route", new_callable=AsyncMock,
+                   return_value=(cot_plan, None)), \
              patch("bantz.core.routing_engine.handle_run_reflection",
                    new_callable=AsyncMock,
                    return_value="🤔 Reflection done") as mock_refl:
@@ -515,9 +548,7 @@ class TestProcessMaintenanceReflectionRouting:
             mock_dl.conversations = MagicMock()
             dl_re.conversations = MagicMock()
 
-            with patch("bantz.core.workflow.workflow_engine") as mock_wf:
-                mock_wf.detect.return_value = []
-                result = _run(b.process("run reflection"))
+            result = _run(b.process("run reflection"))
 
         assert result.tool_used == "reflection"
         mock_refl.assert_awaited_once()
@@ -817,7 +848,10 @@ class TestAudioDuckRoutes:
 # ═══════════════════════════════════════════════════════════════════════════
 
 class TestAmbientRoutes:
-    """_quick_route must match ambient status queries."""
+    """After #272: quick_route no longer matches ambient queries.
+
+    They are now routed via cot_route → dispatch_internal.
+    """
 
     def _route(self, text):
         from bantz.core.brain import Brain
@@ -825,22 +859,18 @@ class TestAmbientRoutes:
         return b._quick_route(text, text.lower())
 
     def test_ambient_noise(self):
-        r = self._route("ambient noise")
-        assert r and r["tool"] == "_ambient_status"
+        assert self._route("ambient noise") is None
 
     def test_ambient_status(self):
-        r = self._route("ambient status")
-        assert r and r["tool"] == "_ambient_status"
+        assert self._route("ambient status") is None
 
     def test_environment_noise(self):
-        r = self._route("environment noise level")
-        assert r and r["tool"] == "_ambient_status"
+        assert self._route("environment noise level") is None
 
     
 
     def test_hows_the_ambient(self):
-        r = self._route("how's the ambient")
-        assert r and r["tool"] == "_ambient_status"
+        assert self._route("how's the ambient") is None
 
     
 
@@ -866,8 +896,17 @@ class TestAmbientRoutes:
         mock_analyzer = MagicMock()
         mock_analyzer.latest.return_value = snap
         mock_analyzer.day_summary.return_value = "Ambient today (5 samples): speech: 60%, silence: 40%"
+
+        cot_plan = {
+            "route": "tool", "tool_name": "_ambient_status",
+            "tool_args": {}, "risk_level": "safe", "confidence": 0.9,
+            "reasoning": "User wants ambient status.",
+        }
+
         with patch("bantz.core.brain.data_layer") as dl, \
              patch("bantz.core.routing_engine.data_layer") as dl_re, \
+             patch("bantz.core.brain.cot_route", new_callable=AsyncMock,
+                   return_value=(cot_plan, None)), \
              patch.dict("sys.modules", {"bantz.agent.ambient": MagicMock(ambient_analyzer=mock_analyzer)}):
             dl_re.conversations = MagicMock()
             result = _run(b.process("ambient noise"))
@@ -878,8 +917,17 @@ class TestAmbientRoutes:
         b = self._make_brain()
         mock_analyzer = MagicMock()
         mock_analyzer.latest.return_value = None
+
+        cot_plan = {
+            "route": "tool", "tool_name": "_ambient_status",
+            "tool_args": {}, "risk_level": "safe", "confidence": 0.9,
+            "reasoning": "User wants ambient status.",
+        }
+
         with patch("bantz.core.brain.data_layer") as dl, \
              patch("bantz.core.routing_engine.data_layer") as dl_re, \
+             patch("bantz.core.brain.cot_route", new_callable=AsyncMock,
+                   return_value=(cot_plan, None)), \
              patch.dict("sys.modules", {"bantz.agent.ambient": MagicMock(ambient_analyzer=mock_analyzer)}):
             dl_re.conversations = MagicMock()
             result = _run(b.process("ambient status"))

--- a/tests/core/test_intent.py
+++ b/tests/core/test_intent.py
@@ -391,3 +391,62 @@ class TestPeoplePleaser:
         assert plan is None
         assert error is not None
         assert "Ollama is down" in error
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 7. Planner route support (#272)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestPlannerRoute:
+    """cot_route can return route='planner' for multi-step requests (#272)."""
+
+    @pytest.mark.asyncio
+    async def test_planner_route_returned(self):
+        from bantz.core.intent import cot_route
+
+        llm_response = json.dumps({
+            "route": "planner",
+            "tool_name": None,
+            "tool_args": {},
+            "risk_level": "safe",
+            "confidence": 0.9,
+            "reasoning": "User wants weather then email — requires two tools.",
+        })
+
+        with patch("bantz.core.intent.ollama") as mock_llm:
+            mock_llm.chat = AsyncMock(return_value=llm_response)
+            plan, error = await cot_route(
+                "Check the weather in Istanbul then email it to John", [
+                    {"name": "weather", "description": "Check weather", "risk_level": "safe"},
+                    {"name": "gmail", "description": "Send email", "risk_level": "safe"},
+                ],
+            )
+
+        assert plan is not None
+        assert error is None
+        assert plan["route"] == "planner"
+        assert plan["reasoning"] == "User wants weather then email — requires two tools."
+
+    @pytest.mark.asyncio
+    async def test_planner_route_with_reasoning_field(self):
+        """Reasoning field is preserved in parsed output."""
+        from bantz.core.intent import cot_route
+
+        llm_response = json.dumps({
+            "route": "tool",
+            "tool_name": "weather",
+            "tool_args": {"city": "London"},
+            "risk_level": "safe",
+            "confidence": 0.95,
+            "reasoning": "Single tool needed — just weather lookup.",
+        })
+
+        with patch("bantz.core.intent.ollama") as mock_llm:
+            mock_llm.chat = AsyncMock(return_value=llm_response)
+            plan, error = await cot_route("weather in London", [
+                {"name": "weather", "description": "Check weather", "risk_level": "safe"},
+            ])
+
+        assert plan is not None
+        assert "reasoning" in plan

--- a/tests/core/test_router.py
+++ b/tests/core/test_router.py
@@ -203,9 +203,7 @@ class TestDiskContextRequired:
 
     def test_biggest_folder(self):
         r = _qr("which folder is the biggest?")
-        assert r is not None
-
-        assert "du" in r["args"]["command"]
+        assert r is None
 
     def test_large_files(self):
         assert True
@@ -213,34 +211,31 @@ class TestDiskContextRequired:
 
     def test_directory_size(self):
         r = _qr("what's the size of my home directory?")
-        assert r is not None
-
-        assert "du" in r["args"]["command"]
+        assert r is None
 
     def test_folder_size_turkish(self):
         r = _qr("klasör boyutu ne kadar?", "how big is the folder size?")
-        assert r is not None
+        assert r is None
 
 
     def test_dosya_boyutu_turkish(self):
         r = _qr("en büyük dosya hangisi?", "which is the biggest file?")
-        assert r is not None
+        assert r is None
 
 
     def test_disk_storage_size(self):
         r = _qr("how big is my disk storage?")
-        assert r is not None
+        assert r is None
 
 
     def test_home_directory_large(self):
         r = _qr("are there large files in ~/Documents directory?")
-        assert r is not None
+        assert r is None
 
 
     def test_path_with_tilde(self):
         r = _qr("what's the biggest folder in ~/projects?")
-        # ~/projects contains both "biggest" (size) and "folder" (disk context)
-        assert r is not None
+        assert r is None
 
 
     # ── Should NOT match (no disk context) ───────────────────────────
@@ -294,23 +289,19 @@ class TestDiskShortcutsRegression:
 
     def test_df_shortcut(self):
         r = _qr("disk space")
-        assert r is not None
-
-        assert "df" in r["args"]["command"]
+        assert r is None
 
     def test_disk_keyword(self):
         r = _qr("disk usage")
-        assert r is not None
+        assert r is None
 
     def test_direct_du_command(self):
         r = _qr("du -sh ~/Downloads")
-        assert r is not None
-
-
+        assert r is None
 
     def test_storage_keyword(self):
         r = _qr("how much storage do I have?")
-        assert r is not None
+        assert r is None
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -330,26 +321,6 @@ class TestQuickRouteAudit:
 
     def test_web_search_regex_is_unanchored(self):
         assert True
-
-    def test_disk_regex_has_word_boundary(self):
-        """Shell/disk regex must use \\b word boundaries."""
-        import inspect
-        from bantz.core.routing_engine import quick_route
-        src = inspect.getsource(quick_route)
-        idx = src.find("Folder / directory sizes")
-        assert idx != -1, "Disk section comment must exist"
-        section = src[idx:idx + 600]
-        assert r"\b" in section, "Disk regex must use word boundaries"
-
-    def test_disk_regex_requires_context(self):
-        """Shell/disk match requires both a size keyword AND a disk-context keyword."""
-        import inspect
-        from bantz.core.routing_engine import quick_route
-        src = inspect.getsource(quick_route)
-        idx = src.find("Folder / directory sizes")
-        section = src[idx:idx + 600]
-        assert "_SIZE_KW" in section and "_DISK_CTX" in section, \
-            "Disk routing must use two-gate (size + context) pattern"
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/tests/core/test_routing_engine.py
+++ b/tests/core/test_routing_engine.py
@@ -1,5 +1,5 @@
 """Tests for ``bantz.core.routing_engine`` — quick_route, dispatch_internal,
-generate_command, execute_plan, and workflow handlers (#228)."""
+generate_command, execute_plan, and workflow handlers (#228, #272)."""
 from __future__ import annotations
 
 import asyncio
@@ -13,41 +13,21 @@ def _run(coro):
 
 
 # ═══════════════════════════════════════════════════════════════════════════
-# 1. quick_route — regex fast-path
+# 1. quick_route — hardware/UI controls only (#272)
 # ═══════════════════════════════════════════════════════════════════════════
 
 class TestQuickRoute:
-    """Exhaustive coverage of ``quick_route`` regex patterns."""
+    """quick_route now ONLY matches hardware/UI toggles.
+
+    All semantic routing (shell, system metrics, briefing, maintenance,
+    reflection, ambient, …) was purged in #272 — the LLM decides via
+    cot_route instead.
+    """
 
     @pytest.fixture(autouse=True)
     def _import(self):
         from bantz.core.routing_engine import quick_route
         self.qr = quick_route
-
-    # ── Shell (direct) ─────────────────────────────────────────────
-    @pytest.mark.parametrize("text", [
-        "ls -la",
-        "df -h",
-        "cat /etc/hosts",
-        "pwd",
-    ])
-    def test_shell_commands(self, text):
-        r = self.qr(text, text)
-        assert r is not None
-        assert r["tool"] == "shell"
-
-    # ── System metrics ────────────────────────────────────────────────
-    @pytest.mark.parametrize("text,expected_tool", [
-        ("system status", "system"),
-        ("cpu usage", "system"),
-        ("memory usage", "system"),
-        ("check disk space", "shell"),
-        ("how much RAM is free", "system"),
-    ])
-    def test_system_metrics(self, text, expected_tool):
-        r = self.qr(text, text)
-        assert r is not None
-        assert r["tool"] == expected_tool
 
     # ── TTS stop ──────────────────────────────────────────────────────
     @pytest.mark.parametrize("text", [
@@ -82,58 +62,42 @@ class TestQuickRoute:
         assert r is not None
         assert r["tool"] == expected
 
-    # ── Ambient / Proactive / Health ──────────────────────────────────
-    @pytest.mark.parametrize("text,expected", [
-        ("ambient status", "_ambient_status"),
-        ("proactive status", "_proactive_status"),
-        ("health status", "_health_status"),
-    ])
-    def test_status_queries(self, text, expected):
-        r = self.qr(text, text)
+    # ── Clear memory ──────────────────────────────────────────────────
+    def test_clear_memory(self):
+        r = self.qr("clear memory", "clear memory")
         assert r is not None
-        assert r["tool"] == expected
+        assert r["tool"] == "_clear_memory"
 
-    # ── Briefing ──────────────────────────────────────────────────────
+    # ── Previously regex-matched queries now go through LLM (#272) ────
     @pytest.mark.parametrize("text", [
+        # Shell commands — no longer regex-matched
+        "ls -la",
+        "df -h",
+        "cat /etc/hosts",
+        "pwd",
+        # System metrics
+        "system status",
+        "cpu usage",
+        "memory usage",
+        "check disk space",
+        "how much RAM is free",
+        # Status queries
+        "ambient status",
+        "proactive status",
+        "health status",
+        # Briefing
         "good morning",
         "morning briefing",
         "what's today",
+        # Maintenance / Reflection
+        "run maintenance",
+        "run maintenance dry",
+        "run reflection",
+        "show reflections",
     ])
-    def test_briefing(self, text):
-        r = self.qr(text, text)
-        assert r is not None
-        assert r["tool"] == "_briefing"
-
-    # ── Maintenance / Reflection ──────────────────────────────────────
-    def test_maintenance(self):
-        r = self.qr("run maintenance", "run maintenance")
-        assert r is not None
-        assert r["tool"] == "_maintenance"
-
-    def test_maintenance_dry_run(self):
-        r = self.qr("run maintenance dry", "run maintenance dry")
-        assert r is not None
-        assert r["args"]["dry_run"] is True
-
-    def test_run_reflection(self):
-        r = self.qr("run reflection", "run reflection")
-        assert r is not None
-        assert r["tool"] == "_run_reflection"
-
-    def test_list_reflections(self):
-        r = self.qr("show reflections", "show reflections")
-        assert r is not None
-        assert r["tool"] == "_list_reflections"
-
-    # ── Clear memory (note: "memory" keyword also triggers system route,
-    #     so clear_memory must appear before system in quick_route) ─────
-    def test_clear_memory(self):
-        # "clear memory" triggers the clear_memory branch ONLY if it
-        # appears before the system-metrics branch.  Verify actual output:
-        r = self.qr("clear memory", "clear memory")
-        assert r is not None
-        # Might be _clear_memory or system depending on regex order
-        assert r["tool"] in ("_clear_memory", "system")
+    def test_removed_regex_returns_none(self, text):
+        """Queries that were previously regex-matched must now return None."""
+        assert self.qr(text, text) is None
 
     # ── No match → None ──────────────────────────────────────────────
     @pytest.mark.parametrize("text", [


### PR DESCRIPTION
## Summary

Closes #272

Strips quick_route() to hardware/UI controls only and unifies all semantic routing under the LLM via cot_route().

### Pipeline Change
OLD: planner.is_complex() → quick_route regex → cot_route → chat
NEW: quick_route (hw only) → cot_route (LLM decides) → safety net → route branch

### Files Changed (11 files, -504/+337 lines)

**Source (4 files):**
- **routing_engine.py** — quick_route() stripped from ~180→~35 lines
- **intent.py** — COT_SYSTEM: route:planner, reasoning field, multi-step audit
- **brain.py** — Complete process() pipeline refactor with safety net
- **planner.py** — Deleted is_complex(), _MULTI_STEP_MARKERS, _TOOL_KEYWORDS

**Tests (7 files):** Updated across test_routing_engine, test_intent, test_brain_integrations, test_planner, test_proactive, test_tts, test_router

### Test Results
- **2811 passed**, 31 skipped, 12 failed (all pre-existing)
- **Zero new regressions**