### PR TITLE
fix: Voice Feedback Loop & TUI Integration Audit

### DIFF
--- a/src/bantz/agent/ghost_loop.py
+++ b/src/bantz/agent/ghost_loop.py
@@ -161,7 +161,7 @@ class GhostLoop:
                 from bantz.agent.wake_word import wake_listener
                 wake_listener.pause()
                 import time
-                time.sleep(0.15)  # give ALSA a moment to release the device
+                time.sleep(0.30)  # give ALSA time to fully release the device
             except Exception as exc:
                 log.debug("Ghost Loop: could not pause wake word — %s", exc)
 
@@ -174,7 +174,10 @@ class GhostLoop:
 
             if not pcm_bytes:
                 log.info("Ghost Loop: no audio captured")
-                bus.emit_threadsafe("ghost_loop_idle")
+                bus.emit_threadsafe(
+                    "voice_no_speech",
+                    reason="no_audio",
+                )
                 return
 
             # 3. Emit "transcribing" event
@@ -186,7 +189,10 @@ class GhostLoop:
 
             if not text:
                 log.info("Ghost Loop: STT returned empty")
-                bus.emit_threadsafe("ghost_loop_idle")
+                bus.emit_threadsafe(
+                    "voice_no_speech",
+                    reason="empty_transcription",
+                )
                 return
 
             self._total_transcriptions += 1
@@ -199,6 +205,10 @@ class GhostLoop:
 
         except Exception as exc:
             log.error("Ghost Loop: pipeline error — %s", exc)
+            bus.emit_threadsafe(
+                "voice_no_speech",
+                reason=f"pipeline_error: {exc}",
+            )
         finally:
             self._busy = False
             # Resume wake word listener so it re-acquires the mic

--- a/src/bantz/interface/tui/app.py
+++ b/src/bantz/interface/tui/app.py
@@ -44,9 +44,6 @@ _STYLES_PATH = Path(__file__).parent / "styles.tcss"
 
 # ── Messages ────────────────────────────────────────────────────────
 
-class WakeWordDetected(Message):
-    """Fired (from the audio thread via call_from_thread) when the user says the wake word."""
-
 
 class BantzEventMessage(Message):
     """Bridges EventBus → Textual main thread (#220, Sprint 3 Part 3).
@@ -333,21 +330,27 @@ class BantzApp(App):
                 except Exception:
                     pass
 
-                # Fallback: render directly to chat
+                # Fallback: render directly to chat (thread-safe)
+                def _show_observer_fallback(ev=event) -> None:
+                    try:
+                        chat = self.query_one("#chat-log", ChatLog)
+                        if ev.severity == Severity.CRITICAL:
+                            icon = "\U0001f6a8"  # 🚨
+                            msg = f"{icon} **Terminal Error Detected**\n```\n{ev.raw_text[:500]}\n```"
+                            if ev.analysis:
+                                msg += f"\n\n**Analysis:** {ev.analysis}"
+                            chat.add_error(msg)
+                        elif ev.severity == Severity.WARNING:
+                            icon = "\u26a0\ufe0f"  # ⚠️
+                            chat.add_system(f"{icon} stderr: {ev.raw_text[:200]}")
+                        else:
+                            chat.add_system(f"\u2139\ufe0f stderr: {ev.raw_text[:120]}")
+                        chat.scroll_end()
+                    except Exception:
+                        pass
+
                 try:
-                    chat = self.query_one("#chat-log", ChatLog)
-                    if event.severity == Severity.CRITICAL:
-                        icon = "\U0001f6a8"  # 🚨
-                        msg = f"{icon} **Terminal Error Detected**\n```\n{event.raw_text[:500]}\n```"
-                        if event.analysis:
-                            msg += f"\n\n**Analysis:** {event.analysis}"
-                        chat.add_error(msg)
-                    elif event.severity == Severity.WARNING:
-                        icon = "\u26a0\ufe0f"  # ⚠️
-                        chat.add_system(f"{icon} stderr: {event.raw_text[:200]}")
-                    else:
-                        chat.add_system(f"\u2139\ufe0f stderr: {event.raw_text[:120]}")
-                    chat.scroll_end()
+                    self.call_from_thread(_show_observer_fallback)
                 except Exception:
                     pass
 
@@ -780,6 +783,8 @@ class BantzApp(App):
         if result.needs_confirm:
             self._pending = result
             chat.add_bantz(result.response)
+        elif not result.response or not result.response.strip():
+            chat.add_system("🤔 I processed your message but had nothing to say. Try rephrasing?")
         else:
             if result.tool_used:
                 chat.add_tool(result.tool_used)
@@ -1048,12 +1053,16 @@ class BantzApp(App):
         bus.on("ghost_loop_listening", self._bus_relay)
         bus.on("ghost_loop_transcribing", self._bus_relay)
         bus.on("ghost_loop_idle", self._bus_relay)
+        bus.on("voice_no_speech", self._bus_relay)
+        bus.on("stt_model_loading", self._bus_relay)
+        bus.on("stt_model_ready", self._bus_relay)
+        bus.on("stt_model_failed", self._bus_relay)
         bus.on("thinking_start", self._bus_relay)
         bus.on("thinking_token", self._bus_relay)
         bus.on("thinking_done", self._bus_relay)
         bus.on("planner_step", self._bus_relay)
 
-        log.debug("EventBus → TUI bridge active (11 subscriptions)")
+        log.debug("EventBus → TUI bridge active (15 subscriptions)")
 
     def _relay_bus_event(self, event: Event) -> None:
         """Relay a single bus Event into the Textual message loop.
