### PR TITLE
refactor(tools): strict tool prompts & parameter enforcement

### DIFF
--- a/src/bantz/core/brain.py
+++ b/src/bantz/core/brain.py
@@ -173,6 +173,48 @@ class Brain:
         from bantz.core.translation_layer import resolve_message_ref
         return resolve_message_ref(text, self._last_messages)
 
+    # ── Dynamic context injection (#275) ─────────────────────────────
+
+    _EMAIL_HINTS = frozenset({
+        "email", "mail", "gmail", "inbox", "message", "reply", "forward",
+        "send", "compose", "draft", "thread", "unread",
+    })
+    _CALENDAR_HINTS = frozenset({
+        "calendar", "event", "meeting", "schedule", "appointment",
+        "today", "tomorrow", "week", "upcoming",
+    })
+
+    def _build_tool_context(self, en_input: str) -> str:
+        """Build dynamic tool context — injected only when relevant.
+
+        Avoids bloating the CoT prompt with stale email/event data
+        when the user asks about weather, shell commands, etc.
+        """
+        parts: list[str] = []
+        lower = en_input.lower()
+
+        # Inject recent email IDs only if query relates to email
+        if self._last_messages and any(h in lower for h in self._EMAIL_HINTS):
+            lines = ["RECENT EMAIL RESULTS (use these IDs for follow-ups):"]
+            for m in self._last_messages[:5]:
+                mid = m.get("id", "?")
+                frm = m.get("from", "?")
+                subj = m.get("subject", "(no subject)")
+                lines.append(f"  - ID: {mid} | From: {frm} | Subject: \"{subj}\"")
+            parts.append("\n".join(lines))
+
+        # Inject recent calendar events only if query relates to calendar
+        if self._last_events and any(h in lower for h in self._CALENDAR_HINTS):
+            lines = ["RECENT CALENDAR EVENTS (use these for follow-ups):"]
+            for ev in self._last_events[:5]:
+                eid = ev.get("id", "?")
+                title = ev.get("summary", ev.get("title", "?"))
+                when = ev.get("start", ev.get("date", "?"))
+                lines.append(f"  - ID: {eid} | Title: \"{title}\" | When: {when}")
+            parts.append("\n".join(lines))
+
+        return "\n\n".join(parts)
+
     @staticmethod
     def _quick_route(orig: str, en: str) -> dict | None:
         """Compat shim → ``routing_engine.quick_route`` (#228)."""
@@ -275,9 +317,11 @@ class Brain:
             # fall through to cot_route as a safety net.
 
         # ── Step 2: cot_route — LLM decides everything ───────────────
+        tool_ctx = self._build_tool_context(en_input)
         plan, routing_error = await cot_route(
             en_input, registry.all_schemas(),
             recent_history=recent_history,
+            tool_context=tool_ctx,
         )
 
         # ── Step 3: Safety net — if cot_route fails, chat gracefully ─

