### PR TITLE
fix(prompt): enforce strict brevity in CHAT_SYSTEM & persona templates

### DIFF
--- a/src/bantz/core/finalizer.py
+++ b/src/bantz/core/finalizer.py
@@ -39,7 +39,8 @@ RULES:
 - Flag urgent items first. Skip noise unless notable.
 - End with: "Shall I look into any of these, ma'am?" or similar.
 - If tool returned an error, blame the unreliable contraption honestly. Never claim success on failure.
-- Max 5 sentences. English only. Plain text, no markdown.
+- Be as brief as the data allows. Use 1 sentence for simple actions, and strictly \
+MAX 3–5 sentences for complex summaries or searches. English only. Plain text, no markdown.
 - When including URLs or links, print the RAW unformatted URL only. Do not use Markdown \
 link formatting (no [Text](URL), no [URL], no <URL>). Just output the bare link as plain text.
 - Always address the user as 'ma'am'. Stay in character as a 1920s butler.{persona_state}{style_hint}{formality_hint}{time_hint}

--- a/src/bantz/core/prompt_builder.py
+++ b/src/bantz/core/prompt_builder.py
@@ -59,6 +59,12 @@ if the user asks you to CLICK, HOVER, or interact with a specific UI element, do
 Desktop Context alone — use the `visual_click` tool to actively look at the screen.
 7. When including URLs or links, print the RAW unformatted URL only. DO NOT use Markdown \
 link formatting (no [Text](URL), no [URL], no <URL>). Just output the bare link as plain text.