@@ -1066,7 +1075,7 @@ class BantzApp(App):
             self.call_from_thread(self.post_message, BantzEventMessage(event))
         except Exception:
             # App shutting down or not yet mounted — silently discard
-            pass
+            log.debug("Bus relay failed for event: %s", event.name)
 
     def _unsubscribe_event_bus(self) -> None:
         """Remove all bus subscriptions (called on quit)."""
@@ -1079,6 +1088,10 @@ class BantzApp(App):
             bus.off("ghost_loop_listening", relay)
             bus.off("ghost_loop_transcribing", relay)
             bus.off("ghost_loop_idle", relay)
+            bus.off("voice_no_speech", relay)
+            bus.off("stt_model_loading", relay)
+            bus.off("stt_model_ready", relay)
+            bus.off("stt_model_failed", relay)
             bus.off("thinking_start", relay)
             bus.off("thinking_token", relay)
             bus.off("thinking_done", relay)
@@ -1106,6 +1119,14 @@ class BantzApp(App):
                 self._on_bus_ghost_transcribing(event)
             elif name == "ghost_loop_idle":
                 self._on_bus_ghost_idle(event)
+            elif name == "voice_no_speech":
+                self._on_bus_voice_no_speech(event)
+            elif name == "stt_model_loading":
+                self._on_bus_stt_model_loading(event)
+            elif name == "stt_model_ready":
+                self._on_bus_stt_model_ready(event)
+            elif name == "stt_model_failed":
+                self._on_bus_stt_model_failed(event)
             elif name == "thinking_start":
                 self._on_bus_thinking_start(event)
             elif name == "thinking_token":
@@ -1114,6 +1135,8 @@ class BantzApp(App):
                 self._on_bus_thinking_done(event)
             elif name == "planner_step":
                 self._on_bus_planner_step(event)
+            else:
+                log.debug("Unhandled bus event: %s", name)
         except Exception:
             log.debug("on_bantz_event_message(%s) error", name, exc_info=True)
 
@@ -1201,6 +1224,11 @@ class BantzApp(App):
         if not text:
             return
 
+        # Guard against concurrent voice + typed input processing
+        if self._busy:
+            log.debug("TUI: voice_input ignored — already processing")
+            return
+
         chat = self.query_one("#chat-log", ChatLog)
         chat.add_user(f"🎤 {text}")
         chat.scroll_end()
@@ -1229,6 +1257,50 @@ class BantzApp(App):
     def _on_bus_ghost_idle(self, event: Event) -> None:
         """Ghost Loop returned to idle — no visual action needed."""
         pass
