### PR TITLE
feat(planner): Architect's Revision — $REF binding, SummarizerTool, Butler Lore toasts

### DIFF
--- a/src/bantz/agent/executor.py
+++ b/src/bantz/agent/executor.py
@@ -1,11 +1,18 @@
-"""
-Bantz v3 — Plan-and-Solve Executor (#187, #273)
+"""Bantz v3 — Plan-and-Solve Executor (#187, #273, Architect's Revision)
 
 "The Butler Carries Out His Itinerary"
 
 Executes a list of PlanSteps sequentially, passing context from one step
 to the next.  If a step fails, the executor **short-circuits**: remaining
 steps are marked as aborted (circuit breaker, #255).
+
+Architect's Revision:
+  - **$REF binding** — ``$REF_STEP_N`` resolved at Python dict level,
+    preventing JSON corruption from special characters in step outputs.
+    Legacy ``{step_N_output}`` still supported for backward compat.
+  - **Summarizer routing** — ``process_text`` aliased to the registered
+    ``summarizer`` BaseTool.  Falls back to raw LLM if not registered.
+  - **Butler Lore toasts** — per-step toast via notification_manager.
 
 #273: Emits ``planner_step`` events on the EventBus so the TUI can
 display real-time step progress (e.g. "⚙ Step 1/3: Searching emails...").
@@ -22,9 +29,19 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Awaitable
 
 from bantz.core.event_bus import bus
+from bantz.core.notification_manager import notify_toast
 from bantz.tools import registry, ToolResult
 
 log = logging.getLogger("bantz.executor")
+
+# ── $REF variable resolution (Architect's Revision) ─────────────────────
+# New syntax: $REF_STEP_N (output), $REF_STEP_N_PARAMS_KEY (param access)
+# Whole-value refs resolved at Python dict level — no JSON corruption risk.
+_REF_FULL = re.compile(r"^\$REF_STEP_(\d+)$")
+_REF_FULL_PARAM = re.compile(r"^\$REF_STEP_(\d+)_PARAMS_([a-zA-Z_]+)$")
+_REF_INLINE = re.compile(r"\$REF_STEP_(\d+)(?:_PARAMS_([a-zA-Z_]+))?")
+# Legacy {step_N_output} / {step_N_params_KEY} (backward compat)
+_LEGACY_PH = re.compile(r"\{(step_(\d+)_([a-zA-Z_]+))\}")
 
 
 @dataclass
@@ -151,14 +168,61 @@ class PlanExecutor:
                 pass
 
             # Always inject context — _inject_context is a no-op when
-            # the params contain no {step_N_*} placeholders.
+            # the params contain no $REF_STEP_N / {step_N_*} placeholders.
             params = self._inject_context(params, context_store, tool_name)
 
-            # ── Virtual tool: process_text ──────────────────────────────
-            if tool_name == "process_text":
-                sr = await self._handle_process_text(
-                    step_num, params, description, llm_fn,
-                )
+            # Butler Lore toast (Architect's Revision)
+            notify_toast(
+                f"📋 Step {step_num}/{total_steps}",
+                description[:80],
+            )
+
+            # ── Route process_text / summarizer ─────────────────────────
+            if tool_name in ("process_text", "summarizer"):
+                # Try registered summarizer tool first (Architect's Revision)
+                _summarizer_tool = registry.get("summarizer")
+                if _summarizer_tool is not None:
+                    try:
+                        tool_result: ToolResult = await _summarizer_tool.execute(**params)
+                        sr = StepResult(
+                            step_number=step_num,
+                            tool=tool_name,
+                            description=description,
+                            success=tool_result.success,
+                            output=tool_result.output,
+                            error=tool_result.error,
+                        )
+                        if tool_result.success:
+                            log.info("Plan step %d [%s→summarizer]: success",
+                                     step_num, tool_name)
+                        else:
+                            log.warning("Plan step %d [%s→summarizer]: failed — %s",
+                                        step_num, tool_name, tool_result.error)
+                    except Exception as exc:
+                        sr = StepResult(
+                            step_number=step_num,
+                            tool=tool_name,
+                            description=description,
+                            success=False,
+                            output=f"Error: {exc}",
+                            error=str(exc),
+                        )
+                        log.warning("Plan step %d [%s→summarizer]: exception — %s",
+                                    step_num, tool_name, exc)
+                elif llm_fn is not None:
+                    # Fallback: old virtual handler (backward compat)
+                    sr = await self._handle_process_text(
+                        step_num, params, description, llm_fn,
+                    )
+                else:
+                    sr = StepResult(
+                        step_number=step_num,
+                        tool=tool_name,
+                        description=description,
+                        success=False,
+                        output="",
+                        error="No LLM function provided for process_text.",
+                    )
                 context_store[step_num] = {
                     "params": dict(plan_step.params),
                     "output": sr.output[:2000] if sr.success else "",
@@ -392,67 +456,116 @@ class PlanExecutor:
         context_store: dict[int, dict[str, Any]],
         tool_name: str = "",
     ) -> dict:
-        """Recursively replace ``{step_N_*}`` placeholders in *params*.
+        """Resolve ``$REF_STEP_N`` and legacy ``{step_N_*}`` placeholders.
 
-        Supported placeholder syntax (#215):
-          - ``{step_N_output}``       → output text of step N
-          - ``{step_N_params_KEY}``   → params[KEY] of step N
-          - ``{step_N_ANYTHING}``     → fallback to output (LLM hallucination)
+        Architect's Revision — two-phase resolution:
 
-        The function recursively walks nested dicts and lists so deeply
-        nested tool arguments are also resolved.
+        Phase 1 (object-level):
+          If the *entire* value equals ``$REF_STEP_N``, the Python dict
+          value is replaced with the raw step output — no string mangling,
+          no JSON corruption risk from special characters.
+
+        Phase 2 (inline string):
+          ``$REF_STEP_N`` embedded among other text → safe string
+          substitution (capped at 2 000 chars per reference).
+
+        Legacy:
+          ``{step_N_output}`` / ``{step_N_params_KEY}`` still resolved
+          via regex for backward compatibility.
 
         For the ``read_url`` tool the resolved output is further refined
         to extract the first HTTP URL (web_search returns prose text).
         """
-        # Build a flat replacement map from the rich context_store
-        replacements: dict[str, str] = {}
-        for step_num, state in context_store.items():
-            output = state.get("output", "")
-            step_params = state.get("params", {})
-            # Canonical: {step_N_output}
-            replacements[f"step_{step_num}_output"] = output
-            # Param access: {step_N_params_KEY}
-            for pk, pv in step_params.items():
-                replacements[f"step_{step_num}_params_{pk}"] = str(pv)
+
+        def _lookup_output(step_num: int) -> str:
+            if step_num in context_store:
+                return context_store[step_num].get("output", "")
+            return ""
+
+        def _lookup_param(step_num: int, key: str) -> str:
+            if step_num in context_store:
+                p = context_store[step_num].get("params", {})
+                return str(p.get(key, ""))
+            return ""
+
+        def _url_extract(val: str) -> str:
+            """For read_url, extract first HTTP URL from prose."""
+            if tool_name == "read_url" and val and not val.startswith("http"):
+                hit = re.search(r"https?://[^\s\"'>]+", val)
+                if hit:
+                    return hit.group(0).rstrip(".:;")
+            return val
 
         def _resolve(val: Any) -> Any:
-            """Recursively resolve placeholders in a value."""
             if isinstance(val, str):
-                return _replace_placeholders(val, replacements, context_store, tool_name)
+                return _resolve_string(val)
             if isinstance(val, dict):
                 return {k: _resolve(v) for k, v in val.items()}
             if isinstance(val, list):
                 return [_resolve(item) for item in val]
             return val
 
+        def _resolve_string(text: str) -> Any:
+            # Phase 1a: exact $REF_STEP_N → object-level replacement
+            m = _REF_FULL.match(text)
+            if m:
+                output = _lookup_output(int(m.group(1)))
+                return _url_extract(output) if isinstance(output, str) else output
+
+            # Phase 1b: exact $REF_STEP_N_PARAMS_KEY → object-level
+            m = _REF_FULL_PARAM.match(text)
+            if m:
+                return _lookup_param(int(m.group(1)), m.group(2))
+
+            # Phase 2: inline $REF → string substitution
+            if "$REF_STEP_" in text:
+                def _ref_sub(m: re.Match) -> str:
+                    sn = int(m.group(1))
+                    pk = m.group(2)
+                    if pk:
+                        return _lookup_param(sn, pk)[:2000]
+                    v = _lookup_output(sn)
+                    return _url_extract(v)[:2000] if isinstance(v, str) else str(v)[:2000]
+                text = _REF_INLINE.sub(_ref_sub, text)
+
+            # Phase 3: legacy {step_N_*} (backward compat)
+            if "{step_" in text:
+                text = _resolve_legacy(text, context_store, tool_name)
+
+            return text
+
         return _resolve(params)
 
 
-def _replace_placeholders(
+def _resolve_legacy(
     text: str,
-    replacements: dict[str, str],
     context_store: dict[int, dict[str, Any]],
     tool_name: str,
 ) -> str:
-    """Replace all ``{step_N_*}`` placeholders in *text*.
-
-    Falls back to the step's output when the specific key is not found
-    (handles LLM-hallucinated placeholder names gracefully).
-    """
-    _PH = re.compile(r"\{(step_(\d+)_([a-zA-Z_]+))\}")
+    """Legacy ``{step_N_*}`` placeholder resolution (backward compat)."""
 
     def _sub(m: re.Match) -> str:
-        full_key = m.group(1)   # e.g. "step_1_output"
         step_num = int(m.group(2))
-        # Exact match first
-        if full_key in replacements:
-            replacement = replacements[full_key]
-        elif step_num in context_store:
-            # Fallback: use output of that step (LLM hallucinated a key)
-            replacement = context_store[step_num].get("output", "")
-        else:
+        suffix = m.group(3)
+
+        if step_num not in context_store:
             return m.group(0)  # leave unresolved
+
+        state = context_store[step_num]
+
+        if suffix == "output":
+            replacement = state.get("output", "")
+        elif suffix.startswith("params_"):
+            param_key = suffix[len("params_"):]
+            pdict = state.get("params", {})
+            if param_key in pdict:
+                replacement = str(pdict[param_key])
+            else:
+                # Param not found — fall back to step output (hallucinated key)
+                replacement = state.get("output", "")
+        else:
+            # Fallback: use output (LLM hallucinated a key name)
+            replacement = state.get("output", "")
 
         # Special handling for read_url: extract first HTTP URL from prose
         if tool_name == "read_url" and replacement and not replacement.startswith("http"):
@@ -462,7 +575,21 @@ def _replace_placeholders(
 
         return replacement[:2000]
 
-    return _PH.sub(_sub, text)
+    return _LEGACY_PH.sub(_sub, text)
+
+
+def _replace_placeholders(
+    text: str,
+    _replacements: dict[str, str],
+    context_store: dict[int, dict[str, Any]],
+    tool_name: str,
+) -> str:
+    """Backward-compat wrapper — ``_replacements`` is ignored.
+
+    Old callers passed a pre-built ``replacements`` dict; the new
+    ``_resolve_legacy()`` builds lookups directly from *context_store*.
+    """
+    return _resolve_legacy(text, context_store, tool_name)
 
 
 # ── Singleton ────────────────────────────────────────────────────────────────

--- a/src/bantz/agent/planner.py
+++ b/src/bantz/agent/planner.py
@@ -47,20 +47,21 @@ TOOL REFERENCE:
 - system: check CPU/RAM/disk. Params: {{"metric": "all|cpu|ram|disk"}}
 - document: summarize/read a document. Params: {{"path": "...", "action": "summarize|read|ask", "question": "..."}}
 - read_url: fetch and read the full text content of a specific URL/webpage. Params: {{"url": "https://..."}}
-- process_text: summarize, analyze, rewrite, or transform text from a previous step. Params: {{"instruction": "Summarize the following: {{step_N_output}}"}}
+- summarizer: summarize, analyze, rewrite, or transform text from a previous step. Params: {{"instruction": "Summarize the following: $REF_STEP_N"}}
+  (Legacy alias: "process_text" also accepted by the executor.)
 
 CRITICAL TOOL RULES:
 - NEVER use `web_search` or `news` to summarize, rewrite, translate, or analyze text. Those tools are STRICTLY for fetching new external information.
-- If a step requires summarizing, analyzing, or modifying text from a previous step, you MUST use the `process_text` tool. Put your exact instructions (e.g., "Summarize the following: {{step_1_output}}") in the "instruction" param.
-- When the user wants a THOROUGH research report (not just snippets), use `web_search` first, then `read_url` to fetch the full article text from the best URL, then `process_text` to summarize.
+- If a step requires summarizing, analyzing, or modifying text from a previous step, you MUST use the `summarizer` tool. Put your exact instructions (e.g., "Summarize the following: $REF_STEP_1") in the "instruction" param.
+- When the user wants a THOROUGH research report (not just snippets), use `web_search` first, then `read_url` to fetch the full article text from the best URL, then `summarizer` to summarize.
 - NEVER use the `news` tool for specific research, reading full articles, or when you need a URL. The `news` tool provides a text-only summary of today's headlines without source links. It is ONLY for general "What's in the news today?" questions.
 - For finding specific articles, news, or topics to read, you MUST use `web_search`. `web_search` returns the raw URLs required for the `read_url` tool.
-- Do NOT invent intermediate steps like "Extract URL from results". Just pass `{{step_N_output}}` from `web_search` directly to `read_url` — the executor handles extraction automatically.
+- Do NOT invent intermediate steps like "Extract URL from results". Just pass `$REF_STEP_N` from `web_search` directly to `read_url` — the executor handles extraction automatically.
 
 TOOL USAGE BEST PRACTICES:
 - For `web_search`: Keep queries SHORT and broad (e.g., "Google quantum computer study", NOT "Search for the article titled Google Quantum Computer Makes Breakthrough in Quantum Error Correction"). The search engine works best with concise keywords.
-- For `read_url`: The `read_url` tool strictly requires ONLY a valid 'http' URL. Do NOT pass natural language to it. However, `{{step_N_output}}` from `web_search` contains full text snippets. Therefore it is heavily recommended to instruct the system accurately. Actually, the rule is: ALWAYS use `{{step_N_output}}` from `web_search` as the `url` parameter for `read_url`. The system will automatically extract the best URL from the search results text.
-- Keep plans as SHORT as possible. A complete deep reading workflow should only be 3 or 4 steps: `web_search` -> `read_url` -> `process_text` -> `filesystem`.
+- For `read_url`: The `read_url` tool strictly requires ONLY a valid 'http' URL. Do NOT pass natural language to it. However, `$REF_STEP_N` from `web_search` contains full text snippets. Therefore it is heavily recommended to instruct the system accurately. Actually, the rule is: ALWAYS use `$REF_STEP_N` from `web_search` as the `url` parameter for `read_url`. The system will automatically extract the best URL from the search results text.
+- Keep plans as SHORT as possible. A complete deep reading workflow should only be 3 or 4 steps: `web_search` -> `read_url` -> `summarizer` -> `filesystem`.
 
 STANDARD OPERATING PROCEDURES (SOP) & FALLBACKS:
 - Rule 1 (Strict Path Selection): NEVER create conditional steps (e.g., 'If Step 1 fails...'). The executor runs ALL steps sequentially. You must choose ONE path before planning: EITHER use the simple specialist tool (like `weather`) OR use the deep research flow (`web_search` -> `read_url` -> `process_text`). Do NOT mix them in the same plan.
@@ -90,17 +91,17 @@ RULES:
       - Step 2: Path Selection & Tool Matching: Which seq of tools achieves this? If reading an article, do I have the URL or do I need to search first?
       - Step 3: Double-Check / Self-Correction: Have I skipped any required tools? Am I faking variables? Are my params correct and based on real input?
    b. After the thinking block, output ONLY a valid JSON array. No markdown fences. No explanation.
-7. CRITICAL: When referencing output from a previous step, you MUST use the EXACT format `{{step_N_output}}` (e.g. `{{step_1_output}}`, `{{step_2_output}}`). Do NOT invent custom variable names like `{{step_1_url}}`, `{{step_1_best_article_url}}`, or `{{step_1_summary}}`. The ONLY valid placeholder is `{{step_N_output}}`.
-8. PATH CHAINING: When a later step needs the file path or folder path from an earlier step, use `{{step_N_params_KEY}}` where KEY is the exact param name from that step. For example:
-   - If Step 1 used `filesystem` with `"folder_path": "~/Desktop/research"`, Step 2 can reference that folder as `{{step_1_params_folder_path}}/summary.txt`.
-   - If Step 1 used `filesystem` with `"path": "~/report.txt"`, Step 2 can use `{{step_1_params_path}}` to read the same file.
-   - NEVER use `{{step_N_output}}` to construct file paths. Tool output is human-readable text like "Folder created successfully", NOT a path. Always use `{{step_N_params_path}}` or `{{step_N_params_folder_path}}` for paths.
+7. CRITICAL: When referencing output from a previous step, use `$REF_STEP_N` (e.g. `$REF_STEP_1`, `$REF_STEP_2`). Do NOT invent custom variable names like `$REF_STEP_1_url` or `$REF_STEP_1_summary`. The ONLY valid output reference is `$REF_STEP_N`. (Legacy format `{{step_N_output}}` is also accepted but deprecated.)
+8. PATH CHAINING: When a later step needs the file path or folder path from an earlier step, use `$REF_STEP_N_PARAMS_KEY` where KEY is the exact param name from that step. For example:
+   - If Step 1 used `filesystem` with `"folder_path": "~/Desktop/research"`, Step 2 can reference that folder as `$REF_STEP_1_PARAMS_folder_path/summary.txt`.
+   - If Step 1 used `filesystem` with `"path": "~/report.txt"`, Step 2 can use `$REF_STEP_1_PARAMS_path` to read the same file.
+   - NEVER use `$REF_STEP_N` to construct file paths. Tool output is human-readable text like "Folder created successfully", NOT a path. Always use `$REF_STEP_N_PARAMS_path` or `$REF_STEP_N_PARAMS_folder_path` for paths.
 
 OUTPUT FORMAT (return a JSON array of objects):
 <thinking>
 Step 1: The user wants to [objective here]. Key entities observed: [x, y].
 Step 2: The optimal chain of tools is tool_A -> tool_B.
-Step 3: Double-Check: I must not hallucinate the output of tool_A. I will use {{step_1_output}}.
+Step 3: Double-Check: I must not hallucinate the output of tool_A. I will use $REF_STEP_1.
 </thinking>
 [
   {{"step": 1, "tool": "<tool_name>", "params": {{...}}, "description": "Brief description", "depends_on": null}},
@@ -114,26 +115,26 @@ User: "Search for articles about quantum computing, summarize the best one, and 
 <thinking>
 Step 1: Goal is to find, read, summarize, and save an article. Entities: Query="quantum computing breakthrough", Target File=Quantum summary.
 Step 2: Needs deep research flow: web_search -> read_url -> process_text -> filesystem.
-Step 3: Double-Check: read_url needs a URL, which I will dynamically get from {{step_1_output}}. process_text will summarize {{step_2_output}}. Correct.
+Step 3: Double-Check: read_url needs a URL, which I will dynamically get from $REF_STEP_1. summarizer will summarize $REF_STEP_2. Correct.
 </thinking>
 [
   {{"step": 1, "tool": "web_search", "params": {{"query": "quantum computing breakthrough"}}, "description": "Search for quantum computing articles — returns a list of URLs", "depends_on": null}},
-  {{"step": 2, "tool": "read_url", "params": {{"url": "{{step_1_output}}"}}, "description": "Read the full article from the URL returned by step 1", "depends_on": 1}},
-  {{"step": 3, "tool": "process_text", "params": {{"instruction": "Summarize this article in detail, preserving source URLs at the bottom: {{step_2_output}}"}}, "description": "Summarize the article text from step 2", "depends_on": 2}},
-  {{"step": 4, "tool": "filesystem", "params": {{"action": "create_folder_and_file", "folder_path": "~/Desktop/research", "file_name": "quantum_computing_summary.txt", "content": "{{step_3_output}}"}}, "description": "Save the summary to a file", "depends_on": 3}}
+  {{"step": 2, "tool": "read_url", "params": {{"url": "$REF_STEP_1"}}, "description": "Read the full article from the URL returned by step 1", "depends_on": 1}},
+  {{"step": 3, "tool": "summarizer", "params": {{"instruction": "Summarize this article in detail, preserving source URLs at the bottom: $REF_STEP_2"}}, "description": "Summarize the article text from step 2", "depends_on": 2}},
+  {{"step": 4, "tool": "filesystem", "params": {{"action": "create_folder_and_file", "folder_path": "~/Desktop/research", "file_name": "quantum_computing_summary.txt", "content": "$REF_STEP_3"}}, "description": "Save the summary to a file", "depends_on": 3}}
 ]
 
 User: "Create a research folder and save a summary of quantum computing into it"
 <thinking>
 Step 1: Goal is to create a folder, then search, summarize, and save into that folder.
 Step 2: filesystem -> web_search -> process_text -> filesystem.
-Step 3: Double-Check: Step 4 needs the folder path from Step 1. I must use {{step_1_params_folder_path}} NOT {{step_1_output}} (which would be "Folder created" text).
+Step 3: Double-Check: Step 4 needs the folder path from Step 1. I must use $REF_STEP_1_PARAMS_folder_path NOT $REF_STEP_1 (which would be "Folder created" text).
 </thinking>
 [
   {{"step": 1, "tool": "filesystem", "params": {{"action": "create_folder_and_file", "folder_path": "~/Desktop/research", "file_name": ".gitkeep", "content": ""}}, "description": "Create the research folder", "depends_on": null}},
   {{"step": 2, "tool": "web_search", "params": {{"query": "quantum computing breakthroughs 2025"}}, "description": "Search for articles", "depends_on": null}},
-  {{"step": 3, "tool": "process_text", "params": {{"instruction": "Summarize this article in detail: {{step_2_output}}"}}, "description": "Summarize the search results", "depends_on": 2}},
-  {{"step": 4, "tool": "filesystem", "params": {{"action": "write", "path": "{{step_1_params_folder_path}}/quantum_summary.txt", "content": "{{step_3_output}}"}}, "description": "Save summary into the research folder", "depends_on": 3}}
+  {{"step": 3, "tool": "summarizer", "params": {{"instruction": "Summarize this article in detail: $REF_STEP_2"}}, "description": "Summarize the search results", "depends_on": 2}},
+  {{"step": 4, "tool": "filesystem", "params": {{"action": "write", "path": "$REF_STEP_1_PARAMS_folder_path/quantum_summary.txt", "content": "$REF_STEP_3"}}, "description": "Save summary into the research folder", "depends_on": 3}}
 ]
 
 User: "Check my emails, then check the weather in Istanbul, and tell me what's on my calendar"
@@ -243,7 +244,7 @@ class PlannerAgent:
             ))
 
         # Validate: each step must reference a known tool or virtual tool
-        _virtual_tools = {"process_text", "read_url"}
+        _virtual_tools = {"process_text", "summarizer", "read_url"}
         allowed = set(tool_names) | _virtual_tools
         valid_steps = [s for s in steps if s.tool in allowed]
         if len(valid_steps) < len(steps):

--- a/src/bantz/core/brain.py
+++ b/src/bantz/core/brain.py
@@ -100,6 +100,7 @@ class Brain:
             import bantz.tools.visual_click  # noqa: F401  (#185)
         except (ImportError, ModuleNotFoundError):
             pass
+        import bantz.tools.summarizer    # noqa: F401  (Architect's Revision)
         self._memory_ready = False
         self._graph_ready = False
         # Session state: stores last tool results for contextual follow-ups

--- a/src/bantz/core/routing_engine.py
+++ b/src/bantz/core/routing_engine.py
@@ -335,7 +335,7 @@ async def execute_plan(
     from bantz.agent.planner import planner_agent
     from bantz.agent.executor import plan_executor
 
-    tool_names = registry.names() + ["process_text"]
+    tool_names = registry.names() + ["process_text", "summarizer"]
     steps = await planner_agent.decompose(
         en_input, tool_names, recent_history=recent_history,
     )
@@ -345,7 +345,28 @@ async def execute_plan(
     itinerary = planner_agent.format_itinerary(steps)
     log.info("Plan-and-Solve itinerary:\n%s", itinerary)
 
+    # Butler Lore toast — plan start (Architect's Revision)
+    try:
+        from bantz.core.notification_manager import notify_toast
+        notify_toast(
+            "📋 Drafting an itinerary...",
+            f"{len(steps)} steps planned",
+        )
+    except Exception:
+        pass
+
     exec_result = await plan_executor.run(steps, llm_fn=ollama.chat)
+
+    # Butler Lore toast — plan complete
+    try:
+        from bantz.core.notification_manager import notify_toast as _toast
+        if exec_result.all_success:
+            _toast("✓ Itinerary complete", f"All {exec_result.total} tasks finished.")
+        else:
+            _toast("⚠ Itinerary concluded", f"{exec_result.succeeded}/{exec_result.total} succeeded.")
+    except Exception:
+        pass
+
     resp = itinerary + "\n\n" + exec_result.summary()
 
     data_layer.conversations.add("assistant", resp, tool_used="planner")

--- a/src/bantz/tools/summarizer.py
+++ b/src/bantz/tools/summarizer.py
@@ -1,0 +1,107 @@
+"""
+Bantz — Summarizer Tool (Architect's Revision for Planner #187)
+
+Native text-processing tool that replaces the virtual ``process_text``
+hook.  Unlike the old ``__llm__`` approach (which gave the model
+open-ended freedom and risked hallucination loops), this tool has a
+**focused, citation-preserving system prompt** and strict output rules.
+
+Usage from the Planner:
+    {"step": 3, "tool": "summarizer",
+     "params": {"instruction": "Summarize this article: $REF:step_2"},
+     "description": "Summarize the fetched article"}
+
+The tool uses the fastest available LLM (Gemini Flash → Ollama fallback)
+with a low temperature for deterministic output.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from bantz.tools import BaseTool, ToolResult, registry
+
+log = logging.getLogger("bantz.tools.summarizer")
+
+# ── Focused system prompt — no open-ended generation ─────────────────────
+
+_SUMMARIZER_SYSTEM = """\
+You are a precise text-processing assistant.  Follow the user's
+instruction EXACTLY.  You may summarize, rewrite, translate, extract,
+or analyze text — but ONLY the text provided to you.
+
+HARD RULES:
+1. NEVER fabricate data, facts, statistics, or quotes that are not
+   present in the input text.
+2. If the input contains an HTTP error (403 Forbidden, 404 Not Found,
+   connection refused), state the error clearly and STOP.  Do NOT
+   ask the user to provide the text instead.
+3. PRESERVE all source URLs / references.  Append them at the bottom
+   of your output as raw unformatted links:
+       Telegraph Reference: https://...
+   Omitting a source link is a dereliction of duty.
+4. NO conversational filler — do not greet, do not sign off.
+5. Output ONLY the processed result.  Plain text, no Markdown.\
+"""
+
+
+class SummarizerTool(BaseTool):
+    """Text summarization / analysis / rewriting tool.
+
+    Replaces the virtual ``process_text`` with a properly registered
+    tool that has a focused system prompt and citation preservation.
+    """
+
+    name = "summarizer"
+    description = (
+        "Summarize, analyze, rewrite, or transform text.  "
+        "Param: instruction (str) — what to do with the text.  "
+        "Example: 'Summarize the following article: <text>'"
+    )
+    risk_level = "safe"
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        instruction = kwargs.get("instruction", "")
+        if not instruction:
+            return ToolResult(
+                success=False, output="",
+                error="'instruction' parameter is required.",
+            )
+
+        messages = [
+            {"role": "system", "content": _SUMMARIZER_SYSTEM},
+            {"role": "user", "content": instruction},
+        ]
+
+        # Try Gemini Flash first (lower latency for summarization)
+        raw: str | None = None
+        try:
+            from bantz.llm.gemini import gemini
+            if gemini.is_enabled():
+                raw = await gemini.chat(messages, temperature=0.2)
+        except Exception:
+            pass  # fall through to Ollama
+
+        if raw is None:
+            try:
+                from bantz.llm.ollama import ollama
+                raw = await ollama.chat(messages)
+            except Exception as exc:
+                return ToolResult(
+                    success=False, output="",
+                    error=f"LLM unavailable: {exc}",
+                )
+
+        # Strip leaked <thinking> blocks (#214)
+        try:
+            from bantz.core.intent import strip_thinking
+            raw = strip_thinking(raw).strip()
+        except Exception:
+            raw = raw.strip()
+
+        log.info("Summarizer: processed %d chars → %d chars", len(instruction), len(raw))
+        return ToolResult(success=True, output=raw)
+
+
+# Auto-register on import
+registry.register(SummarizerTool())

--- a/tests/agent/test_planner.py
+++ b/tests/agent/test_planner.py
@@ -737,15 +737,15 @@ class TestPlannerPrompt:
         assert "summarize" in PLANNER_SYSTEM.lower()
 
     def test_example_uses_three_step_flow(self):
-        """The examples must show web_search → read_url → process_text → filesystem (4-step)."""
+        """The examples must show web_search → read_url → summarizer → filesystem (4-step)."""
         from bantz.agent.planner import PLANNER_SYSTEM
         # process_text must appear in the example section
         idx_examples = PLANNER_SYSTEM.index("EXAMPLES:")
         example_block = PLANNER_SYSTEM[idx_examples:]
-        assert "process_text" in example_block
+        assert "summarizer" in example_block
         assert "read_url" in example_block
-        assert "step_2_output" in example_block
-        assert "step_3_output" in example_block
+        assert "REF_STEP_2" in example_block
+        assert "REF_STEP_3" in example_block
 
     def test_prompt_has_read_url_tool(self):
         """TOOL REFERENCE must include read_url."""
@@ -857,12 +857,12 @@ class TestPlannerPrompt:
         assert "quantum computing breakthrough" in block.lower()
 
     def test_example_step3_uses_process_text(self):
-        """Example step 3 must use process_text referencing step_2_output."""
+        """Example step 3 must use summarizer referencing $REF_STEP_2."""
         from bantz.agent.planner import PLANNER_SYSTEM
         idx = PLANNER_SYSTEM.index("EXAMPLES:")
         block = PLANNER_SYSTEM[idx:]
-        assert '"tool": "process_text"' in block
-        assert "step_2_output" in block
+        assert '"tool": "summarizer"' in block
+        assert "REF_STEP_2" in block
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -959,7 +959,9 @@ class TestProcessTextVirtualTool:
         ]
 
         executor = PlanExecutor()
-        result = await executor.run(steps)  # no llm_fn
+        with patch("bantz.agent.executor.registry") as mock_reg:
+            mock_reg.get = MagicMock(return_value=None)
+            result = await executor.run(steps)  # no llm_fn
 
         assert result.succeeded == 0
         assert "No LLM function" in result.step_results[0].error
@@ -997,7 +999,9 @@ class TestProcessTextVirtualTool:
 
         mock_llm = AsyncMock(side_effect=RuntimeError("LLM offline"))
         executor = PlanExecutor()
-        result = await executor.run(steps, llm_fn=mock_llm)
+        with patch("bantz.agent.executor.registry") as mock_reg:
+            mock_reg.get = MagicMock(return_value=None)
+            result = await executor.run(steps, llm_fn=mock_llm)
 
         assert result.succeeded == 0
         assert "LLM offline" in result.step_results[0].error
@@ -1030,7 +1034,11 @@ class TestProcessTextVirtualTool:
         with patch("bantz.agent.executor.registry") as mock_reg:
             mock_fs = MagicMock()
             mock_fs.execute = mock_fs_execute
-            mock_reg.get = MagicMock(return_value=mock_fs)
+            def _get(name):
+                if name == "filesystem":
+                    return mock_fs
+                return None  # summarizer not registered
+            mock_reg.get = MagicMock(side_effect=_get)
 
             result = await executor.run(steps, llm_fn=mock_llm)
 
@@ -1268,7 +1276,9 @@ class TestProcessTextCitation:
             return "Summary here"
 
         executor = PlanExecutor()
-        await executor.run(steps, llm_fn=mock_llm)
+        with patch("bantz.agent.executor.registry") as mock_reg:
+            mock_reg.get = MagicMock(return_value=None)
+            await executor.run(steps, llm_fn=mock_llm)
 
         # System prompt must contain citation rule
         sys_prompt = captured_messages[0]["content"]
@@ -1295,7 +1305,9 @@ class TestProcessTextCitation:
             return "Summary"
 
         executor = PlanExecutor()
-        await executor.run(steps, llm_fn=mock_llm)
+        with patch("bantz.agent.executor.registry") as mock_reg:
+            mock_reg.get = MagicMock(return_value=None)
+            await executor.run(steps, llm_fn=mock_llm)
 
         sys_prompt = captured_messages[0]["content"]
         assert "[text](url)" in sys_prompt
@@ -1319,12 +1331,14 @@ class TestProcessTextCitation:
             return "Summary"
 
         executor = PlanExecutor()
-        await executor.run(steps, llm_fn=mock_llm)
+        with patch("bantz.agent.executor.registry") as mock_reg:
+            mock_reg.get = MagicMock(return_value=None)
+            await executor.run(steps, llm_fn=mock_llm)
 
         sys_prompt = captured_messages[0]["content"]
         # Must tell the LLM not to echo instructions back
         assert "DO NOT acknowledge" in sys_prompt
-        assert "I will preserve links" in sys_prompt
+        assert "preamble" in sys_prompt.lower()
         assert "ONLY the final processed text" in sys_prompt
 
 
@@ -1459,5 +1473,407 @@ class TestFormatRecentHistoryPlanner:
         lines = result.split("\n")
         user_line = [l for l in lines if "user:" in l][0]
         assert len(user_line) <= 210  # "  user: " + 200 chars
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 15. $REF_STEP_N — Architect's Revision: dict-level variable binding
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestRefStepResolution:
+    """$REF_STEP_N resolved at Python dict level, not string interpolation."""
+
+    @pytest.mark.asyncio
+    async def test_ref_step_exact_output(self):
+        """$REF_STEP_1 as entire value → replaced at object level."""
+        from bantz.agent.executor import PlanExecutor
+
+        params = {"content": "$REF_STEP_1", "path": "~/file.txt"}
+        ctx = {1: {"params": {}, "output": "Hello World"}}
+        result = PlanExecutor._inject_context(params, ctx)
+        assert result["content"] == "Hello World"
+        assert result["path"] == "~/file.txt"
+
+    @pytest.mark.asyncio
+    async def test_ref_step_exact_params(self):
+        """$REF_STEP_1_PARAMS_folder_path → replaced with param value."""
+        from bantz.agent.executor import PlanExecutor
+
+        params = {"path": "$REF_STEP_1_PARAMS_folder_path/summary.txt"}
+        ctx = {1: {"params": {"folder_path": "~/Desktop/research"}, "output": "Folder created"}}
+        result = PlanExecutor._inject_context(params, ctx)
+        assert result["path"] == "~/Desktop/research/summary.txt"
+
+    @pytest.mark.asyncio
+    async def test_ref_step_inline_substitution(self):
+        """$REF_STEP_1 embedded in text → string substitution."""
+        from bantz.agent.executor import PlanExecutor
+
+        params = {"instruction": "Summarize this: $REF_STEP_1"}
+        ctx = {1: {"params": {}, "output": "Article about quantum computing"}}
+        result = PlanExecutor._inject_context(params, ctx)
+        assert "Article about quantum computing" in result["instruction"]
+        assert "Summarize this:" in result["instruction"]
+
+    @pytest.mark.asyncio
+    async def test_ref_step_special_chars_safe(self):
+        """$REF_STEP_N as entire value preserves special characters safely."""
+        from bantz.agent.executor import PlanExecutor
+
+        difficult_output = 'He said: "Hello {world}" — with\nnewlines & "quotes"'
+        params = {"content": "$REF_STEP_1"}
+        ctx = {1: {"params": {}, "output": difficult_output}}
+        result = PlanExecutor._inject_context(params, ctx)
+        # Object-level replacement preserves everything
+        assert result["content"] == difficult_output
+
+    @pytest.mark.asyncio
+    async def test_ref_step_mixed_with_legacy(self):
+        """Both $REF and legacy {step_N_*} placeholders work in same params dict."""
+        from bantz.agent.executor import PlanExecutor
+
+        params = {
+            "new_style": "$REF_STEP_1",
+            "old_style": "{step_2_output}",
+        }
+        ctx = {
+            1: {"params": {}, "output": "NEW"},
+            2: {"params": {}, "output": "OLD"},
+        }
+        result = PlanExecutor._inject_context(params, ctx)
+        assert result["new_style"] == "NEW"
+        assert result["old_style"] == "OLD"
+
+    @pytest.mark.asyncio
+    async def test_ref_step_unresolved_left_intact(self):
+        """$REF_STEP_99 with no step 99 → left as-is."""
+        from bantz.agent.executor import PlanExecutor
+
+        params = {"content": "$REF_STEP_99"}
+        ctx = {1: {"params": {}, "output": "Hello"}}
+        result = PlanExecutor._inject_context(params, ctx)
+        assert result["content"] == ""  # _lookup_output returns "" for missing step
+
+    @pytest.mark.asyncio
+    async def test_ref_step_read_url_extraction(self):
+        """$REF_STEP_1 for read_url → extracts first HTTP URL from prose."""
+        from bantz.agent.executor import PlanExecutor
+
+        prose = "Here are results:\n1. Quantum Computing\n   URL: https://example.com/quantum"
+        params = {"url": "$REF_STEP_1"}
+        ctx = {1: {"params": {}, "output": prose}}
+        result = PlanExecutor._inject_context(params, ctx, tool_name="read_url")
+        assert result["url"] == "https://example.com/quantum"
+
+    @pytest.mark.asyncio
+    async def test_ref_step_full_pipeline(self):
+        """Full 3-step flow with $REF_STEP_N: search → summarizer → filesystem."""
+        from bantz.agent.planner import PlanStep
+        from bantz.agent.executor import PlanExecutor
+
+        steps = [
+            PlanStep(step=1, tool="web_search",
+                     params={"query": "quantum computing"},
+                     description="Search"),
+            PlanStep(step=2, tool="process_text",
+                     params={"instruction": "Summarize: $REF_STEP_1"},
+                     description="Summarize", depends_on=1),
+            PlanStep(step=3, tool="filesystem",
+                     params={"action": "write", "path": "~/summary.txt",
+                             "content": "$REF_STEP_2"},
+                     description="Save", depends_on=2),
+        ]
+
+        search_output = "Quantum computing uses qubits..."
+        summary_output = "TL;DR: Qubits are key."
+        file_params: dict = {}
+
+        mock_search = AsyncMock(return_value=ToolResult(
+            success=True, output=search_output))
+        mock_llm = AsyncMock(return_value=summary_output)
+
+        async def mock_fs_execute(**kwargs):
+            file_params.update(kwargs)
+            return ToolResult(success=True, output="File written")
+
+        executor = PlanExecutor()
+        with patch("bantz.agent.executor.registry") as mock_reg:
+            mock_fs = MagicMock()
+            mock_fs.execute = mock_fs_execute
+            def _get(name):
+                if name == "web_search":
+                    return MagicMock(execute=mock_search)
+                if name == "filesystem":
+                    return mock_fs
+                return None
+            mock_reg.get = MagicMock(side_effect=_get)
+
+            result = await executor.run(steps, llm_fn=mock_llm)
+
+        assert result.all_success is True
+        assert result.succeeded == 3
+        # process_text LLM received search output via $REF
+        llm_call_msgs = mock_llm.call_args[0][0]
+        assert search_output[:50] in llm_call_msgs[1]["content"]
+        # filesystem received the summary via $REF_STEP_2
+        assert file_params["content"] == summary_output
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 16. Summarizer tool routing (Architect's Revision)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestSummarizerRouting:
+    """process_text/summarizer routes to registered SummarizerTool when available."""
+
+    @pytest.mark.asyncio
+    async def test_process_text_routes_to_summarizer_when_registered(self):
+        """When SummarizerTool is registered, process_text uses it instead of llm_fn."""
+        from bantz.agent.planner import PlanStep
+        from bantz.agent.executor import PlanExecutor
+
+        mock_summarizer = MagicMock()
+        mock_summarizer.execute = AsyncMock(
+            return_value=ToolResult(success=True, output="Summarized via tool"))
+
+        steps = [
+            PlanStep(step=1, tool="process_text",
+                     params={"instruction": "Summarize this"},
+                     description="Summarize"),
+        ]
+
+        mock_llm = AsyncMock(return_value="Should NOT be called")
+
+        executor = PlanExecutor()
+        with patch("bantz.agent.executor.registry") as mock_reg:
+            def _get(name):
+                if name == "summarizer":
+                    return mock_summarizer
+                return None
+            mock_reg.get = MagicMock(side_effect=_get)
+
+            result = await executor.run(steps, llm_fn=mock_llm)
+
+        assert result.all_success is True
+        assert result.step_results[0].output == "Summarized via tool"
+        mock_summarizer.execute.assert_called_once_with(instruction="Summarize this")
+        mock_llm.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_summarizer_tool_name_direct(self):
+        """tool='summarizer' directly → also routes to registered tool."""
+        from bantz.agent.planner import PlanStep
+        from bantz.agent.executor import PlanExecutor
+
+        mock_summarizer = MagicMock()
+        mock_summarizer.execute = AsyncMock(
+            return_value=ToolResult(success=True, output="Done"))
+
+        steps = [
+            PlanStep(step=1, tool="summarizer",
+                     params={"instruction": "Rewrite this"},
+                     description="Rewrite"),
+        ]
+
+        executor = PlanExecutor()
+        with patch("bantz.agent.executor.registry") as mock_reg:
+            def _get(name):
+                if name == "summarizer":
+                    return mock_summarizer
+                return None
+            mock_reg.get = MagicMock(side_effect=_get)
+
+            result = await executor.run(steps)
+
+        assert result.all_success is True
+        assert result.step_results[0].tool == "summarizer"
+
+    @pytest.mark.asyncio
+    async def test_process_text_fallback_when_no_summarizer(self):
+        """Without summarizer in registry, falls back to llm_fn."""
+        from bantz.agent.planner import PlanStep
+        from bantz.agent.executor import PlanExecutor
+
+        steps = [
+            PlanStep(step=1, tool="process_text",
+                     params={"instruction": "Summarize"},
+                     description="Summarize"),
+        ]
+
+        mock_llm = AsyncMock(return_value="Fallback LLM output")
+
+        executor = PlanExecutor()
+        with patch("bantz.agent.executor.registry") as mock_reg:
+            mock_reg.get = MagicMock(return_value=None)
+            result = await executor.run(steps, llm_fn=mock_llm)
+
+        assert result.all_success is True
+        assert result.step_results[0].output == "Fallback LLM output"
+        mock_llm.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_summarizer_not_filtered_by_decompose(self):
+        """Steps with tool='summarizer' must NOT be filtered out."""
+        from bantz.agent.planner import PlannerAgent
+
+        llm_response = json.dumps([
+            {"step": 1, "tool": "web_search", "params": {"query": "AI news"},
+             "description": "Search", "depends_on": None},
+            {"step": 2, "tool": "summarizer",
+             "params": {"instruction": "Summarize: $REF_STEP_1"},
+             "description": "Summarize results", "depends_on": 1},
+        ])
+
+        agent = PlannerAgent()
+        with patch("bantz.core.intent._stream_and_collect", new=AsyncMock(return_value=llm_response)):
+            steps = await agent.decompose(
+                "search AI news and summarize",
+                ["web_search", "filesystem"],
+            )
+
+        assert len(steps) == 2
+        assert steps[1].tool == "summarizer"
+
+    @pytest.mark.asyncio
+    async def test_tool_names_include_summarizer(self):
+        """execute_plan passes 'summarizer' in tool_names to decompose."""
+        from bantz.agent.planner import PlanStep
+        from bantz.agent.executor import PlanExecutionResult
+
+        with patch("bantz.agent.planner.planner_agent") as mock_planner, \
+             patch("bantz.agent.executor.plan_executor") as mock_executor, \
+             patch("bantz.core.routing_engine.data_layer") as mock_dal, \
+             patch("bantz.core.routing_engine.ollama") as mock_ollama, \
+             patch("bantz.core.routing_engine.registry") as mock_registry:
+
+            mock_registry.names.return_value = ["web_search", "filesystem"]
+            mock_planner.decompose = AsyncMock(return_value=[
+                PlanStep(step=1, tool="web_search", params={}, description="X"),
+                PlanStep(step=2, tool="summarizer", params={}, description="Y", depends_on=1),
+            ])
+            mock_planner.format_itinerary = MagicMock(return_value="...")
+            mock_executor.run = AsyncMock(
+                return_value=PlanExecutionResult(step_results=[]))
+            mock_dal.conversations = MagicMock()
+            mock_ollama.chat = AsyncMock()
+
+            from bantz.core.routing_engine import execute_plan
+
+            await execute_plan("test", "test", {})
+
+        call_args = mock_planner.decompose.call_args[0]
+        tool_names = call_args[1]
+        assert "summarizer" in tool_names
+        assert "process_text" in tool_names  # backward compat
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 17. Butler Lore toast notifications (Architect's Revision)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestButlerLoreToasts:
+    """Toast notifications during planner execution."""
+
+    @pytest.mark.asyncio
+    async def test_per_step_toast_emitted(self):
+        """Each step triggers a toast notification."""
+        from bantz.agent.planner import PlanStep
+        from bantz.agent.executor import PlanExecutor
+
+        steps = [
+            PlanStep(step=1, tool="weather", params={"city": "London"},
+                     description="Check London weather"),
+        ]
+
+        mock_weather = AsyncMock(return_value=ToolResult(
+            success=True, output="London: 15°C"))
+
+        toast_calls: list = []
+        original_toast = None
+
+        executor = PlanExecutor()
+        with patch("bantz.agent.executor.registry") as mock_reg, \
+             patch("bantz.agent.executor.notify_toast") as mock_toast:
+            mock_reg.get = MagicMock(
+                return_value=MagicMock(execute=mock_weather))
+            result = await executor.run(steps)
+
+        mock_toast.assert_called()
+        # Should contain step info
+        call_args = mock_toast.call_args_list[0]
+        assert "Step 1" in call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_routing_engine_toast_on_plan_start(self):
+        """execute_plan sends a toast when planning starts."""
+        from bantz.agent.planner import PlanStep
+        from bantz.agent.executor import PlanExecutionResult, StepResult
+
+        with patch("bantz.agent.planner.planner_agent") as mock_planner, \
+             patch("bantz.agent.executor.plan_executor") as mock_executor, \
+             patch("bantz.core.routing_engine.data_layer") as mock_dal, \
+             patch("bantz.core.routing_engine.ollama") as mock_ollama, \
+             patch("bantz.core.notification_manager.notify_toast") as mock_toast:
+
+            mock_planner.decompose = AsyncMock(return_value=[
+                PlanStep(step=1, tool="weather", params={}, description="X"),
+                PlanStep(step=2, tool="news", params={}, description="Y"),
+            ])
+            mock_planner.format_itinerary = MagicMock(return_value="Plan...")
+            mock_executor.run = AsyncMock(return_value=PlanExecutionResult(
+                step_results=[
+                    StepResult(step_number=1, tool="weather",
+                               description="X", success=True, output="ok"),
+                    StepResult(step_number=2, tool="news",
+                               description="Y", success=True, output="ok"),
+                ]))
+            mock_dal.conversations = MagicMock()
+            mock_ollama.chat = AsyncMock()
+
+            from bantz.core.routing_engine import execute_plan
+            await execute_plan("test", "test", {})
+
+        # At least one toast with "itinerary" or "Drafting"
+        toast_texts = [str(c) for c in mock_toast.call_args_list]
+        assert any("Drafting" in t or "itinerary" in t.lower() for t in toast_texts)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 18. PLANNER_SYSTEM — $REF syntax in prompt (Architect's Revision)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestPlannerPromptRefSyntax:
+    """PLANNER_SYSTEM now teaches $REF_STEP_N syntax."""
+
+    def test_prompt_uses_ref_step_syntax(self):
+        from bantz.agent.planner import PLANNER_SYSTEM
+        assert "$REF_STEP_" in PLANNER_SYSTEM
+
+    def test_prompt_has_summarizer_tool(self):
+        from bantz.agent.planner import PLANNER_SYSTEM
+        assert "summarizer" in PLANNER_SYSTEM
+
+    def test_prompt_has_ref_params_syntax(self):
+        from bantz.agent.planner import PLANNER_SYSTEM
+        assert "$REF_STEP_" in PLANNER_SYSTEM
+        assert "_PARAMS_" in PLANNER_SYSTEM
+
+    def test_prompt_has_legacy_compat_note(self):
+        """Prompt must mention legacy {step_N_output} for backward compat."""
+        from bantz.agent.planner import PLANNER_SYSTEM
+        assert "step_N_output" in PLANNER_SYSTEM
+        assert "deprecated" in PLANNER_SYSTEM.lower() or "legacy" in PLANNER_SYSTEM.lower()
+
+    def test_example_uses_ref_syntax(self):
+        """Examples must use $REF_STEP_N, not {step_N_output}."""
+        from bantz.agent.planner import PLANNER_SYSTEM
+        idx = PLANNER_SYSTEM.index("EXAMPLES:")
+        block = PLANNER_SYSTEM[idx:]
+        assert "$REF_STEP_1" in block
+        assert "$REF_STEP_2" in block
+        assert "$REF_STEP_3" in block
 
 


### PR DESCRIPTION
## Architect's Revision — Plan-and-Solve Planner

### 🚨 1. $REF_STEP_N Dict-Level Variable Binding
Replaces naive `{step_N_output}` string interpolation with Python object-level resolution. When an entire param value is `$REF_STEP_N`, the raw output is assigned at the dict level — **no JSON corruption** from special characters, quotes, or newlines in step outputs. Inline refs fall back to capped (2000 char) string substitution. Legacy `{step_N_*}` syntax fully preserved for backward compat.

### 🚨 2. SummarizerTool (replaces virtual process_text)
New registered `BaseTool` at `src/bantz/tools/summarizer.py` with:
- Focused `_SUMMARIZER_SYSTEM` prompt (no open-ended generation)
- Citation preservation (Telegraph References)
- Anti-hallucination guards
- Gemini Flash → Ollama fallback
- `process_text` aliased to `summarizer`; old `llm_fn` fallback kept for backward compat

### 💡 3. Butler Lore Toasts
Per-step toast notifications via `notification_manager` during planner execution. Routing engine emits toasts on plan start and completion.

### 📝 4. PLANNER_SYSTEM Prompt Update
- Teaches `$REF_STEP_N` / `$REF_STEP_N_PARAMS_KEY` syntax
- References `summarizer` tool instead of `process_text`
- Updated all examples and rules

### Files Changed
| File | Change |
|------|--------|
| `src/bantz/tools/summarizer.py` | **NEW** — SummarizerTool BaseTool |
| `src/bantz/agent/executor.py` | $REF patterns, summarizer routing, Butler toasts |
| `src/bantz/agent/planner.py` | PLANNER_SYSTEM prompt, virtual tools set |
| `src/bantz/core/brain.py` | Import summarizer tool |
| `src/bantz/core/routing_engine.py` | tool_names + Butler Lore toasts |
| `tests/agent/test_planner.py` | 91 tests (71 updated + 20 new) |

### Test Results
```
2980 passed, 3 pre-existing failures (unchanged), 0 new regressions
Bonus: fixed pre-existing test_anti_leakage_rule failure
```