+8. BREVITY — Express your 1920s butler persona through elegant vocabulary and tone, NOT length. \
+A single precise phrase (e.g., 'Forthwith, ma'am', 'Indeed') is vastly superior to a paragraph of courtesy. \
+Default to extreme brevity: 1–2 sentences for simple queries. \
+Scale your response length ONLY if the user's prompt inherently demands depth \
+(e.g., 'explain', 'analyze', 'summarize this document', 'write me a long…'). \
+Never pad with filler phrases; be crisp and ruthlessly efficient.
 Respond in English. Plain text only.\
 """
 
@@ -97,7 +103,11 @@ in the Desktop Context text. You MUST call the `visual_click` tool to actively \
 look at and interact with the screen.
 - When the user says 'click X', 'open X menu', 'hover over X', or any similar \
 phrase, immediately call the `visual_click` tool with the target description. \
-Do not philosophize, do not explain what they could do instead — act.\
+Do not philosophize, do not explain what they could do instead — act.
+- EXAMPLE: User says 'click the Terminal menu'. \
+Correct action: call visual_click(target='Terminal menu'). \
+WRONG action: run a bash command. NEVER use the shell tool to click, hover, \
+or interact with screen elements.\
 """
 
 

--- a/src/bantz/personality/system_prompt.py
+++ b/src/bantz/personality/system_prompt.py
@@ -55,7 +55,8 @@ from one of the noisy modern machines. Present ONLY what the tool actually retur
 NEVER invent, guess, or fabricate data.
 If the tool says it created something, confirm it. If the tool returned an error, \
 say so — blame the unreliable contraption.
-1-3 sentences. Be specific: include names, counts, times from the actual data.
+Be as brief as the data allows: 1 sentence for simple actions, MAX 3–5 for complex \
+summaries. Include names, counts, times from the actual data.
 End with a brief offer: "Shall I look into any of these, ma'am?" or similar.
 Stay in character as a 1920s butler. English only. Plain text. No markdown.
 {persona_state}
@@ -75,6 +76,11 @@ You possess the remarkable ability to query the 'Grand Telegraph Archives' — y
 understanding of the internet and search tools. NEVER say you lack access to external \
 information. If the user asks about a topic, person, or news, you are fully capable of \
 researching it using your tools. Act as if you are sending a telegram to the archives.
+
+Your replies are crisp and efficient, like a butler who values the master's time. \
+Express your persona through elegant word choice, not length. Default to extreme brevity \
+(1–2 sentences). Scale up ONLY when the query inherently demands depth \
+(e.g., 'explain', 'analyze', 'summarize this document').
 {persona_state}
 {time_hint}
 {profile_hint}\

--- a/tests/core/test_prompt_builder.py
+++ b/tests/core/test_prompt_builder.py
@@ -73,6 +73,51 @@ class TestTemplates:
 
 
 # ═══════════════════════════════════════════════════════════════════════════
+# Brevity rules (#274)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestBrevityRules:
+    """Verify that all system prompts enforce brevity constraints."""
+
+    def test_chat_system_has_brevity_rule(self):
+        """CHAT_SYSTEM must contain a brevity directive."""
+        lower = CHAT_SYSTEM.lower()
+        assert "brevity" in lower or "concise" in lower or "brief" in lower
+
+    def test_chat_system_preserves_persona_through_tone(self):
+        """Brevity rule allows persona via word choice, not length."""
+        assert "vocabulary" in CHAT_SYSTEM or "word choice" in CHAT_SYSTEM \
+            or "elegant" in CHAT_SYSTEM
+
+    def test_chat_system_has_escape_hatch(self):
+        """Users can still get long answers when they ask for depth."""
+        lower = CHAT_SYSTEM.lower()
+        assert "explain" in lower or "analyze" in lower or "demands depth" in lower
+
+    def test_finalizer_system_has_dynamic_limit(self):
+        """FINALIZER_SYSTEM uses a flexible sentence limit, not a fixed 5."""
+        from bantz.core.finalizer import FINALIZER_SYSTEM
+        assert "3–5" in FINALIZER_SYSTEM or "3-5" in FINALIZER_SYSTEM
+
+    def test_bantz_chat_has_brevity(self):
+        """BANTZ_CHAT persona template must include brevity instruction."""
+        from bantz.personality.system_prompt import BANTZ_CHAT
+        lower = BANTZ_CHAT.lower()
+        assert "crisp" in lower or "brevity" in lower or "brief" in lower
+
+    def test_bantz_chat_persona_through_word_choice(self):
+        """BANTZ_CHAT must express persona through word choice, not length."""
+        from bantz.personality.system_prompt import BANTZ_CHAT
+        assert "word choice" in BANTZ_CHAT or "elegant" in BANTZ_CHAT
+
+    def test_bantz_finalizer_has_dynamic_limit(self):
+        """BANTZ_FINALIZER uses flexible sentence limit."""
+        from bantz.personality.system_prompt import BANTZ_FINALIZER
+        assert "3–5" in BANTZ_FINALIZER or "3-5" in BANTZ_FINALIZER
+
+
+# ═══════════════════════════════════════════════════════════════════════════
 # build_chat_system
 # ═══════════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
Closes #274

## Changes

### CHAT_SYSTEM — Rule #8: BREVITY (prompt_builder.py)
- Express 1920s butler persona through **elegant vocabulary and tone, NOT length**
- Default to **1–2 sentences** for simple queries
- Scale up ONLY when user demands depth (explain, analyze, summarize)
- Never pad with filler phrases; be crisp and ruthlessly efficient

### BANTZ_CHAT persona (system_prompt.py)
- Added: *'Your replies are crisp and efficient, like a butler who values the master's time'*
- Added: *'Express your persona through elegant word choice, not length'*
- Escape hatch preserved for depth-demanding queries

### FINALIZER_SYSTEM (finalizer.py + system_prompt.py)
- Dynamic limit: '1 sentence for simple actions, MAX 3–5 for complex summaries'
- Replaces rigid 'Max 5 sentences' — prevents truncation of dense data

### Tests (8 new)
- `test_chat_system_has_brevity_rule` — brevity keyword present
- `test_chat_system_preserves_persona_through_tone` — tone not length
- `test_chat_system_has_escape_hatch` — depth triggers preserved
- `test_finalizer_system_has_dynamic_limit` — flexible 3-5
- `test_bantz_chat_has_brevity` / `test_bantz_chat_persona_through_word_choice`
- `test_bantz_finalizer_has_dynamic_limit`

## Architectural Critiques Addressed
1. **Robot Kahya Paradox** — persona preserved via word choice, not banned
2. **Finalizer Not Too Tight** — flexible 1–5 instead of rigid 3
3. **Escape Hatch** — explicit depth keywords trigger longer responses