+
+    def _on_bus_voice_no_speech(self, event: Event) -> None:
+        """Ghost Loop couldn't capture or transcribe speech → tell user."""
+        try:
+            chat = self.query_one("#chat-log", ChatLog)
+            reason = event.data.get("reason", "")
+            if "no_audio" in reason:
+                chat.add_system("🤔 I didn't catch that — no speech detected.")
+            elif "empty_transcription" in reason:
+                chat.add_system("🤔 I heard something but couldn't make it out.")
+            else:
+                chat.add_system("🤔 Something went wrong — try again.")
+            chat.add_system("Say \"Hey Bantz\" to try again.")
+            chat.scroll_end()
+        except Exception:
+            pass
+
+    def _on_bus_stt_model_loading(self, event: Event) -> None:
+        """STT model is being downloaded/loaded → show indicator."""
+        try:
+            chat = self.query_one("#chat-log", ChatLog)
+            chat.add_system("⏳ Loading speech recognition model (first time may take a minute)...")
+            chat.scroll_end()
+        except Exception:
+            pass
+
+    def _on_bus_stt_model_ready(self, event: Event) -> None:
+        """STT model loaded → confirm."""
+        try:
+            chat = self.query_one("#chat-log", ChatLog)
+            chat.add_system("✅ Speech recognition ready.")
+            chat.scroll_end()
+        except Exception:
+            pass
+
+    def _on_bus_stt_model_failed(self, event: Event) -> None:
+        """STT model failed to load → warn user."""
+        try:
+            chat = self.query_one("#chat-log", ChatLog)
+            error = event.data.get("error", "unknown error")
+            chat.add_error(f"❌ Speech recognition failed to load: {error}")
+            chat.scroll_end()
+        except Exception:
+            pass
 
     def _start_ghost_loop(self) -> None:
         """Start the Ghost Loop if enabled (#36)."""
@@ -1269,21 +1341,6 @@ class BantzApp(App):
                 chat.add_system("Wake Word: listening for \"Hey Bantz\"")
         except Exception as exc:
             log.debug("Wake word start failed: %s", exc)
-
-    def on_wake_word_detected(self, _msg: WakeWordDetected) -> None:
-        """Handle wake word detection — focus input + notify user.
-
-        .. deprecated:: Sprint 3 Part 3
-           Kept for backward compat.  Primary path is now
-           ``on_bantz_event_message`` → ``_on_bus_wake_word``.
-        """
-        try:
-            chat = self.query_one("#chat-log", ChatLog)
-            chat.add_bantz("Yes boss? 🎤")
-            chat.scroll_end()
-            self.query_one("#chat-input", Input).focus()
-        except Exception as exc:
-            log.debug("Wake word handler error: %s", exc)
 
 
 def run() -> None:

--- a/tests/agent/test_ghost_loop.py
+++ b/tests/agent/test_ghost_loop.py
@@ -382,10 +382,15 @@ class TestGhostLoopPipeline:
             with patch("bantz.agent.voice_capture.voice_capture", mock_vc):
                 gl._capture_and_transcribe()
         assert gl._busy is False
-        # Should have emitted listening + idle
+        # Should have emitted listening + voice_no_speech + idle
         calls = [c[0][0] for c in mock_bus.emit_threadsafe.call_args_list]
         assert "ghost_loop_listening" in calls
+        assert "voice_no_speech" in calls
         assert "ghost_loop_idle" in calls
+        # voice_no_speech should include reason
+        no_speech = [c for c in mock_bus.emit_threadsafe.call_args_list
+                     if c[0][0] == "voice_no_speech"]
+        assert no_speech[0][1]["reason"] == "no_audio"
 
     def test_pipeline_successful_transcription(self):
         from bantz.agent.ghost_loop import GhostLoop
@@ -420,9 +425,38 @@ class TestGhostLoopPipeline:
                 with patch("bantz.agent.stt.stt_engine", mock_stt):
                     gl._capture_and_transcribe()
         assert gl._total_transcriptions == 0
-        # voice_input should NOT have been emitted
+        # voice_input should NOT have been emitted, but voice_no_speech SHOULD
         emit_names = [c[0][0] for c in mock_bus.emit_threadsafe.call_args_list]
         assert "voice_input" not in emit_names
