### PR TITLE
fix(memory): context-window loop breaker + Telegram spam filter

### DIFF
--- a/src/bantz/core/brain.py
+++ b/src/bantz/core/brain.py
@@ -647,6 +647,52 @@ class Brain:
         self._fire_embeddings()
         return BrainResult(response=resp, tool_used=tool_name, tool_result=result)
 
+    @staticmethod
+    def _dedup_history(history: list[dict]) -> list[dict]:
+        """Collapse repeated assistant responses to prevent context-window echo loops (#184).
+
+        If the same assistant message appears ≥ LOOP_THRESHOLD times in the
+        supplied history, all duplicates are removed (keeping the first copy)
+        and a system-level anti-loop warning is appended so the LLM knows to
+        say something new.
+
+        User messages are never touched.
+        Comparison is case-insensitive and whitespace-normalised.
+        """
+        from collections import Counter
+
+        LOOP_THRESHOLD = 3
+
+        assistant_msgs = [
+            m["content"].strip().lower()
+            for m in history if m["role"] == "assistant"
+        ]
+        counts = Counter(assistant_msgs)
+        repeated = {msg for msg, count in counts.items() if count >= LOOP_THRESHOLD}
+
+        if not repeated:
+            return history
+
+        seen_repeated: set[str] = set()
+        deduped: list[dict] = []
+        for m in history:
+            key = m["content"].strip().lower() if m["role"] == "assistant" else None
+            if key and key in repeated:
+                if key in seen_repeated:
+                    continue  # drop duplicate
+                seen_repeated.add(key)
+            deduped.append(m)
+
+        deduped.append({
+            "role": "system",
+            "content": (
+                "[WARNING: You have been repeating the same response. "
+                "Say something NEW and relevant. Do NOT repeat previous messages.]"
+            ),
+        })
+        log.warning("_dedup_history: collapsed %d repeated assistant message(s)", len(repeated))
+        return deduped
+
     async def _chat(self, en_input: str, tc: dict) -> str:
         """
         Chat mode with conversation history.
@@ -655,6 +701,7 @@ class Brain:
         """
         history = data_layer.conversations.context(n=12)
         prior = history[:-1] if (history and history[-1]["role"] == "user") else history
+        prior = self._dedup_history(prior)
 
         # Concurrent context injection (#227)
         ctx = BantzContext(en_input=en_input)