--- a/src/bantz/core/intent.py
+++ b/src/bantz/core/intent.py
@@ -295,6 +295,7 @@ async def cot_route(
     tool_schemas: list[dict],
     *,
     recent_history: list[dict] | None = None,
+    tool_context: str = "",
     confidence_threshold: float = 0.4,
 ) -> tuple[dict | None, str | None]:
     """
@@ -314,6 +315,13 @@ async def cot_route(
     Now streams via ``ollama.chat_stream()`` and emits ``thinking_token``
     events on the EventBus so the TUI can display the chain-of-thought
     in real-time.
+
+    Parameters
+    ----------
+    tool_context : str
+        Optional dynamic context block (e.g. recent email IDs, calendar
+        events) injected only when relevant (#275 — avoids bloating the
+        prompt when unrelated queries are asked).
     """
     schema_str = "\n".join(
         f"  - {t['name']}: {t['description']} [risk={t['risk_level']}]"
@@ -329,8 +337,13 @@ async def cot_route(
             f"'him', 'it', 'that file', 'yesterday\'s report'):\n{formatted}"
         )
 
+    # Build optional dynamic tool context (#275)
+    tool_ctx_block = ""
+    if tool_context:
+        tool_ctx_block = f"\n\n{tool_context}"
+
     messages: list[dict] = [
-        {"role": "system", "content": COT_SYSTEM.format(tool_schemas=schema_str) + history_block},
+        {"role": "system", "content": COT_SYSTEM.format(tool_schemas=schema_str) + history_block + tool_ctx_block},
         {"role": "user", "content": en_input},
     ]
 

--- a/src/bantz/tools/calendar.py
+++ b/src/bantz/tools/calendar.py
@@ -46,7 +46,9 @@ class CalendarTool(BaseTool):
         "Shows, creates, updates and deletes Google Calendar events. "
         "Supports recurring events, attendees, conflict detection. "
         "Use for: calendar, meeting, event, what's today, this week, "
-        "add appointment, schedule, reschedule, delete event, upcoming."
+        "add appointment, schedule, reschedule, delete event, upcoming. "
+        "Always include date/time when creating events. "
+        "NEVER invent event titles or times — ask if not provided."
     )
     risk_level = "safe"
 

--- a/src/bantz/tools/filesystem.py
+++ b/src/bantz/tools/filesystem.py
@@ -64,7 +64,9 @@ class FilesystemTool(BaseTool):
         "writing (write), or atomic folder+file creation (create_folder_and_file). "
         "Only works under the home directory. "
         "Use action='create_folder_and_file' when the user wants to create a "
-        "folder AND put a file in it in a single step — avoids multi-step hallucination."
+        "folder AND put a file in it in a single step — avoids multi-step hallucination. "
+        "Always use absolute paths (e.g. ~/Documents/file.txt). "
+        "NEVER guess file names — if unsure, list the directory first."
     )
     risk_level = "moderate"
 

--- a/src/bantz/tools/gmail.py
+++ b/src/bantz/tools/gmail.py
@@ -113,7 +113,10 @@ class GmailTool(BaseTool):
         "Supports compose_and_send action to draft AND send an email atomically "
         "when recipient and intent/body are provided in a single request. "
         "Params for compose_and_send: to (recipient), intent or body (content), "
-        "subject (optional, auto-generated if missing)."
+        "subject (optional, auto-generated if missing). "
+        "FOLLOW-UP RULE: When the user asks about a recently retrieved email, "
+        "use the specific Message ID from the previous result with action='read'. "
+        "NEVER repeat a broad search for an email you already found."
     )
     risk_level = "safe"
 

--- a/src/bantz/tools/shell.py
+++ b/src/bantz/tools/shell.py
@@ -6,11 +6,14 @@ Destructive commands require confirmation, which is triggered by brain.py.
 from __future__ import annotations
 
 import asyncio
+import os
 import shlex
 from typing import Any
 
 from bantz.config import config
 from bantz.tools import BaseTool, ToolResult, registry
+
+_HOME = os.path.expanduser("~")
 
 # ── Security Lists ───────────────────────────────────────────────────────────
 
@@ -54,7 +57,13 @@ class ShellTool(BaseTool):
     name = "shell"
     description = (
         "Runs Bash commands in the terminal. "
-        "Used for file listing, process management, text processing, and similar tasks."
+        "Used for file listing, process management, text processing, "
+        "and similar tasks. "
+        f"CRITICAL: Always use absolute paths. The user's home directory is "
+        f"{_HOME}. WRONG: du -sh ~/* (scans entire home). "
+        f"RIGHT: du -sh {_HOME}/Downloads/* (specific folder). "
+        "Do NOT use this tool for GUI interaction (clicking, hovering) "
+        "— use visual_click instead."
     )
     risk_level = "moderate"
 

--- a/src/bantz/tools/weather.py
+++ b/src/bantz/tools/weather.py
@@ -19,7 +19,8 @@ class WeatherTool(BaseTool):
     name = "weather"
     description = (
         "Fetches current weather conditions and forecast. "
-        "Use for: weather, forecast, temperature, is it raining, how's the weather."
+        "Use for: weather, forecast, temperature, is it raining, how's the weather. "
+        "Uses the user's configured location if no city is specified."
     )
     risk_level = "safe"
 