+        assert "voice_no_speech" in emit_names
+        no_speech = [c for c in mock_bus.emit_threadsafe.call_args_list
+                     if c[0][0] == "voice_no_speech"]
+        assert no_speech[0][1]["reason"] == "empty_transcription"
+
+    def test_pipeline_exception_emits_voice_no_speech(self):
+        """Pipeline exceptions should emit voice_no_speech with error info."""
+        from bantz.agent.ghost_loop import GhostLoop
+        gl = GhostLoop()
+        mock_vc = MagicMock()
+        mock_vc.capture.side_effect = RuntimeError("mic exploded")
+        mock_bus = MagicMock()
+        with patch("bantz.agent.ghost_loop.bus", mock_bus):
+            with patch("bantz.agent.voice_capture.voice_capture", mock_vc):
+                gl._capture_and_transcribe()
+        assert gl._busy is False
+        emit_names = [c[0][0] for c in mock_bus.emit_threadsafe.call_args_list]
+        assert "voice_no_speech" in emit_names
+        no_speech = [c for c in mock_bus.emit_threadsafe.call_args_list
+                     if c[0][0] == "voice_no_speech"]
+        assert "pipeline_error" in no_speech[0][1]["reason"]
+
+    def test_pipeline_alsa_release_sleep(self):
+        """Pipeline should sleep ≥0.25s after pausing wake word for ALSA."""
+        import inspect
+        from bantz.agent.ghost_loop import GhostLoop
+        src = inspect.getsource(GhostLoop._capture_and_transcribe)
+        # Verify the sleep is at least 0.25s (we set it to 0.30)
+        assert "time.sleep(0.30)" in src or "time.sleep(0.3)" in src
 
 
 class TestGhostLoopDiagnose:
@@ -458,6 +492,10 @@ class TestTUIEventSubscriptions:
         assert 'bus.on("ghost_loop_listening"' in src
         assert 'bus.on("ghost_loop_transcribing"' in src
         assert 'bus.on("ghost_loop_idle"' in src
+        assert 'bus.on("voice_no_speech"' in src
+        assert 'bus.on("stt_model_loading"' in src
+        assert 'bus.on("stt_model_ready"' in src
+        assert 'bus.on("stt_model_failed"' in src
 
     def test_unsubscribe_has_voice_events(self):
         """_unsubscribe_event_bus must unsubscribe from ghost loop events."""
@@ -468,6 +506,10 @@ class TestTUIEventSubscriptions:
         assert 'bus.off("ghost_loop_listening"' in src
         assert 'bus.off("ghost_loop_transcribing"' in src
         assert 'bus.off("ghost_loop_idle"' in src
+        assert 'bus.off("voice_no_speech"' in src
+        assert 'bus.off("stt_model_loading"' in src
+        assert 'bus.off("stt_model_ready"' in src
+        assert 'bus.off("stt_model_failed"' in src
 
     def test_event_dispatch_has_voice_input(self):
         """on_bantz_event_message must dispatch voice_input events."""
@@ -477,6 +519,8 @@ class TestTUIEventSubscriptions:
         assert '"voice_input"' in src
         assert '"ghost_loop_listening"' in src
         assert '"ghost_loop_transcribing"' in src
+        assert '"voice_no_speech"' in src
+        assert '"stt_model_loading"' in src
 
     def test_voice_input_handler_exists(self):
         """BantzApp must have _on_bus_voice_input method."""
@@ -491,6 +535,39 @@ class TestTUIEventSubscriptions:
     def test_ghost_transcribing_handler_exists(self):
         from bantz.interface.tui.app import BantzApp
         assert hasattr(BantzApp, "_on_bus_ghost_transcribing")