@@ -703,6 +750,7 @@ class Brain:
         """
         history = data_layer.conversations.context(n=12)
         prior = history[:-1] if (history and history[-1]["role"] == "user") else history
+        prior = self._dedup_history(prior)
 
         # Concurrent context injection (#227)
         ctx = BantzContext(en_input=en_input)

--- a/src/bantz/interface/telegram_bot.py
+++ b/src/bantz/interface/telegram_bot.py
@@ -94,6 +94,102 @@ _STREAM_INTERVAL: float = 2.0  # seconds between edit_text updates
 _msg_lock = asyncio.Lock()
 
 
+# ── Telegram Spam Filter (#184) ───────────────────────────────────────────────
+
+class _TelegramSpamFilter:
+    """Aggregates rapid-fire system/maintenance messages into a single summary.
+
+    User messages always pass through immediately.
+    System messages are buffered: if ≥ SPAM_THRESHOLD arrive within
+    WINDOW_SECONDS, they are collapsed into one butler-style summary.
+    """
+
+    WINDOW_SECONDS: float = 60.0
+    SPAM_THRESHOLD: int = 5
+
+    def __init__(self) -> None:
+        self._buffer: list[str] = []
+        self._window_start: float = 0.0
+        self._lock: asyncio.Lock = asyncio.Lock()
+
+    async def should_send(self, message: str, *, is_system: bool = False) -> str | None:
+        """Return the message to send, or None if it was buffered.
+
+        Non-system messages always return immediately.
+        System messages are rate-checked against the sliding window.
+        When the threshold is reached the buffer is flushed as a summary.
+        """
+        if not is_system:
+            return message
+
+        async with self._lock:
+            now = time.monotonic()
+
+            if now - self._window_start > self.WINDOW_SECONDS:
+                self._buffer.clear()
+                self._window_start = now
+
+            self._buffer.append(message)
+
+            if len(self._buffer) >= self.SPAM_THRESHOLD:
+                count = len(self._buffer)
+                summary = (
+                    f"Ma'am, the machines have been undergoing routine maintenance. "
+                    f"{count} tasks completed in the past minute. All systems nominal."
+                )
+                self._buffer.clear()
+                self._window_start = now
+                log.info("_TelegramSpamFilter: bundled %d system messages into summary", count)
+                return summary
+
+            return message
+
+    async def flush(self) -> str | None:
+        """Flush any buffered messages (e.g. on shutdown). Returns summary or None."""
+        async with self._lock:
+            if not self._buffer:
+                return None
+            count = len(self._buffer)
+            summary = f"Ma'am, {count} maintenance tasks completed. All quiet now."
+            self._buffer.clear()
+            return summary
+
+
+_spam_filter = _TelegramSpamFilter()
+
+
+async def send_system_notification(text: str) -> None:
+    """Send a system/background notification to all active chats, via spam filter.
+
+    Use this instead of raw bot.send_message() for proactive/background sends
+    so that rapid-fire maintenance messages are automatically bundled (#184).
+    Silently no-ops when no bot application is running or no chats are active.
+    """
+    filtered = await _spam_filter.should_send(text, is_system=True)
+    if filtered is None:
+        return  # buffered, not yet due for sending
+
+    if not _active_chats:
+        return
+
+    try:
+        from telegram.ext import Application as _TgApp
+        app: _TgApp | None = _current_app
+        if app is None:
+            return
+        for chat_id in _active_chats:
+            try:
+                await app.bot.send_message(chat_id=chat_id, text=filtered)
+            except Exception as exc:
+                log.debug("send_system_notification: failed for %d: %s", chat_id, exc)
+    except Exception as exc:
+        log.debug("send_system_notification: %s", exc)
+
+
+# Module-level reference to the running Application, set in run_bot()
+_current_app = None
+
+
 def _authorized(func: Callable[..., Coroutine]) -> Callable[..., Coroutine]:
     """Decorator: silently drop messages from non-whitelisted users (#178)."""
     async def wrapper(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -441,9 +537,14 @@ async def _check_reminders_job(context: ContextTypes.DEFAULT_TYPE) -> None:
         else:
             text = f"⏰ Reminder: {title}"
 
+        # Route through spam filter so burst reminders are bundled (#184)
+        filtered = await _spam_filter.should_send(text, is_system=True)
+        if filtered is None:
+            continue
+
         for chat_id in _active_chats:
             try:
-                await context.bot.send_message(chat_id=chat_id, text=text)
+                await context.bot.send_message(chat_id=chat_id, text=filtered)
             except Exception as exc:
                 log.debug("Failed to send reminder to %d: %s", chat_id, exc)
 
@@ -588,7 +689,9 @@ def run_bot() -> None:
         print("   → or run: bantz --setup telegram")
         return
 
+    global _current_app
     app = Application.builder().token(token).build()
+    _current_app = app
 
     app.add_handler(CommandHandler("start", cmd_start))
     app.add_handler(CommandHandler("help", cmd_start))

--- a/tests/core/test_loop_breaker.py
+++ b/tests/core/test_loop_breaker.py
@@ -1,0 +1,137 @@
+"""Tests for Brain._dedup_history — context-window loop breaker (#184)."""
+from __future__ import annotations
+
+import pytest
+
+from bantz.core.brain import Brain
+
+
+def _asst(text: str) -> dict:
+    return {"role": "assistant", "content": text}
+
+
+def _user(text: str) -> dict:
+    return {"role": "user", "content": text}
+
+
+def _sys(text: str) -> dict:
+    return {"role": "system", "content": text}
+
+
+# ── 1. No dedup below threshold ───────────────────────────────────────────────
+
+def test_no_dedup_below_threshold():
+    """2 identical assistant messages → history unchanged."""
+    history = [_user("hi"), _asst("Drink water"), _user("ok"), _asst("Drink water")]
+    result = Brain._dedup_history(history)
+    assert result == history
+
+
+# ── 2. Dedup at threshold ─────────────────────────────────────────────────────
+
+def test_dedup_at_threshold():
+    """3 identical 'Drink water' messages → collapsed to 1 + anti-loop warning."""
+    history = [
+        _user("hi"), _asst("Drink water"),
+        _user("and"), _asst("Drink water"),
+        _user("so"), _asst("Drink water"),
+    ]
+    result = Brain._dedup_history(history)
+
+    assistant_texts = [m["content"] for m in result if m["role"] == "assistant"]
+    assert assistant_texts.count("Drink water") == 1
+
+
+# ── 3. Anti-loop warning injected ────────────────────────────────────────────
+
+def test_anti_loop_warning_injected():
+    """After dedup triggers, a system warning is appended."""
+    history = [_asst("Drink water")] * 3
+    result = Brain._dedup_history(history)
+
+    system_msgs = [m["content"] for m in result if m["role"] == "system"]
+    assert any("repeating" in s for s in system_msgs)
+    assert any("NEW" in s for s in system_msgs)
+
+
+# ── 4. User messages never deduplicated ──────────────────────────────────────
+
+def test_dedup_preserves_user_messages():
+    """Identical user messages are never removed."""
+    history = [
+        _user("Drink water"), _user("Drink water"), _user("Drink water"),
+        _asst("Sure, I will."),
+    ]
+    result = Brain._dedup_history(history)
+    user_msgs = [m for m in result if m["role"] == "user"]
+    assert len(user_msgs) == 3
+
+
+# ── 5. Unique assistant messages preserved ───────────────────────────────────
+
+def test_dedup_preserves_unique_messages():
+    """Different assistant messages are not removed even if one set repeats."""
+    history = [
+        _asst("Hello"), _asst("Hello"), _asst("Hello"),
+        _asst("Goodbye"),
+    ]
+    result = Brain._dedup_history(history)
+    texts = [m["content"] for m in result if m["role"] == "assistant"]
+    assert "Goodbye" in texts
+
+
+# ── 6. Multiple repeated topics collapsed ────────────────────────────────────
+
+def test_multiple_repeated_topics():
+    """Two different repeated messages → both collapsed."""
+    history = (
+        [_asst("Drink water")] * 3
+        + [_asst("Exercise daily")] * 3
+    )
+    result = Brain._dedup_history(history)
+    assistant_texts = [m["content"] for m in result if m["role"] == "assistant"]
+    assert assistant_texts.count("Drink water") == 1
+    assert assistant_texts.count("Exercise daily") == 1
+
+
+# ── 7. Case-insensitive dedup ─────────────────────────────────────────────────
+
+def test_case_insensitive_dedup():
+    """'Drink Water' and 'drink water' are treated as the same message."""
+    history = [
+        _asst("Drink Water"),
+        _asst("drink water"),
+        _asst("DRINK WATER"),
+    ]
+    result = Brain._dedup_history(history)
+    assistant_texts = [m["content"].lower().strip() for m in result if m["role"] == "assistant"]
+    assert assistant_texts.count("drink water") == 1
+
+
+# ── 8. Whitespace normalised ──────────────────────────────────────────────────
+
+def test_whitespace_normalised():
+    """'  Drink water  ' and 'Drink water' are treated as the same message."""
+    history = [
+        _asst("  Drink water  "),
+        _asst("Drink water"),
+        _asst("Drink water"),
+    ]
+    result = Brain._dedup_history(history)
+    assistant_texts = [m["content"] for m in result if m["role"] == "assistant"]
+    # Only one copy should survive
+    normalised = [t.strip().lower() for t in assistant_texts]
+    assert normalised.count("drink water") == 1
+
+
+# ── 9. Empty history → empty list ────────────────────────────────────────────
+
+def test_empty_history():
+    assert Brain._dedup_history([]) == []
+
+
+# ── 10. No repeated messages → identical list returned ───────────────────────
+
+def test_no_repetition_returns_unchanged():
+    history = [_user("hello"), _asst("Hi there"), _user("bye"), _asst("Farewell")]
+    assert Brain._dedup_history(history) == history

--- a/tests/interface/test_telegram_spam.py
+++ b/tests/interface/test_telegram_spam.py
@@ -1,0 +1,137 @@
+"""Tests for _TelegramSpamFilter — Telegram background spam filter (#184)."""
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from bantz.interface.telegram_bot import _TelegramSpamFilter
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def fresh_filter(**kwargs) -> _TelegramSpamFilter:
+    """Return a new _TelegramSpamFilter, optionally overriding class constants."""
+    f = _TelegramSpamFilter()
+    for k, v in kwargs.items():
+        setattr(f, k, v)
+    return f
+
+
+# ── 1. User messages always pass through ─────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_user_messages_pass_through():
+    f = fresh_filter()
+    for _ in range(10):
+        result = await f.should_send("Hello!", is_system=False)
+        assert result == "Hello!"
+
+
+# ── 2. Below threshold → each message returned individually ──────────────────
+
+@pytest.mark.asyncio
+async def test_below_threshold_pass_through():
+    f = fresh_filter(SPAM_THRESHOLD=5)
+    results = []
+    for i in range(4):
+        r = await f.should_send(f"Task {i} done", is_system=True)
+        results.append(r)
+    assert all(r is not None for r in results)
+    assert len(results) == 4
+
+
+# ── 3. At threshold → bundled summary returned ───────────────────────────────
+
+@pytest.mark.asyncio
+async def test_threshold_triggers_summary():
+    f = fresh_filter(SPAM_THRESHOLD=5)
+    results = []
+    for i in range(5):
+        r = await f.should_send(f"Task {i} done", is_system=True)
+        results.append(r)
+
+    # First 4 pass through, 5th triggers summary
+    non_null = [r for r in results if r is not None]
+    # The 5th should be a summary bundling all 5
+    summary_results = [r for r in non_null if "maintenance" in r.lower() or "tasks completed" in r.lower()]
+    assert len(summary_results) >= 1
+
+
+# ── 4. Window resets after expiry ────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_window_resets_after_expiry():
+    f = fresh_filter(SPAM_THRESHOLD=5, WINDOW_SECONDS=0.01)
+    # Send 3 messages
+    for i in range(3):
+        await f.should_send(f"msg {i}", is_system=True)
+
+    # Wait for window to expire
+    await asyncio.sleep(0.05)
+
+    # Buffer should reset — first message of new window passes through
+    result = await f.should_send("fresh start", is_system=True)
+    assert result is not None
+    assert result == "fresh start"
+
+
+# ── 5. Summary is in butler character ────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_summary_is_in_character():
+    f = fresh_filter(SPAM_THRESHOLD=3)
+    results = []
+    for i in range(3):
+        r = await f.should_send(f"job {i}", is_system=True)
+        results.append(r)
+
+    summaries = [r for r in results if r and ("ma'am" in r.lower() or "nominal" in r.lower() or "tasks" in r.lower())]
+    assert summaries, "Summary should be in butler character (mention Ma'am, tasks, or nominal)"
+
+
+# ── 6. flush() returns summary of buffered messages ──────────────────────────
+
+@pytest.mark.asyncio
+async def test_flush_returns_buffered():
+    f = fresh_filter(SPAM_THRESHOLD=10)  # high threshold so nothing auto-flushes
+    await f.should_send("task A", is_system=True)
+    await f.should_send("task B", is_system=True)
+
+    summary = await f.flush()
+    assert summary is not None
+    assert "2" in summary or "two" in summary.lower() or "tasks" in summary.lower()
+
+
+# ── 7. flush() with empty buffer returns None ────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_flush_empty_returns_none():
+    f = fresh_filter()
+    result = await f.flush()
+    assert result is None
+
+
+# ── 8. Buffer cleared after flush ────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_buffer_cleared_after_flush():
+    f = fresh_filter(SPAM_THRESHOLD=10)
+    await f.should_send("msg", is_system=True)
+    await f.flush()
+    # Second flush should return None (buffer empty)
+    assert await f.flush() is None
+
+
+# ── 9. Concurrent sends are safe ─────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_concurrent_sends_are_thread_safe():
+    f = fresh_filter(SPAM_THRESHOLD=5)
+    results = await asyncio.gather(*[
+        f.should_send(f"concurrent {i}", is_system=True) for i in range(5)
+    ])
+    # Should not raise; exactly one summary emitted at threshold
+    non_null = [r for r in results if r is not None]
+    assert len(non_null) >= 1


### PR DESCRIPTION
Closes #184

Fixes two conversation quality regressions:

**Loop Breaker (brain.py):** Brain._dedup_history() collapses assistant messages that appear 3+ times in context(n=12) to a single copy and injects an anti-loop system warning. Called in both _chat() and _chat_stream().

**Telegram Spam Filter (telegram_bot.py):** _TelegramSpamFilter bundles rapid-fire system/background messages — 5+ within 60s collapse into one butler-style summary. Integrated into _check_reminders_job. send_system_notification() helper exported for maintenance.py/reflection.py.

19 new tests, 805 existing pass.