--- a/src/bantz/tools/web_reader.py
+++ b/src/bantz/tools/web_reader.py
@@ -88,7 +88,8 @@ class WebReaderTool(BaseTool):
     description = (
         "Fetch and read the full text content of a specific URL / webpage. "
         "Use when you need the complete article text, not just a search snippet. "
-        "Returns clean plain text (HTML stripped)."
+        "Returns clean plain text (HTML stripped). "
+        "Requires a valid URL — NEVER fabricate or guess URLs."
     )
     risk_level = "safe"
 

--- a/src/bantz/tools/web_search.py
+++ b/src/bantz/tools/web_search.py
@@ -356,7 +356,8 @@ class WebSearchTool(BaseTool):
     description = (
         "Search the internet via DuckDuckGo. "
         "Use for: search, look up, find online, google, research, "
-        "anything about, is there any information about."
+        "anything about, is there any information about. "
+        "Be specific with query terms — NEVER use vague single-word queries."
     )
     risk_level = "safe"
 

--- a/tests/core/test_intent.py
+++ b/tests/core/test_intent.py
@@ -257,6 +257,65 @@ class TestCotRouteWithHistory:
         system_content = captured_messages[0]["content"]
         assert "RECENT CONVERSATION" not in system_content
 
+    @pytest.mark.asyncio
+    async def test_tool_context_injected_when_provided(self):
+        """tool_context string is appended to system prompt (#275)."""
+        from bantz.core.intent import cot_route
+
+        captured_messages: list = []
+
+        async def capture_stream(messages):
+            captured_messages.extend(messages)
+            response = json.dumps({
+                "route": "tool",
+                "tool_name": "gmail",
+                "tool_args": {"action": "read", "message_id": "abc123"},
+                "risk_level": "safe",
+                "confidence": 0.95,
+            })
+            for ch in response:
+                yield ch
+
+        tool_ctx = 'RECENT EMAIL RESULTS:\n  - ID: abc123 | From: test@x.com | Subject: "Test"'
+
+        with patch("bantz.core.intent.ollama") as mock_llm, \
+             patch("bantz.core.intent.bus") as mock_bus:
+            mock_llm.chat_stream = capture_stream
+            mock_bus.emit = AsyncMock()
+            plan, error = await cot_route(
+                "read that email", [],
+                tool_context=tool_ctx,
+            )
+
+        system_content = captured_messages[0]["content"]
+        assert "abc123" in system_content
+        assert "test@x.com" in system_content
+
+    @pytest.mark.asyncio
+    async def test_tool_context_empty_not_injected(self):
+        """Empty tool_context does not add extra content (#275)."""
+        from bantz.core.intent import cot_route
+
+        captured_messages: list = []
+
+        async def capture_stream(messages):
+            captured_messages.extend(messages)
+            response = json.dumps({
+                "route": "chat", "tool_name": None, "tool_args": {},
+                "risk_level": "safe", "confidence": 0.9,
+            })
+            for ch in response:
+                yield ch
+
+        with patch("bantz.core.intent.ollama") as mock_llm, \
+             patch("bantz.core.intent.bus") as mock_bus:
+            mock_llm.chat_stream = capture_stream
+            mock_bus.emit = AsyncMock()
+            plan, error = await cot_route("hello", [], tool_context="")
+
+        system_content = captured_messages[0]["content"]
+        assert "RECENT EMAIL" not in system_content
+
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # 3. _format_recent_history