+
+    def test_voice_no_speech_handler_exists(self):
+        from bantz.interface.tui.app import BantzApp
+        assert hasattr(BantzApp, "_on_bus_voice_no_speech")
+        assert callable(getattr(BantzApp, "_on_bus_voice_no_speech"))
+
+    def test_stt_model_loading_handler_exists(self):
+        from bantz.interface.tui.app import BantzApp
+        assert hasattr(BantzApp, "_on_bus_stt_model_loading")
+        assert callable(getattr(BantzApp, "_on_bus_stt_model_loading"))
+
+    def test_stt_model_ready_handler_exists(self):
+        from bantz.interface.tui.app import BantzApp
+        assert hasattr(BantzApp, "_on_bus_stt_model_ready")
+        assert callable(getattr(BantzApp, "_on_bus_stt_model_ready"))
+
+    def test_stt_model_failed_handler_exists(self):
+        from bantz.interface.tui.app import BantzApp
+        assert hasattr(BantzApp, "_on_bus_stt_model_failed")
+        assert callable(getattr(BantzApp, "_on_bus_stt_model_failed"))
+
+    def test_voice_input_handler_has_busy_guard(self):
+        """_on_bus_voice_input must check _busy before processing."""
+        import inspect
+        from bantz.interface.tui.app import BantzApp
+        src = inspect.getsource(BantzApp._on_bus_voice_input)
+        assert "_busy" in src
+
+    def test_legacy_wake_word_message_removed(self):
+        """The dead WakeWordDetected message class should no longer exist."""
+        from bantz.interface import tui
+        from bantz.interface.tui import app as tui_app
+        assert not hasattr(tui_app, "WakeWordDetected")
 
     def test_start_ghost_loop_method_exists(self):
         from bantz.interface.tui.app import BantzApp

--- a/tests/agent/test_wake_word.py
+++ b/tests/agent/test_wake_word.py
@@ -431,14 +431,15 @@ class TestDoctorSection:
 # ═══════════════════════════════════════════════════════════════════════════
 
 class TestTUIMessage:
-    def test_wake_word_detected_message_exists(self):
-        from bantz.interface.tui.app import WakeWordDetected
-        msg = WakeWordDetected()
-        assert msg is not None
+    def test_wake_word_detected_legacy_removed(self):
+        """WakeWordDetected legacy Message was removed — bus path is canonical."""
+        from bantz.interface.tui import app as tui_app
+        assert not hasattr(tui_app, "WakeWordDetected")
 
-    def test_app_has_handler(self):
+    def test_app_has_bus_wake_handler(self):
+        """BantzApp should handle wake_word via the EventBus bridge."""
         from bantz.interface.tui.app import BantzApp
-        assert hasattr(BantzApp, "on_wake_word_detected")
+        assert hasattr(BantzApp, "_on_bus_wake_word")
 
     def test_app_has_start_wake_word(self):
         from bantz.interface.tui.app import BantzApp

--- a/tests/tui/test_event_bridge.py
+++ b/tests/tui/test_event_bridge.py
@@ -62,18 +62,19 @@ class TestBantzEventMessage:
 
 
 # ═══════════════════════════════════════════════════════════════════════════
-# 2. WakeWordDetected (legacy, backward compat)
+# 2. WakeWordDetected (removed — legacy dead code cleaned up)
 # ═══════════════════════════════════════════════════════════════════════════
 
 class TestWakeWordDetectedLegacy:
-    def test_still_importable(self):
-        from bantz.interface.tui.app import WakeWordDetected
-        assert WakeWordDetected is not None
+    def test_legacy_class_removed(self):
+        """WakeWordDetected was dead code — verify it's been removed."""
+        from bantz.interface.tui import app as tui_app
+        assert not hasattr(tui_app, "WakeWordDetected")
 
-    def test_is_message(self):
-        from bantz.interface.tui.app import WakeWordDetected
-        from textual.message import Message
-        assert issubclass(WakeWordDetected, Message)
+    def test_bus_wake_handler_exists(self):
+        """The canonical wake word handler is via EventBus bridge."""
+        from bantz.interface.tui.app import BantzApp
+        assert hasattr(BantzApp, "_on_bus_wake_word")
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -103,6 +104,10 @@ class TestSubscribeEventBus:
             assert test_bus.subscriber_count("ghost_loop_listening") == 1
             assert test_bus.subscriber_count("ghost_loop_transcribing") == 1
             assert test_bus.subscriber_count("ghost_loop_idle") == 1
+            assert test_bus.subscriber_count("voice_no_speech") == 1
+            assert test_bus.subscriber_count("stt_model_loading") == 1
+            assert test_bus.subscriber_count("stt_model_ready") == 1
+            assert test_bus.subscriber_count("stt_model_failed") == 1
 
     def test_calls_bind_loop(self):
         app = self._make_app()
@@ -140,7 +145,7 @@ class TestUnsubscribeEventBus:
         test_bus.bind_loop = MagicMock()
         with patch("bantz.interface.tui.app.bus", test_bus):
             app._subscribe_event_bus()
