### PR TITLE
feat(executor): dynamic replanning on step failure (#216)

### DIFF
--- a/src/bantz/agent/executor.py
+++ b/src/bantz/agent/executor.py
@@ -61,6 +61,7 @@ class PlanExecutionResult:
     """Aggregate result of executing an entire plan."""
     step_results: list[StepResult] = field(default_factory=list)
     aborted: bool = False
+    replanned: bool = False   # True when Plan B was attempted (#216)
 
     @property
     def succeeded(self) -> int:
@@ -126,6 +127,8 @@ class PlanExecutor:
         *,
         on_step_start: Any = None,  # optional callback(step_number, description)
         llm_fn: Callable[..., Awaitable[str]] | None = None,
+        original_request: str = "",
+        _replanned: bool = False,   # internal guard — prevents replan recursion
     ) -> PlanExecutionResult:
         """Execute all steps in order.
 
@@ -133,6 +136,10 @@ class PlanExecutor:
           step N+1 declares ``depends_on: N``.
         - **Circuit breaker (#255):** If a step fails, execution stops
           immediately.  All remaining steps are marked as aborted.
+        - **Dynamic replanning (#216):** On first failure, if ``original_request``
+          is provided, the LLM is asked for a Plan B.  The Plan B steps are then
+          executed in a recursive call with ``_replanned=True`` to prevent
+          infinite loops.
         - ``on_step_start`` is an optional async callback for progress updates.
         - ``llm_fn`` is an async callable used by the virtual ``process_text``
           tool.  Signature: ``await llm_fn(messages) -> str``.
@@ -237,17 +244,17 @@ class PlanExecutor:
                 result.step_results.append(sr)
                 # (#273) Emit step completion event
                 await self._emit_step_result(sr, total_steps)
-                # ── Circuit breaker: abort remaining steps on failure ──
+                # ── Circuit breaker → dynamic replan (#216) ──────────────
                 if self._is_step_failure(sr):
-                    log.warning(
-                        "Circuit breaker tripped at step %d [%s] — "
-                        "aborting %d remaining step(s)",
-                        step_num, tool_name, len(steps) - step_idx - 1,
+                    replan_result = await self._attempt_replan(
+                        sr, steps[step_idx + 1:], result, context_store,
+                        original_request=original_request,
+                        llm_fn=llm_fn,
+                        on_step_start=on_step_start,
+                        already_replanned=_replanned,
                     )
-                    self._abort_remaining(
-                        steps[step_idx + 1:], step_num, result, context_store,
-                    )
-                    result.aborted = True
+                    if replan_result is not None:
+                        return replan_result
                     break
                 continue
 
@@ -321,17 +328,17 @@ class PlanExecutor:
             # (#273) Emit step completion event
             await self._emit_step_result(sr, total_steps)
 
-            # ── Circuit breaker: abort remaining steps on failure ──
+            # ── Circuit breaker → dynamic replan (#216) ──────────────
             if self._is_step_failure(sr):
-                log.warning(
-                    "Circuit breaker tripped at step %d [%s] — "
-                    "aborting %d remaining step(s)",
-                    step_num, tool_name, len(steps) - step_idx - 1,
+                replan_result = await self._attempt_replan(
+                    sr, steps[step_idx + 1:], result, context_store,
+                    original_request=original_request,
+                    llm_fn=llm_fn,
+                    on_step_start=on_step_start,
+                    already_replanned=_replanned,
                 )
-                self._abort_remaining(
-                    steps[step_idx + 1:], step_num, result, context_store,
-                )
-                result.aborted = True
+                if replan_result is not None:
+                    return replan_result
                 break
 
         return result
@@ -354,6 +361,90 @@ class PlanExecutor:
             await asyncio.sleep(0)  # flush dispatcher so TUI sees result immediately
         except Exception:
             pass
+
+    async def _attempt_replan(
+        self,
+        failed_sr: StepResult,
+        remaining_steps: list[Any],
+        result: PlanExecutionResult,
+        context_store: dict[int, dict[str, Any]],
+        *,
+        original_request: str,
+        llm_fn: Callable[..., Awaitable[str]] | None,
+        on_step_start: Any,
+        already_replanned: bool,
+    ) -> "PlanExecutionResult | None":
+        """Try to recover from a step failure via dynamic replanning (#216).
+
+        If replanning is possible (original_request given, not already attempted,
+        LLM available) ask the planner for a Plan B and execute it.
+
+        Returns:
+            A new PlanExecutionResult if Plan B was generated and run.
+            None if replanning was skipped or produced no steps (caller should
+            then abort normally).
+        """
+        if already_replanned or not original_request:
+            # Guard: only one replan attempt; nothing to replan without a request
+            log.warning(
+                "Circuit breaker tripped at step %d [%s] — "
+                "aborting %d remaining step(s) (no replan: %s)",
+                failed_sr.step_number, failed_sr.tool, len(remaining_steps),
+                "already replanned" if already_replanned else "no original_request",
+            )
+            self._abort_remaining(remaining_steps, failed_sr.step_number, result, context_store)
+            result.aborted = True
+            return None
+
+        log.warning(
+            "Circuit breaker at step %d [%s] — attempting dynamic replan (#216)",
+            failed_sr.step_number, failed_sr.tool,
+        )
+
+        # Notify TUI about replanning attempt
+        try:
+            from bantz.core.notification_manager import notify_toast
+            notify_toast("🔄 Replanning…", f"Step {failed_sr.step_number} failed — devising Plan B")
+        except Exception:
+            pass
+
+        from bantz.agent.planner import planner_agent
+        from bantz.tools import registry
+
+        tool_names = registry.names() + ["process_text", "summarizer"]
+
+        plan_b = await planner_agent.replan(
+            original_request=original_request,
+            failed_step_num=failed_sr.step_number,
+            failed_tool=failed_sr.tool,
+            failed_error=failed_sr.error or failed_sr.output,
+            context_store=context_store,
+            tool_names=tool_names,
+        )
+
+        if not plan_b:
+            log.warning("Replanner produced no steps — aborting")
+            self._abort_remaining(remaining_steps, failed_sr.step_number, result, context_store)
+            result.aborted = True
+            return None
+
+        log.info("Replanner produced %d Plan-B step(s) — executing", len(plan_b))
+        result.replanned = True
+
+        plan_b_result = await self.run(
+            plan_b,
+            on_step_start=on_step_start,
+            llm_fn=llm_fn,
+            original_request=original_request,
+            _replanned=True,  # prevent further recursion
+        )
+
+        # Merge Plan B results into the parent result
+        result.step_results.extend(plan_b_result.step_results)
+        if plan_b_result.aborted:
+            result.aborted = True
+
+        return result
 
     @staticmethod
     def _abort_remaining(

--- a/src/bantz/agent/planner.py
+++ b/src/bantz/agent/planner.py
@@ -202,6 +202,37 @@ Step 3: Double-Check: I have the city "Istanbul". I don't need any complex varia
 ]\
 """
 
+REPLAN_SYSTEM = """\
+You are Bantz, a 1920s-era English butler. The original multi-step plan has
+encountered an obstacle at one of its steps.  You must devise a concise Plan B.
+
+ORIGINAL REQUEST: {original_request}
+
+COMPLETED STEPS AND THEIR OUTPUTS:
+{completed_summary}
+
+FAILED STEP:
+  Step {failed_step_num}: tool={failed_tool}, error="{failed_error}"
+
+AVAILABLE TOOLS: {tool_names}
+
+Your task: return a NEW JSON array of steps (Plan B) that accomplishes the
+original request given what has already succeeded.  Number steps from 1.
+Rules:
+- Do NOT repeat already-completed steps.
+- If no alternative exists, return a single step using the "summarizer" tool
+  that honestly reports the failure to the user.
+- Return ONLY valid JSON — no markdown fences, no explanation.
+- Maximum 4 steps.
+
+Example output:
+[
+  {{"step": 1, "tool": "web_search", "params": {{"query": "alternative source"}}, "description": "Try alternative source", "depends_on": null}},
+  {{"step": 2, "tool": "summarizer", "params": {{"instruction": "Summarize: $REF_STEP_1"}}, "description": "Summarize result", "depends_on": 1}}
+]\
+"""
+
+
 @dataclass
 class PlanStep:
     """A single step in the butler's itinerary."""
@@ -377,6 +408,71 @@ class PlannerAgent:
         lines.append("")
         lines.append("Commencing forthwith.")
         return "\n".join(lines)
+
+    async def replan(
+        self,
+        original_request: str,
+        failed_step_num: int,
+        failed_tool: str,
+        failed_error: str,
+        context_store: dict,  # step_num → {"params": ..., "output": ...}
+        tool_names: list[str],
+    ) -> list[PlanStep]:
+        """Ask the LLM to devise a Plan B after a step failure (#216).
+
+        Uses the REPLAN_SYSTEM prompt which includes what succeeded so far,
+        what failed, and why — so the LLM can generate a targeted recovery plan.
+
+        Returns a (possibly empty) list of PlanStep objects.
+        Maximum 1 replan per execution — the caller enforces the guard.
+        """
+        from bantz.core.intent import _stream_and_collect
+
+        # Summarise completed steps for the prompt
+        completed_lines: list[str] = []
+        for step_num in sorted(context_store):
+            entry = context_store[step_num]
+            out = (entry.get("output") or "")[:300].replace("\n", " ")
+            completed_lines.append(
+                f"  Step {step_num}: output='{out}'" if out else f"  Step {step_num}: (no output)"
+            )
+        completed_summary = "\n".join(completed_lines) if completed_lines else "  (none)"
+
+        prompt = REPLAN_SYSTEM.format(
+            original_request=original_request,
+            completed_summary=completed_summary,
+            failed_step_num=failed_step_num,
+            failed_tool=failed_tool,
+            failed_error=failed_error[:300],
+            tool_names=", ".join(tool_names),
+        )
+
+        messages = [
+            {"role": "system", "content": prompt},
+            {"role": "user", "content": "Devise Plan B now."},
+        ]
+
+        try:
+            raw = await _stream_and_collect(
+                messages, emit_thinking=True, source="replanner",
+            )
+            steps_data = self._parse_steps(raw)
+        except Exception as exc:
+            log.warning("Replanner failed: %s", exc)
+            return []
+
+        steps: list[PlanStep] = []
+        for i, s in enumerate(steps_data, 1):
+            steps.append(PlanStep(
+                step=s.get("step", i),
+                tool=s.get("tool", ""),
+                params=s.get("params", {}),
+                description=s.get("description", ""),
+                depends_on=s.get("depends_on"),
+            ))
+
+        log.info("Replanner produced %d Plan-B step(s)", len(steps))
+        return steps
 
 
 # ── Singleton ────────────────────────────────────────────────────────────────

--- a/src/bantz/core/routing_engine.py
+++ b/src/bantz/core/routing_engine.py
@@ -355,7 +355,9 @@ async def execute_plan(
     except Exception:
         pass
 
-    exec_result = await plan_executor.run(steps, llm_fn=ollama.chat)
+    exec_result = await plan_executor.run(
+        steps, llm_fn=ollama.chat, original_request=en_input,
+    )
 
     # Butler Lore toast — plan complete
     try:

--- a/tests/agent/test_dynamic_replanning.py
+++ b/tests/agent/test_dynamic_replanning.py
@@ -1,0 +1,227 @@
+"""Tests for dynamic replanning — executor circuit breaker + Plan B (#216)."""
+from __future__ import annotations
+
+import pytest
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import AsyncMock, patch, MagicMock
+
+from bantz.agent.executor import PlanExecutor, PlanExecutionResult, StepResult
+from bantz.agent.planner import PlanStep, PlannerAgent
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def make_step(num: int, tool: str, **params) -> PlanStep:
+    return PlanStep(step=num, tool=tool, params=params, description=f"Step {num}")
+
+
+def ok_tool_result(output: str = "ok"):
+    from bantz.tools import ToolResult
+    return ToolResult(success=True, output=output)
+
+
+def fail_tool_result(error: str = "HTTP 403 Forbidden"):
+    from bantz.tools import ToolResult
+    return ToolResult(success=False, output="", error=error)
+
+
+# ── 1. Baseline: no failure → no replan ──────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_no_replan_when_all_succeed():
+    """All steps succeed → replanned flag stays False."""
+    executor = PlanExecutor()
+    steps = [make_step(1, "web_search", query="test")]
+
+    with patch("bantz.tools.registry.get") as mock_get:
+        mock_tool = AsyncMock()
+        mock_tool.execute = AsyncMock(return_value=ok_tool_result("results"))
+        mock_get.return_value = mock_tool
+
+        result = await executor.run(steps, original_request="search something")
+
+    assert result.succeeded == 1
+    assert not result.replanned
+    assert not result.aborted
+
+
+# ── 2. Failure without original_request → plain abort ────────────────────────
+
+@pytest.mark.asyncio
+async def test_no_replan_without_original_request():
+    """Failure with no original_request → circuit breaker aborts, no replan."""
+    executor = PlanExecutor()
+    steps = [make_step(1, "read_url", url="http://x.com"), make_step(2, "summarizer")]
+
+    with patch("bantz.tools.registry.get") as mock_get:
+        mock_tool = AsyncMock()
+        mock_tool.execute = AsyncMock(return_value=fail_tool_result("HTTP 403"))
+        mock_get.return_value = mock_tool
+
+        result = await executor.run(steps)  # no original_request
+
+    assert result.aborted
+    assert not result.replanned
+
+
+# ── 3. Failure triggers replan when original_request provided ─────────────────
+
+@pytest.mark.asyncio
+async def test_replan_triggered_on_failure():
+    """Step fails + original_request given → replanner is called."""
+    executor = PlanExecutor()
+    steps = [make_step(1, "read_url", url="http://blocked.com"), make_step(2, "summarizer")]
+
+    plan_b = [make_step(1, "web_search", query="fallback")]
+
+    with patch("bantz.tools.registry.get") as mock_get, \
+         patch("bantz.tools.registry.names", return_value=["web_search", "read_url"]), \
+         patch("bantz.agent.planner.planner_agent.replan", new_callable=AsyncMock) as mock_replan, \
+         patch("bantz.core.notification_manager.notify_toast", side_effect=Exception):
+
+        def tool_side_effect(name):
+            if name == "read_url":
+                t = AsyncMock()
+                t.execute = AsyncMock(return_value=fail_tool_result("HTTP 403"))
+                return t
+            elif name == "web_search":
+                t = AsyncMock()
+                t.execute = AsyncMock(return_value=ok_tool_result("fallback results"))
+                return t
+            return None
+
+        mock_get.side_effect = tool_side_effect
+        mock_replan.return_value = plan_b
+
+        result = await executor.run(steps, original_request="find article about AI")
+
+    assert result.replanned
+    mock_replan.assert_called_once()
+
+
+# ── 4. Plan B executes and its results are merged ─────────────────────────────
+
+@pytest.mark.asyncio
+async def test_plan_b_results_merged():
+    """Plan B steps complete → their results appear in final PlanExecutionResult."""
+    executor = PlanExecutor()
+    steps = [make_step(1, "read_url", url="http://blocked.com")]
+    plan_b = [make_step(1, "web_search", query="alternative")]
+
+    with patch("bantz.tools.registry.get") as mock_get, \
+         patch("bantz.tools.registry.names", return_value=["web_search", "read_url"]), \
+         patch("bantz.agent.planner.planner_agent.replan", new_callable=AsyncMock) as mock_replan, \
+         patch("bantz.core.notification_manager.notify_toast", side_effect=Exception):
+
+        def tool_side_effect(name):
+            if name == "read_url":
+                t = AsyncMock(); t.execute = AsyncMock(return_value=fail_tool_result("403"))
+                return t
+            t = AsyncMock(); t.execute = AsyncMock(return_value=ok_tool_result("plan b output"))
+            return t
+
+        mock_get.side_effect = tool_side_effect
+        mock_replan.return_value = plan_b
+
+        result = await executor.run(steps, original_request="research AI")
+
+    tool_names = [sr.tool for sr in result.step_results]
+    assert "web_search" in tool_names
+    success_results = [sr for sr in result.step_results if sr.success]
+    assert len(success_results) >= 1
+
+
+# ── 5. Replan not triggered twice (guard against infinite loop) ───────────────
+
+@pytest.mark.asyncio
+async def test_no_double_replan():
+    """_replanned=True flag prevents recursive replanning."""
+    executor = PlanExecutor()
+    steps = [make_step(1, "read_url", url="http://blocked.com")]
+
+    with patch("bantz.tools.registry.get") as mock_get, \
+         patch("bantz.agent.planner.planner_agent.replan", new_callable=AsyncMock) as mock_replan:
+
+        mock_tool = AsyncMock()
+        mock_tool.execute = AsyncMock(return_value=fail_tool_result("error"))
+        mock_get.return_value = mock_tool
+
+        # Run with _replanned=True (simulating we're already in Plan B)
+        result = await executor.run(
+            steps, original_request="test", _replanned=True,
+        )
+
+    # Replanner should NOT have been called since _replanned=True
+    mock_replan.assert_not_called()
+    assert result.aborted
+
+
+# ── 6. Empty Plan B → plain abort ────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_empty_plan_b_falls_back_to_abort():
+    """If replanner returns empty steps → abort normally."""
+    executor = PlanExecutor()
+    steps = [make_step(1, "read_url", url="http://x.com"), make_step(2, "summarizer")]
+
+    with patch("bantz.tools.registry.get") as mock_get, \
+         patch("bantz.tools.registry.names", return_value=[]), \
+         patch("bantz.agent.planner.planner_agent.replan", new_callable=AsyncMock) as mock_replan, \
+         patch("bantz.core.notification_manager.notify_toast", side_effect=Exception):
+
+        mock_tool = AsyncMock()
+        mock_tool.execute = AsyncMock(return_value=fail_tool_result("blocked"))
+        mock_get.return_value = mock_tool
+        mock_replan.return_value = []  # empty Plan B
+
+        result = await executor.run(steps, original_request="test")
+
+    assert result.aborted
+
+
+# ── 7. PlanExecutionResult.replanned defaults to False ───────────────────────
+
+def test_plan_execution_result_replanned_defaults_false():
+    r = PlanExecutionResult()
+    assert r.replanned is False
+
+
+# ── 8. Replan passes correct context to planner ──────────────────────────────
+
+@pytest.mark.asyncio
+async def test_replan_receives_context_store():
+    """Replanner receives completed step outputs in context_store."""
+    executor = PlanExecutor()
+    steps = [
+        make_step(1, "web_search", query="AI news"),   # succeeds
+        make_step(2, "read_url", url="http://x.com"),  # fails
+    ]
+
+    captured_kwargs: dict = {}
+
+    async def fake_replan(**kwargs):
+        captured_kwargs.update(kwargs)
+        return []
+
+    with patch("bantz.tools.registry.get") as mock_get, \
+         patch("bantz.tools.registry.names", return_value=["web_search", "read_url"]), \
+         patch("bantz.agent.planner.planner_agent.replan", side_effect=fake_replan), \
+         patch("bantz.core.notification_manager.notify_toast", side_effect=Exception):
+
+        def tool_side_effect(name):
+            if name == "web_search":
+                t = AsyncMock(); t.execute = AsyncMock(return_value=ok_tool_result("search done"))
+                return t
+            t = AsyncMock(); t.execute = AsyncMock(return_value=fail_tool_result("403"))
+            return t
+
+        mock_get.side_effect = tool_side_effect
+        await executor.run(steps, original_request="AI research")
+
+    # Step 1 output should be in context_store passed to replanner
+    assert "context_store" in captured_kwargs
+    assert 1 in captured_kwargs["context_store"]
+    assert captured_kwargs["context_store"][1]["output"] == "search done"
+    assert captured_kwargs["original_request"] == "AI research"
+    assert captured_kwargs["failed_step_num"] == 2


### PR DESCRIPTION
Closes #216

## Summary

When a plan step fails (e.g. HTTP 403 on read_url), instead of blindly continuing and producing garbage output, the executor now asks the LLM for a Plan B and executes it.

## Changes

| File | What changed |
|------|-------------|
| planner.py | REPLAN_SYSTEM prompt + PlannerAgent.replan() method |
| executor.py | _attempt_replan() helper, replanned flag, original_request param |
| routing_engine.py | Pass original_request=en_input to executor |
| tests/agent/test_dynamic_replanning.py | 8 new tests |

## Guard against infinite loops
- Maximum 1 replan per execution (_replanned=True flag)
- No replan if original_request not provided
- Empty Plan B falls back to normal abort

## Tests
8 new tests pass. 980 existing tests pass. 8 pre-existing test_health failures are unrelated.

Generated with Claude Code