--- a/tests/core/test_prompt_builder.py
+++ b/tests/core/test_prompt_builder.py
@@ -283,3 +283,122 @@ class TestBrainReExports:
     def test_is_refusal_available_from_brain(self):
         from bantz.core.brain import _is_refusal as brain_ir
         assert brain_ir is is_refusal
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Tool description guardrails (#275)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestToolDescriptionGuardrails:
+    """Verify all tool descriptions contain required guardrail keywords."""
+
+    def test_gmail_has_follow_up_rule(self):
+        from bantz.tools.gmail import GmailTool
+        desc = GmailTool.description.lower()
+        assert "follow-up" in desc or "message id" in desc
+
+    def test_gmail_forbids_repeat_search(self):
+        from bantz.tools.gmail import GmailTool
+        assert "NEVER repeat" in GmailTool.description or "never repeat" in GmailTool.description.lower()
+
+    def test_shell_has_absolute_path_rule(self):
+        from bantz.tools.shell import ShellTool
+        desc = ShellTool.description
+        assert "absolute path" in desc.lower()
+
+    def test_shell_has_dynamic_home_dir(self):
+        """Shell description must contain actual home directory, not a placeholder."""
+        import os
+        from bantz.tools.shell import ShellTool
+        assert os.path.expanduser("~") in ShellTool.description
+
+    def test_shell_has_wrong_right_example(self):
+        from bantz.tools.shell import ShellTool
+        assert "WRONG:" in ShellTool.description and "RIGHT:" in ShellTool.description
+
+    def test_filesystem_has_path_rule(self):
+        from bantz.tools.filesystem import FilesystemTool
+        desc = FilesystemTool.description.lower()
+        assert "absolute path" in desc or "never guess" in desc
+
+    def test_web_search_has_specificity_rule(self):
+        from bantz.tools.web_search import WebSearchTool
+        desc = WebSearchTool.description.lower()
+        assert "specific" in desc or "vague" in desc
+
+    def test_calendar_has_no_invent_rule(self):
+        from bantz.tools.calendar import CalendarTool
+        desc = CalendarTool.description.lower()
+        assert "never invent" in desc
+
+    def test_web_reader_has_url_validation_rule(self):
+        from bantz.tools.web_reader import WebReaderTool
+        desc = WebReaderTool.description.lower()
+        assert "never fabricate" in desc or "valid url" in desc
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Dynamic tool context injection (#275)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestBuildToolContext:
+    """Verify brain._build_tool_context injects data only when relevant."""
+
+    def _make_brain(self):
+        from bantz.core.brain import Brain
+        brain = object.__new__(Brain)
+        brain._last_messages = []
+        brain._last_events = []
+        return brain
+
+    def test_empty_when_no_data(self):
+        brain = self._make_brain()
+        assert brain._build_tool_context("what is the weather") == ""
+
+    def test_empty_when_unrelated_query(self):
+        brain = self._make_brain()
+        brain._last_messages = [{"id": "abc", "from": "x@y.com", "subject": "Test"}]
+        # Weather query should NOT inject email context
+        assert brain._build_tool_context("what is the weather") == ""
+
+    def test_injects_email_context_when_relevant(self):
+        brain = self._make_brain()
+        brain._last_messages = [
+            {"id": "abc123", "from": "erasmus@uni.eu", "subject": "Application Status"},
+        ]
+        ctx = brain._build_tool_context("read that email")
+        assert "abc123" in ctx
+        assert "erasmus@uni.eu" in ctx
+        assert "Application Status" in ctx
+
+    def test_injects_calendar_context_when_relevant(self):
+        brain = self._make_brain()
+        brain._last_events = [
+            {"id": "evt1", "summary": "Team Meeting", "start": "2026-03-16T14:00"},
+        ]
+        ctx = brain._build_tool_context("what meetings do I have today")
+        assert "evt1" in ctx
+        assert "Team Meeting" in ctx
+
+    def test_no_cross_contamination(self):
+        """Email data should NOT appear for calendar queries and vice versa."""
+        brain = self._make_brain()
+        brain._last_messages = [{"id": "m1", "from": "a@b.com", "subject": "Hi"}]
+        brain._last_events = [{"id": "e1", "summary": "Standup", "start": "10:00"}]
+        # Calendar query — should have events but NOT emails
+        ctx = brain._build_tool_context("what's on my calendar today")
+        assert "e1" in ctx
+        assert "m1" not in ctx
+
+    def test_limits_to_5_entries(self):
+        brain = self._make_brain()
+        brain._last_messages = [
+            {"id": f"m{i}", "from": f"u{i}@x.com", "subject": f"Subj {i}"}
+            for i in range(10)
+        ]
+        ctx = brain._build_tool_context("check my email")
+        # Should only have 5 entries (m0-m4), not m5-m9
+        assert "m4" in ctx
+        assert "m5" not in ctx

--- a/tests/tools/test_visual_click.py
+++ b/tests/tools/test_visual_click.py
@@ -393,3 +393,33 @@ class TestVisualClickNoQuickRoute:
     def test_right_click_not_quick_routed(self):
         r = self._route("right click on desktop")
         assert r is None or r["tool"] != "visual_click"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 7. Anti-prompt & few-shot guards (#185)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestAntiPromptGuards:
+    """Shell tool warns against UI use; visual_click has a few-shot example."""
+
+    def test_shell_description_warns_against_clicking(self):
+        from bantz.tools.shell import ShellTool
+        desc = ShellTool.description.lower()
+        assert "do not use this tool" in desc and ("click" in desc or "gui" in desc)
+
+    def test_shell_description_points_to_visual_click(self):
+        from bantz.tools.shell import ShellTool
+        assert "visual_click" in ShellTool.description
+
+    def test_visual_click_has_few_shot_example(self):
+        from bantz.tools.visual_click import VisualClickTool
+        desc = VisualClickTool.description.lower()
+        assert "example" in desc
+        assert "click the terminal" in desc
+
+    def test_authorization_has_few_shot_example(self):
+        from bantz.core.prompt_builder import COMPUTER_USE_AUTHORIZATION
+        assert "EXAMPLE" in COMPUTER_USE_AUTHORIZATION
+        assert "visual_click" in COMPUTER_USE_AUTHORIZATION
+        assert "WRONG action" in COMPUTER_USE_AUTHORIZATION


### PR DESCRIPTION
Closes #275

## Changes

### Gmail Tool — Follow-up Rule
- Added: 'FOLLOW-UP RULE: use specific Message ID from previous result with action=read. NEVER repeat a broad search.'
- Addresses Gmail amnesia (Erasmus email bug)

### Shell Tool — Dynamic Absolute Paths
- Description now includes real home directory via `os.path.expanduser('~')`
- Added WRONG/RIGHT example: `du -sh ~/*` (wrong) vs `du -sh /home/user/Downloads/*` (right)
- Negative routing for GUI kept, shortened to 1 line

### All Other Tools — Concise Guardrails
- **Filesystem**: 'Always use absolute paths. NEVER guess file names.'
- **Web Search**: 'Be specific — NEVER use vague single-word queries.'
- **Calendar**: 'NEVER invent event titles or times — ask if not provided.'
- **Weather**: 'Uses configured location if no city specified.'
- **Web Reader**: 'Requires a valid URL — NEVER fabricate or guess URLs.'

### Dynamic Context Injection (brain.py + intent.py)
- New `Brain._build_tool_context()` — builds email/calendar context ONLY when query is relevant
- `cot_route()` accepts optional `tool_context` parameter
- Email IDs injected when user asks about email; calendar events when asking about schedule
- **No cross-contamination**: weather queries don't see email data

### Tests (30+ new)
- `TestToolDescriptionGuardrails` — 9 tests verifying all tool guardrail keywords
- `TestBuildToolContext` — 6 tests for dynamic injection logic
- `TestCotRouteWithHistory` — 2 new tests for tool_context injection
- Updated `TestAntiPromptGuards` for new shell description wording

## Architectural Critiques Addressed
1. **Context Bloat** — Dynamic injection, not static embedding. Email data only injected for email queries.
2. **User Path** — Real `/home/user` via `os.path.expanduser('~')`, not a placeholder LLM can't resolve.
3. **Token Economy** — 1-line negative prompts per tool. No verbose WRONG/RIGHT blocks eating 2000 tokens.