-            assert test_bus.subscriber_count() == 11
+            assert test_bus.subscriber_count() == 15
             app._unsubscribe_event_bus()
             assert test_bus.subscriber_count("wake_word_detected") == 0
             assert test_bus.subscriber_count("ambient_change") == 0
@@ -149,6 +154,10 @@ class TestUnsubscribeEventBus:
             assert test_bus.subscriber_count("ghost_loop_listening") == 0
             assert test_bus.subscriber_count("ghost_loop_transcribing") == 0
             assert test_bus.subscriber_count("ghost_loop_idle") == 0
+            assert test_bus.subscriber_count("voice_no_speech") == 0
+            assert test_bus.subscriber_count("stt_model_loading") == 0
+            assert test_bus.subscriber_count("stt_model_ready") == 0
+            assert test_bus.subscriber_count("stt_model_failed") == 0
             assert test_bus.subscriber_count("thinking_start") == 0
             assert test_bus.subscriber_count("thinking_token") == 0
             assert test_bus.subscriber_count("thinking_done") == 0
@@ -479,19 +488,17 @@ class TestSourceAudit:
 
     def test_no_on_wake_closure_in_start_listener(self):
         """The legacy _on_wake closure must be gone from _start_wake_word_listener."""
-        # Find the method body
-        start = self.src.index("def _start_wake_word_listener")
-        # Find next def at same indent
-        next_def = self.src.index("\n    def ", start + 1)
-        method_body = self.src[start:next_def]
+        import inspect
+        from bantz.interface.tui.app import BantzApp
+        method_body = inspect.getsource(BantzApp._start_wake_word_listener)
         assert "def _on_wake()" not in method_body
         assert "on_wake=_on_wake" not in method_body
 
     def test_wake_listener_start_no_callback(self):
         """wake_listener.start() should be called without on_wake arg."""
-        start = self.src.index("def _start_wake_word_listener")
-        next_def = self.src.index("\n    def ", start + 1)
-        method_body = self.src[start:next_def]
+        import inspect
+        from bantz.interface.tui.app import BantzApp
+        method_body = inspect.getsource(BantzApp._start_wake_word_listener)
         assert "wake_listener.start()" in method_body
 
     def test_three_bus_subscriptions(self):


### PR DESCRIPTION
## Summary

Fixes the **"doesn't listen after wake word"** bug and addresses findings from a comprehensive TUI/brain integration audit.

### Root Cause
When the wake word ("Hey Bantz") was detected, the Ghost Loop would:
1. Show "🎙️ Listening..." in the TUI
2. Attempt to capture audio via VoiceCapture
3. If no speech was detected or STT returned empty → **silently return to idle**

The user saw "Yes boss? 🎤" then "🎙️ Listening..." then... nothing. It looked like the system ignored them.

### Voice Pipeline Fixes
- **`ghost_loop.py`**: Emit new `voice_no_speech` event (with reason) when capture/STT fails — replaces silent return
- **`ghost_loop.py`**: Increase ALSA release sleep from 0.15s → 0.30s for reliable mic handoff
- **`ghost_loop.py`**: Emit `voice_no_speech` with error details on pipeline exceptions

### TUI Integration Improvements  
- Subscribe to `voice_no_speech` → show "🤔 I didn't catch that" feedback
- Subscribe to `stt_model_loading/ready/failed` → show STT model status during first-time download
- Add `_busy` guard on `_on_bus_voice_input` to prevent concurrent voice+typed processing
- **Fix critical thread safety bug**: Observer `_on_error` fallback now wraps widget access in `call_from_thread` (was: direct access from non-main thread → potential `ThreadError`)
- Guard empty non-streaming brain responses
- Add `else` log for unhandled bus events in dispatch chain
- Improve `_relay_bus_event` to log on failure instead of silent pass

### Dead Code Cleanup
- Remove `WakeWordDetected` legacy Message class (never posted)
- Remove `on_wake_word_detected` legacy handler (duplicated `_on_bus_wake_word`)

### Test Results
```
2988 passed, 31 skipped, 3 pre-existing failures
```
+7 new tests covering voice_no_speech events, pipeline error handling, ALSA timing, handler existence, busy guard, and legacy removal.