### PR TITLE
feat(vision): AutonomousVisionLoop — Observe→Analyze→Act→Verify cycle (#188)

### DIFF
--- a/src/bantz/tools/computer_use.py
+++ b/src/bantz/tools/computer_use.py
@@ -1,0 +1,127 @@
+"""
+Bantz — ComputerUseTool: visual desktop/web automation via AutonomousVisionLoop (#188)
+
+Registered in the tool registry as "computer_use".  Allows the planner and
+cot_route() to delegate visual navigation tasks to the VLM loop.
+
+Usage (via tool registry):
+    result = await registry.get("computer_use").execute(
+        task="Open Firefox and navigate to wikipedia.org",
+        timeout=120,
+    )
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from bantz.tools import BaseTool, ToolResult
+
+log = logging.getLogger("bantz.tool.computer_use")
+
+
+class ComputerUseTool(BaseTool):
+    """Visual desktop / web automation via AutonomousVisionLoop.
+
+    The tool captures screenshots, sends them to a VLM for visual grounding,
+    and executes the decided actions (click, type, scroll, hotkey) in a loop
+    until the goal is achieved or safety limits are hit.
+    """
+
+    name = "computer_use"
+    description = (
+        "Visually navigate and interact with desktop applications and web pages "
+        "using screen vision.  Provide a plain-English task description."
+    )
+    risk_level = "moderate"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._loop: Any = None  # lazily initialised
+
+    def _get_loop(self):
+        if self._loop is None:
+            from bantz.vision.computer_use import vision_loop
+            self._loop = vision_loop
+        return self._loop
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        """Run a visual navigation task.
+
+        Keyword args:
+            task (str):          Plain-English description of what to do.
+            success_criteria (str, optional): How to know when done.
+                                             Defaults to "Task completed: {task}".
+            app (str, optional): Hint for which application to focus first.
+            timeout (int):       Maximum seconds to spend (default 120).
+            max_steps (int):     Maximum loop iterations (default 15).
+
+        Returns:
+            ToolResult with output = final_observation + extracted_text.
+        """
+        task = str(kwargs.get("task", "")).strip()
+        if not task:
+            return ToolResult(success=False, output="", error="task parameter is required")
+
+        timeout = int(kwargs.get("timeout", 120))
+        max_steps = int(kwargs.get("max_steps", 15))
+        success_criteria = str(
+            kwargs.get("success_criteria", f"Task completed: {task}")
+        )
+
+        from bantz.vision.computer_use import VisionGoal
+
+        goal = VisionGoal(
+            description=task,
+            success_criteria=success_criteria,
+            max_steps=max_steps,
+            timeout_s=float(timeout),
+        )
+
+        step_log: list[str] = []
+
+        async def _on_step(vs):
+            step_log.append(
+                f"Step {vs.step_num}: {vs.action} {vs.target!r} "
+                f"— {'ok' if vs.success else vs.error}"
+            )
+            # Notify TUI toast if available
+            try:
+                from bantz.core.notification_manager import notify_toast
+                notify_toast(
+                    f"👁 Step {vs.step_num}/{goal.max_steps}: "
+                    f"{vs.action} {vs.target or '…'}",
+                    toast_type="info",
+                )
+            except Exception:
+                pass
+
+        try:
+            result = await self._get_loop().execute(goal, on_step=_on_step)
+        except Exception as exc:
+            log.warning("ComputerUseTool.execute error: %s", exc)
+            return ToolResult(success=False, output="", error=str(exc))
+
+        output_parts = []
+        if result.final_observation:
+            output_parts.append(result.final_observation)
+        if result.extracted_text.strip():
+            output_parts.append(f"Extracted text:\n{result.extracted_text.strip()}")
+        if step_log:
+            output_parts.append("Steps:\n" + "\n".join(step_log))
+
+        return ToolResult(
+            success=result.success,
+            output="\n\n".join(output_parts),
+            error=result.error if not result.success else "",
+            data={
+                "steps": len(result.steps),
+                "total_time_s": round(result.total_time_s, 2),
+            },
+        )
+
+
+# ── Auto-register ─────────────────────────────────────────────────────────────
+
+from bantz.tools import registry as _registry  # noqa: E402
+_registry.register(ComputerUseTool())

--- a/src/bantz/vision/computer_use.py
+++ b/src/bantz/vision/computer_use.py
@@ -1,0 +1,545 @@
+"""
+Bantz — Autonomous VLM Web/Desktop Navigation Loop (#188)
+
+Provides a closed-loop Observe → Analyze → Act → Verify cycle that chains
+VLM perception with input control to complete multi-step visual tasks.
+
+Classes exported:
+    VisionGoal          — task specification with safety limits
+    VisionStep          — record of one Observe-Analyze-Act cycle
+    VisionLoopResult    — final result of the whole loop
+    ActionResult        — outcome of executing one action
+    AutonomousVisionLoop — the main loop engine
+    WebNavigationMacros — pre-built shortcut sequences
+
+Usage:
+    from bantz.vision.computer_use import AutonomousVisionLoop, VisionGoal
+
+    loop = AutonomousVisionLoop()
+    goal = VisionGoal(
+        description="Open Firefox and navigate to wikipedia.org",
+        success_criteria="Wikipedia homepage is visible",
+    )
+    result = await loop.execute(goal)
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable
+
+log = logging.getLogger("bantz.computer_use")
+
+# ── Safety constants ──────────────────────────────────────────────────────────
+
+_STUCK_THRESHOLD = 3          # identical screenshots in a row → abort
+_DESTRUCTIVE_HOTKEYS = frozenset({
+    "ctrl+w", "alt+f4", "ctrl+alt+delete",
+    "super+shift+q", "ctrl+shift+w",
+})
+
+# Butler–Gemini rivalry lines
+_VLM_INVOKED_LINES = [
+    "I shall… reluctantly… consult the Loquacious American Calculating Machine. "
+    "One does hope it will be brief, though hope springs eternal.",
+    "Very well, sir. Engaging the Transatlantic Oracle. I make no promises regarding verbosity.",
+    "The Machine's optical faculties are adequate — if one overlooks the verbose tendencies.",
+]
+_VLM_SUCCESS_LINES = [
+    "The Machine performed adequately, I suppose. Even a broken clock.",
+    "I shan't say I expected competence, but competence was delivered. Adequate.",
+]
+_VLM_FAILURE_LINES = [
+    "I shan't say 'I told you so,' sir, but I did harbour reservations regarding the Machine's optical faculties.",
+    "The Transatlantic Oracle has, regrettably, proven itself less than oracular.",
+]
+
+
+# ── Data classes ──────────────────────────────────────────────────────────────
+
+@dataclass
+class VisionGoal:
+    """Specification of an autonomous visual navigation task."""
+    description: str
+    success_criteria: str
+    max_steps: int = 15
+    timeout_s: float = 120.0
+    allowed_domains: list[str] = field(default_factory=list)
+
+
+@dataclass
+class VisionStep:
+    """Record of one Observe → Analyze → Act cycle."""
+    step_num: int
+    observation: str
+    reasoning: str
+    action: str           # click | type | scroll | hotkey | wait | read | done
+    target: str
+    args: dict
+    screenshot_b64: str
+    success: bool = False
+    error: str = ""
+
+
+@dataclass
+class VisionLoopResult:
+    """Final outcome of AutonomousVisionLoop.execute()."""
+    success: bool
+    steps: list[VisionStep]
+    final_observation: str
+    extracted_text: str
+    total_time_s: float
+    error: str = ""
+
+
+@dataclass
+class ActionResult:
+    """Outcome of executing a single action."""
+    success: bool
+    message: str = ""
+    error: str = ""
+
+
+# ── Autonomous Vision Loop ────────────────────────────────────────────────────
+
+class AutonomousVisionLoop:
+    """Closed-loop Observe → Analyze → Act → Verify visual navigation engine.
+
+    Dependency injection via constructor: pass mock vlm_fn / input_ctrl / llm_fn
+    in tests; in production the module-level ``vision_loop`` singleton uses real
+    implementations (lazy-imported so no hard runtime dependency).
+
+    Args:
+        vlm_fn:     async (image_b64, prompt) -> str  — describes the screen
+        llm_fn:     async (prompt) -> str             — decides next action
+        input_ctrl: object with async click/type_text/scroll/hotkey methods
+        navigator:  object with async execute_action method
+    """
+
+    def __init__(
+        self,
+        vlm_fn: Callable[..., Awaitable[str]] | None = None,
+        llm_fn: Callable[..., Awaitable[str]] | None = None,
+        input_ctrl: Any = None,
+        navigator: Any = None,
+    ) -> None:
+        self._vlm_fn = vlm_fn
+        self._llm_fn = llm_fn
+        self._input_ctrl = input_ctrl
+        self._navigator = navigator
+
+    # ── Public API ─────────────────────────────────────────────────────────
+
+    async def execute(
+        self,
+        goal: VisionGoal,
+        on_step: Callable[[VisionStep], Awaitable[None]] | None = None,
+    ) -> VisionLoopResult:
+        """Run the Observe → Analyze → Act → Verify loop until goal met or abort.
+
+        Args:
+            goal:    What to accomplish and when to stop.
+            on_step: Optional async callback called after each VisionStep.
+
+        Returns:
+            VisionLoopResult with success flag, step history, and extracted text.
+        """
+        start = time.monotonic()
+        steps: list[VisionStep] = []
+        history_summaries: list[str] = []
+        extracted_text = ""
+        _last_hashes: list[str] = []
+        _finished_by_done = False
+
+        log.info("AutonomousVisionLoop: starting — %s", goal.description)
+        _butler_line = _VLM_INVOKED_LINES[len(goal.description) % len(_VLM_INVOKED_LINES)]
+        log.info("Butler: %s", _butler_line)
+
+        for step_num in range(1, goal.max_steps + 1):
+            elapsed = time.monotonic() - start
+            if elapsed >= goal.timeout_s:
+                log.warning("Vision loop timeout after %.1fs", elapsed)
+                return VisionLoopResult(
+                    success=False,
+                    steps=steps,
+                    final_observation="Timeout reached.",
+                    extracted_text=extracted_text,
+                    total_time_s=elapsed,
+                    error="timeout",
+                )
+
+            # 1. OBSERVE
+            screenshot_b64 = await self._observe()
+            if not screenshot_b64:
+                log.warning("Vision loop: screenshot failed at step %d", step_num)
+                break
+
+            # Stuck detection
+            img_hash = hashlib.md5(screenshot_b64.encode()).hexdigest()
+            _last_hashes.append(img_hash)
+            if len(_last_hashes) > _STUCK_THRESHOLD:
+                _last_hashes.pop(0)
+            if len(_last_hashes) == _STUCK_THRESHOLD and len(set(_last_hashes)) == 1:
+                log.warning("Vision loop: stuck — %d identical screenshots", _STUCK_THRESHOLD)
+                return VisionLoopResult(
+                    success=False,
+                    steps=steps,
+                    final_observation="Loop stuck — screen not changing.",
+                    extracted_text=extracted_text,
+                    total_time_s=time.monotonic() - start,
+                    error="stuck",
+                )
+
+            # 2. ANALYZE — VLM describes screen, LLM decides action
+            try:
+                action_dict = await self._decide_action(goal, screenshot_b64, history_summaries)
+            except Exception as exc:
+                log.debug("_decide_action error: %s", exc)
+                action_dict = {"action": "wait", "target": "", "args": {},
+                               "reasoning": "decision error", "done": False}
+
+            observation = action_dict.get("observation", "")
+            reasoning = action_dict.get("reasoning", "")
+            action_name = action_dict.get("action", "wait")
+            target = action_dict.get("target", "")
+            args = action_dict.get("args", {})
+            done = action_dict.get("done", False)
+
+            # 3. ACT
+            vs = VisionStep(
+                step_num=step_num,
+                observation=observation,
+                reasoning=reasoning,
+                action=action_name,
+                target=target,
+                args=args,
+                screenshot_b64=screenshot_b64,
+            )
+
+            if done or action_name == "done":
+                vs.success = True
+                extracted_text = action_dict.get("extracted_text", "")
+                steps.append(vs)
+                if on_step:
+                    try:
+                        await on_step(vs)
+                    except Exception:
+                        pass
+                _finished_by_done = True
+                break
+
+            if action_name == "read":
+                # Extract text from current screen
+                extracted_text += await self._read_screen(screenshot_b64) + "\n"
+                vs.success = True
+            else:
+                ar = await self._execute_action(action_dict, goal)
+                vs.success = ar.success
+                vs.error = ar.error
+
+            steps.append(vs)
+            history_summaries.append(
+                f"Step {step_num}: {action_name} {target!r} — {'ok' if vs.success else vs.error}"
+            )
+
+            if on_step:
+                try:
+                    await on_step(vs)
+                except Exception:
+                    pass
+
+            # 4. VERIFY — ask VLM if goal is met
+            goal_met, final_obs = await self._verify_goal(goal, screenshot_b64)
+            if goal_met:
+                log.info("Vision loop: goal met at step %d", step_num)
+                log.info("Butler: %s", _VLM_SUCCESS_LINES[step_num % len(_VLM_SUCCESS_LINES)])
+                return VisionLoopResult(
+                    success=True,
+                    steps=steps,
+                    final_observation=final_obs,
+                    extracted_text=extracted_text,
+                    total_time_s=time.monotonic() - start,
+                )
+
+        # Done action broke the loop → success
+        if _finished_by_done:
+            log.info("Butler: %s", _VLM_SUCCESS_LINES[len(steps) % len(_VLM_SUCCESS_LINES)])
+            return VisionLoopResult(
+                success=True,
+                steps=steps,
+                final_observation=steps[-1].observation if steps else "",
+                extracted_text=extracted_text,
+                total_time_s=time.monotonic() - start,
+            )
+
+        # Max steps reached
+        final_obs = "Max steps reached without achieving goal."
+        log.info("Butler: %s", _VLM_FAILURE_LINES[0])
+        return VisionLoopResult(
+            success=False,
+            steps=steps,
+            final_observation=final_obs,
+            extracted_text=extracted_text,
+            total_time_s=time.monotonic() - start,
+            error="max_steps_reached",
+        )
+
+    # ── Internal ───────────────────────────────────────────────────────────
+
+    async def _observe(self) -> str | None:
+        """Capture a screenshot and return base64 string."""
+        try:
+            from bantz.vision import screenshot as _ss
+            b64 = await _ss.capture_base64()
+            return b64
+        except Exception as exc:
+            log.debug("_observe error: %s", exc)
+            return None
+
+    async def _decide_action(
+        self,
+        goal: VisionGoal,
+        screenshot_b64: str,
+        history: list[str],
+    ) -> dict:
+        """Ask VLM/LLM to decide the next action.
+
+        Returns a dict:
+            {"action": str, "target": str, "args": dict,
+             "reasoning": str, "observation": str, "done": bool}
+        """
+        history_text = "\n".join(f"{i+1}. {h}" for i, h in enumerate(history)) or "None"
+        prompt = (
+            f"You are a desktop automation agent.\n"
+            f"Goal: {goal.description}\n"
+            f"Success criteria: {goal.success_criteria}\n\n"
+            f"Previous actions:\n{history_text}\n\n"
+            f"Look at the current screenshot and decide the next action.\n"
+            f"Respond ONLY with valid JSON:\n"
+            f'{{"observation": "...", "reasoning": "...", '
+            f'"action": "click|type|scroll|hotkey|wait|read|done", '
+            f'"target": "element label or empty", '
+            f'"args": {{}}, "done": false, "extracted_text": ""}}\n\n'
+            f"Available actions: click, type, scroll, hotkey, wait, read, done\n"
+            f"NEVER type passwords or sensitive data."
+        )
+
+        raw = await self._call_llm_with_vision(screenshot_b64, prompt)
+        return self._parse_action_json(raw)
+
+    async def _verify_goal(
+        self,
+        goal: VisionGoal,
+        screenshot_b64: str,
+    ) -> tuple[bool, str]:
+        """Ask VLM if the success criteria are met.
+
+        Returns (goal_met: bool, observation: str).
+        """
+        prompt = (
+            f"Success criteria: {goal.success_criteria}\n\n"
+            f"Is the success criteria met in the screenshot? "
+            f"Reply ONLY with JSON: {{\"done\": true/false, \"observation\": \"...\"}}"
+        )
+        try:
+            raw = await self._call_llm_with_vision(screenshot_b64, prompt)
+            data = self._parse_action_json(raw)
+            done = bool(data.get("done", False))
+            obs = data.get("observation", "")
+            return done, obs
+        except Exception as exc:
+            log.debug("_verify_goal error: %s", exc)
+            return False, ""
+
+    async def _execute_action(self, action_dict: dict, goal: VisionGoal) -> ActionResult:
+        """Dispatch action to input_control or navigator.
+
+        Applies safety gate for destructive hotkeys.
+        """
+        action = action_dict.get("action", "wait")
+        target = action_dict.get("target", "")
+        args = action_dict.get("args", {})
+
+        # Destructive action gate
+        if action == "hotkey":
+            combo = args.get("keys", "").lower().replace(" ", "")
+            if combo in _DESTRUCTIVE_HOTKEYS:
+                log.warning("Destructive hotkey blocked: %s", combo)
+                return ActionResult(success=False, error=f"blocked_destructive_hotkey:{combo}")
+
+        # Domain allowlist check for URL navigation
+        if action == "type" and goal.allowed_domains:
+            text = args.get("text", "")
+            if text.startswith("http") or "://" in text:
+                if not any(d in text for d in goal.allowed_domains):
+                    log.warning("URL not in allowlist: %s", text)
+                    return ActionResult(success=False, error="url_not_in_allowlist")
+
+        try:
+            ctrl = self._get_input_ctrl()
+            if action == "click":
+                x, y = args.get("x", 0), args.get("y", 0)
+                if x or y:
+                    await ctrl.click(x, y)
+                elif target and self._navigator:
+                    await self._navigator.navigate_to(target)
+            elif action == "type":
+                text = args.get("text", "")
+                await ctrl.type_text(text)
+            elif action == "scroll":
+                direction = args.get("direction", "down")
+                amount = args.get("amount", 3)
+                await ctrl.scroll(direction, amount)
+            elif action == "hotkey":
+                keys_str = args.get("keys", "")
+                if keys_str:
+                    await ctrl.hotkey(*keys_str.split("+"))
+            elif action == "wait":
+                await asyncio.sleep(args.get("seconds", 1))
+            return ActionResult(success=True)
+        except Exception as exc:
+            log.debug("_execute_action error: %s", exc)
+            return ActionResult(success=False, error=str(exc))
+
+    async def _read_screen(self, screenshot_b64: str) -> str:
+        """Extract visible text from screenshot via VLM."""
+        prompt = "List all visible text on the screen, line by line."
+        try:
+            return await self._call_llm_with_vision(screenshot_b64, prompt)
+        except Exception:
+            return ""
+
+    async def _call_llm_with_vision(self, screenshot_b64: str, prompt: str) -> str:
+        """Route to injected VLM/LLM or fall back to built-in remote_vlm."""
+        if self._vlm_fn is not None:
+            return await self._vlm_fn(screenshot_b64, prompt)
+        # Built-in fallback
+        try:
+            from bantz.vision.remote_vlm import describe_screen
+            result = await describe_screen(screenshot_b64)
+            return result.raw if hasattr(result, "raw") else str(result)
+        except Exception as exc:
+            log.debug("VLM call failed: %s", exc)
+            return "{}"
+
+    def _get_input_ctrl(self) -> Any:
+        if self._input_ctrl is not None:
+            return self._input_ctrl
+        from bantz.tools import input_control
+        return input_control
+
+    @staticmethod
+    def _parse_action_json(raw: str) -> dict:
+        """Parse JSON from potentially noisy LLM output."""
+        if not raw:
+            return {}
+        # Try to find JSON block
+        start = raw.find("{")
+        end = raw.rfind("}") + 1
+        if start >= 0 and end > start:
+            try:
+                return json.loads(raw[start:end])
+            except json.JSONDecodeError:
+                pass
+        return {}
+
+
+# ── Web Navigation Macros ─────────────────────────────────────────────────────
+
+class WebNavigationMacros:
+    """Pre-built shortcut sequences for common web navigation patterns.
+
+    These reduce loop iterations by batching common UI sequences into
+    single macro calls that the loop can invoke instead of individual
+    click → screenshot → type steps.
+    """
+
+    def __init__(self, input_ctrl: Any = None, loop: AutonomousVisionLoop | None = None) -> None:
+        self._input_ctrl = input_ctrl
+        self._loop = loop
+
+    def _ctrl(self) -> Any:
+        if self._input_ctrl is not None:
+            return self._input_ctrl
+        from bantz.tools import input_control
+        return input_control
+
+    async def open_browser(self) -> bool:
+        """Launch or focus the default browser via system tool."""
+        try:
+            from bantz.tools.system_tool import system_tool
+            result = system_tool.run("xdg-open about:blank", timeout=5, safe_mode=False)
+            return result.success
+        except Exception as exc:
+            log.debug("open_browser: %s", exc)
+            return False
+
+    async def navigate_to_url(self, url: str) -> bool:
+        """Focus URL bar (Ctrl+L) → type URL → Enter."""
+        ctrl = self._ctrl()
+        try:
+            await ctrl.hotkey("ctrl", "l")
+            await asyncio.sleep(0.2)
+            await ctrl.type_text(url)
+            await asyncio.sleep(0.1)
+            await ctrl.hotkey("Return")
+            return True
+        except Exception as exc:
+            log.debug("navigate_to_url: %s", exc)
+            return False
+
+    async def search_in_page(self, query: str) -> bool:
+        """Ctrl+F → type query → check via screenshot."""
+        ctrl = self._ctrl()
+        try:
+            await ctrl.hotkey("ctrl", "f")
+            await asyncio.sleep(0.2)
+            await ctrl.type_text(query)
+            return True
+        except Exception as exc:
+            log.debug("search_in_page: %s", exc)
+            return False
+
+    async def scroll_and_read(self, direction: str = "down", amount: int = 3) -> str:
+        """Scroll the page and return VLM-extracted text."""
+        ctrl = self._ctrl()
+        try:
+            await ctrl.scroll(direction, amount)
+            await asyncio.sleep(0.3)
+        except Exception as exc:
+            log.debug("scroll_and_read scroll: %s", exc)
+
+        if self._loop:
+            b64 = await self._loop._observe()
+            if b64:
+                return await self._loop._read_screen(b64)
+        return ""
+
+    async def wait_for_element(self, label: str, timeout: float = 10.0) -> bool:
+        """Repeatedly screenshot + VLM until element appears or timeout."""
+        if self._loop is None:
+            return False
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            b64 = await self._loop._observe()
+            if b64:
+                prompt = (
+                    f"Is there a UI element labelled '{label}' visible on screen? "
+                    f"Reply ONLY: {{\"found\": true}} or {{\"found\": false}}"
+                )
+                raw = await self._loop._call_llm_with_vision(b64, prompt)
+                data = AutonomousVisionLoop._parse_action_json(raw)
+                if data.get("found"):
+                    return True
+            await asyncio.sleep(1.0)
+        return False
+
+
+# ── Module singleton ──────────────────────────────────────────────────────────
+
+vision_loop = AutonomousVisionLoop()
+web_macros = WebNavigationMacros(loop=vision_loop)

--- a/tests/vision/test_computer_use.py
+++ b/tests/vision/test_computer_use.py
@@ -1,0 +1,566 @@
+"""Tests for AutonomousVisionLoop, WebNavigationMacros, ComputerUseTool (#188).
+
+All VLM/input_control interactions are mocked — no real display or LLM needed.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass, field
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bantz.vision.computer_use import (
+    AutonomousVisionLoop,
+    VisionGoal,
+    VisionStep,
+    VisionLoopResult,
+    ActionResult,
+    WebNavigationMacros,
+    _DESTRUCTIVE_HOTKEYS,
+)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _goal(description="open Firefox", criteria="Firefox is open", max_steps=5, timeout=10.0):
+    return VisionGoal(
+        description=description,
+        success_criteria=criteria,
+        max_steps=max_steps,
+        timeout_s=timeout,
+    )
+
+
+def _make_loop(vlm_responses=None, screenshots=None, input_ctrl=None):
+    """Build a loop with injected fakes."""
+    _screenshots = iter(screenshots or ["aGVsbG8=" * 5])
+
+    async def _fake_vlm(b64, prompt):
+        resp = vlm_responses.pop(0) if vlm_responses else '{"action":"done","done":true}'
+        return resp if isinstance(resp, str) else json.dumps(resp)
+
+    loop = AutonomousVisionLoop(
+        vlm_fn=_fake_vlm,
+        llm_fn=None,
+        input_ctrl=input_ctrl or _mock_input(),
+    )
+
+    # Patch _observe to return controlled screenshots
+    async def _fake_observe():
+        try:
+            return next(_screenshots)
+        except StopIteration:
+            return "aGVsbG8=" * 5
+
+    loop._observe = _fake_observe
+    return loop
+
+
+def _mock_input():
+    ctrl = MagicMock()
+    ctrl.click = AsyncMock(return_value={"success": True})
+    ctrl.type_text = AsyncMock(return_value={"success": True})
+    ctrl.scroll = AsyncMock(return_value={"success": True})
+    ctrl.hotkey = AsyncMock(return_value={"success": True})
+    return ctrl
+
+
+# ── VisionGoal ────────────────────────────────────────────────────────────────
+
+class TestVisionGoal:
+
+    def test_defaults(self):
+        g = VisionGoal(description="do stuff", success_criteria="stuff done")
+        assert g.max_steps == 15
+        assert g.timeout_s == 120.0
+        assert g.allowed_domains == []
+
+    def test_custom_fields(self):
+        g = VisionGoal("desc", "criteria", max_steps=5, timeout_s=30.0,
+                        allowed_domains=["wikipedia.org"])
+        assert g.max_steps == 5
+        assert g.allowed_domains == ["wikipedia.org"]
+
+
+# ── VisionLoopResult ──────────────────────────────────────────────────────────
+
+class TestVisionLoopResult:
+
+    def test_fields(self):
+        r = VisionLoopResult(
+            success=True, steps=[], final_observation="done",
+            extracted_text="text", total_time_s=1.5,
+        )
+        assert r.success
+        assert r.error == ""
+
+
+# ── _parse_action_json ────────────────────────────────────────────────────────
+
+class TestParseActionJson:
+
+    def test_valid_json(self):
+        raw = '{"action": "click", "target": "button", "done": false}'
+        d = AutonomousVisionLoop._parse_action_json(raw)
+        assert d["action"] == "click"
+
+    def test_json_with_prefix_noise(self):
+        raw = 'Sure! {"action": "type", "args": {"text": "hello"}}'
+        d = AutonomousVisionLoop._parse_action_json(raw)
+        assert d["action"] == "type"
+
+    def test_empty_string_returns_empty(self):
+        assert AutonomousVisionLoop._parse_action_json("") == {}
+
+    def test_no_json_returns_empty(self):
+        assert AutonomousVisionLoop._parse_action_json("no json here") == {}
+
+    def test_malformed_json_returns_empty(self):
+        assert AutonomousVisionLoop._parse_action_json("{broken json") == {}
+
+
+# ── execute() — basic flow ────────────────────────────────────────────────────
+
+class TestExecuteBasic:
+
+    @pytest.mark.asyncio
+    async def test_goal_met_on_first_verify(self):
+        """VLM immediately says goal met → success in 1 step."""
+        loop = _make_loop(
+            vlm_responses=[
+                '{"action":"click","target":"button","done":false,"reasoning":"r","observation":"o"}',
+                '{"done":true,"observation":"goal met"}',  # verify response
+            ]
+        )
+        result = await loop.execute(_goal(max_steps=5))
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_done_action_exits_immediately(self):
+        """If LLM returns action=done, loop exits without verify."""
+        loop = _make_loop(
+            vlm_responses=[
+                '{"action":"done","done":true,"observation":"ok","reasoning":"done"}'
+            ]
+        )
+        result = await loop.execute(_goal())
+        assert result.success is True
+        assert len(result.steps) == 1
+
+    @pytest.mark.asyncio
+    async def test_max_steps_abort(self):
+        """If goal never met, loop aborts after max_steps."""
+        responses = []
+        for i in range(10):
+            responses.append('{"action":"wait","done":false,"reasoning":"r","observation":"o"}')
+            responses.append('{"done":false,"observation":"not done yet"}')
+
+        # Use unique screenshots to avoid stuck detection
+        _step = 0
+
+        async def _fake_vlm(b64, prompt):
+            return responses.pop(0) if responses else '{"action":"wait","done":false}'
+
+        loop = AutonomousVisionLoop(vlm_fn=_fake_vlm, input_ctrl=_mock_input())
+
+        _counter = [0]
+
+        async def _unique_screenshots():
+            _counter[0] += 1
+            return f"screenshot_{_counter[0]}" * 3
+
+        loop._observe = _unique_screenshots
+        result = await loop.execute(_goal(max_steps=3))
+        assert result.success is False
+        assert result.error == "max_steps_reached"
+
+    @pytest.mark.asyncio
+    async def test_on_step_callback_fires(self):
+        """on_step callback is called once per step."""
+        fired: list[VisionStep] = []
+
+        async def _cb(vs: VisionStep):
+            fired.append(vs)
+
+        loop = _make_loop(
+            vlm_responses=[
+                '{"action":"done","done":true,"observation":"ok","reasoning":"r"}'
+            ]
+        )
+        await loop.execute(_goal(), on_step=_cb)
+        assert len(fired) == 1
+
+    @pytest.mark.asyncio
+    async def test_returns_extracted_text(self):
+        """extracted_text from done action is propagated to result."""
+        loop = _make_loop(
+            vlm_responses=[
+                '{"action":"done","done":true,"observation":"ok",'
+                '"reasoning":"r","extracted_text":"some page content"}'
+            ]
+        )
+        result = await loop.execute(_goal())
+        assert "some page content" in result.extracted_text
+
+    @pytest.mark.asyncio
+    async def test_read_action_accumulates_text(self):
+        """action=read calls _read_screen, text appended to extracted_text."""
+        loop = _make_loop(
+            vlm_responses=[
+                '{"action":"read","done":false,"reasoning":"r","observation":"o"}',
+                '{"done":true,"observation":"done"}',
+            ]
+        )
+        loop._read_screen = AsyncMock(return_value="page text here")
+        result = await loop.execute(_goal(max_steps=3))
+        assert "page text here" in result.extracted_text
+
+
+# ── Stuck detection ───────────────────────────────────────────────────────────
+
+class TestStuckDetection:
+
+    @pytest.mark.asyncio
+    async def test_identical_screenshots_abort(self):
+        """3 identical screenshots → stuck error."""
+        same = "AAAA"
+        responses = []
+        for _ in range(5):
+            responses.append('{"action":"wait","done":false,"reasoning":"r","observation":"o"}')
+            responses.append('{"done":false,"observation":"not done"}')
+
+        loop = AutonomousVisionLoop(
+            vlm_fn=None,
+            input_ctrl=_mock_input(),
+        )
+        _call = 0
+
+        async def _fake_vlm(b64, prompt):
+            nonlocal _call
+            _call += 1
+            return responses.pop(0) if responses else '{"action":"wait","done":false}'
+
+        loop._vlm_fn = _fake_vlm
+
+        async def _same_screenshot():
+            return same
+
+        loop._observe = _same_screenshot
+
+        result = await loop.execute(_goal(max_steps=10))
+        assert result.error == "stuck"
+
+
+# ── Timeout ───────────────────────────────────────────────────────────────────
+
+class TestTimeout:
+
+    @pytest.mark.asyncio
+    async def test_timeout_abort(self):
+        """timeout_s=0 → immediate timeout."""
+        loop = _make_loop(vlm_responses=[])
+        result = await loop.execute(_goal(timeout=0.0, max_steps=100))
+        assert result.error == "timeout"
+        assert result.success is False
+
+
+# ── _execute_action ───────────────────────────────────────────────────────────
+
+class TestExecuteAction:
+
+    @pytest.mark.asyncio
+    async def test_click_delegates_to_input_ctrl(self):
+        ctrl = _mock_input()
+        loop = AutonomousVisionLoop(input_ctrl=ctrl)
+        ar = await loop._execute_action(
+            {"action": "click", "args": {"x": 100, "y": 200}}, _goal()
+        )
+        ctrl.click.assert_called_once_with(100, 200)
+        assert ar.success
+
+    @pytest.mark.asyncio
+    async def test_type_delegates_to_input_ctrl(self):
+        ctrl = _mock_input()
+        loop = AutonomousVisionLoop(input_ctrl=ctrl)
+        ar = await loop._execute_action(
+            {"action": "type", "args": {"text": "hello"}}, _goal()
+        )
+        ctrl.type_text.assert_called_once_with("hello")
+        assert ar.success
+
+    @pytest.mark.asyncio
+    async def test_scroll_delegates_to_input_ctrl(self):
+        ctrl = _mock_input()
+        loop = AutonomousVisionLoop(input_ctrl=ctrl)
+        ar = await loop._execute_action(
+            {"action": "scroll", "args": {"direction": "down", "amount": 3}}, _goal()
+        )
+        ctrl.scroll.assert_called_once_with("down", 3)
+        assert ar.success
+
+    @pytest.mark.asyncio
+    async def test_hotkey_delegates_to_input_ctrl(self):
+        ctrl = _mock_input()
+        loop = AutonomousVisionLoop(input_ctrl=ctrl)
+        ar = await loop._execute_action(
+            {"action": "hotkey", "args": {"keys": "ctrl+t"}}, _goal()
+        )
+        ctrl.hotkey.assert_called_once_with("ctrl", "t")
+        assert ar.success
+
+    @pytest.mark.asyncio
+    async def test_destructive_hotkey_blocked(self):
+        ctrl = _mock_input()
+        loop = AutonomousVisionLoop(input_ctrl=ctrl)
+        ar = await loop._execute_action(
+            {"action": "hotkey", "args": {"keys": "alt+f4"}}, _goal()
+        )
+        ctrl.hotkey.assert_not_called()
+        assert not ar.success
+        assert "blocked_destructive_hotkey" in ar.error
+
+    @pytest.mark.asyncio
+    async def test_url_not_in_allowlist_blocked(self):
+        ctrl = _mock_input()
+        loop = AutonomousVisionLoop(input_ctrl=ctrl)
+        goal = _goal()
+        goal.allowed_domains = ["wikipedia.org"]
+        ar = await loop._execute_action(
+            {"action": "type", "args": {"text": "http://evil.com"}}, goal
+        )
+        ctrl.type_text.assert_not_called()
+        assert "url_not_in_allowlist" in ar.error
+
+    @pytest.mark.asyncio
+    async def test_url_in_allowlist_allowed(self):
+        ctrl = _mock_input()
+        loop = AutonomousVisionLoop(input_ctrl=ctrl)
+        goal = _goal()
+        goal.allowed_domains = ["wikipedia.org"]
+        ar = await loop._execute_action(
+            {"action": "type", "args": {"text": "https://wikipedia.org/wiki/Python"}}, goal
+        )
+        ctrl.type_text.assert_called_once()
+        assert ar.success
+
+    @pytest.mark.asyncio
+    async def test_wait_action_returns_success(self):
+        loop = AutonomousVisionLoop(input_ctrl=_mock_input())
+        ar = await loop._execute_action(
+            {"action": "wait", "args": {"seconds": 0}}, _goal()
+        )
+        assert ar.success
+
+
+# ── _verify_goal ──────────────────────────────────────────────────────────────
+
+class TestVerifyGoal:
+
+    @pytest.mark.asyncio
+    async def test_verify_true_when_vlm_says_done(self):
+        async def _vlm(b64, prompt):
+            return '{"done": true, "observation": "Firefox is open"}'
+
+        loop = AutonomousVisionLoop(vlm_fn=_vlm)
+        done, obs = await loop._verify_goal(_goal(), "img_b64")
+        assert done is True
+        assert "Firefox" in obs
+
+    @pytest.mark.asyncio
+    async def test_verify_false_when_vlm_says_not_done(self):
+        async def _vlm(b64, prompt):
+            return '{"done": false, "observation": "still loading"}'
+
+        loop = AutonomousVisionLoop(vlm_fn=_vlm)
+        done, obs = await loop._verify_goal(_goal(), "img_b64")
+        assert done is False
+
+    @pytest.mark.asyncio
+    async def test_verify_false_on_vlm_error(self):
+        async def _vlm(b64, prompt):
+            raise RuntimeError("VLM down")
+
+        loop = AutonomousVisionLoop(vlm_fn=_vlm)
+        done, obs = await loop._verify_goal(_goal(), "img_b64")
+        assert done is False
+
+
+# ── Destructive hotkeys set ───────────────────────────────────────────────────
+
+class TestDestructiveHotkeys:
+
+    def test_alt_f4_in_set(self):
+        assert "alt+f4" in _DESTRUCTIVE_HOTKEYS
+
+    def test_ctrl_w_in_set(self):
+        assert "ctrl+w" in _DESTRUCTIVE_HOTKEYS
+
+    def test_safe_hotkey_not_in_set(self):
+        assert "ctrl+t" not in _DESTRUCTIVE_HOTKEYS
+
+
+# ── WebNavigationMacros ───────────────────────────────────────────────────────
+
+class TestWebNavigationMacros:
+
+    @pytest.mark.asyncio
+    async def test_navigate_to_url(self):
+        ctrl = _mock_input()
+        macros = WebNavigationMacros(input_ctrl=ctrl)
+        result = await macros.navigate_to_url("https://wikipedia.org")
+        ctrl.hotkey.assert_called()
+        ctrl.type_text.assert_called_once_with("https://wikipedia.org")
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_search_in_page(self):
+        ctrl = _mock_input()
+        macros = WebNavigationMacros(input_ctrl=ctrl)
+        result = await macros.search_in_page("Ottoman Empire")
+        ctrl.hotkey.assert_called()
+        ctrl.type_text.assert_called_once_with("Ottoman Empire")
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_scroll_and_read(self):
+        ctrl = _mock_input()
+        loop = AutonomousVisionLoop(input_ctrl=ctrl)
+
+        async def _observe():
+            return "aGVsbG8="
+
+        loop._observe = _observe
+        loop._read_screen = AsyncMock(return_value="article text")
+        macros = WebNavigationMacros(input_ctrl=ctrl, loop=loop)
+        text = await macros.scroll_and_read()
+        assert "article text" in text
+
+    @pytest.mark.asyncio
+    async def test_wait_for_element_found(self):
+        ctrl = _mock_input()
+        loop = AutonomousVisionLoop(input_ctrl=ctrl)
+
+        async def _observe():
+            return "aGVsbG8="
+
+        call_count = 0
+
+        async def _vlm(b64, prompt):
+            nonlocal call_count
+            call_count += 1
+            return '{"found": true}'
+
+        loop._observe = _observe
+        loop._vlm_fn = _vlm
+        macros = WebNavigationMacros(input_ctrl=ctrl, loop=loop)
+        result = await macros.wait_for_element("search box", timeout=2.0)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_wait_for_element_timeout(self):
+        ctrl = _mock_input()
+        loop = AutonomousVisionLoop(input_ctrl=ctrl)
+
+        async def _observe():
+            return "aGVsbG8="
+
+        async def _vlm(b64, prompt):
+            return '{"found": false}'
+
+        loop._observe = _observe
+        loop._vlm_fn = _vlm
+        macros = WebNavigationMacros(input_ctrl=ctrl, loop=loop)
+        result = await macros.wait_for_element("nonexistent button", timeout=0.1)
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_wait_for_element_no_loop_returns_false(self):
+        macros = WebNavigationMacros()
+        result = await macros.wait_for_element("anything")
+        assert result is False
+
+
+# ── ComputerUseTool ───────────────────────────────────────────────────────────
+
+class TestComputerUseTool:
+
+    def test_tool_name(self):
+        from bantz.tools.computer_use import ComputerUseTool
+        assert ComputerUseTool.name == "computer_use"
+
+    def test_tool_registered(self):
+        import bantz.tools.computer_use  # ensure registration  # noqa
+        from bantz.tools import registry
+        assert registry.get("computer_use") is not None
+
+    @pytest.mark.asyncio
+    async def test_execute_missing_task_returns_error(self):
+        from bantz.tools.computer_use import ComputerUseTool
+        tool = ComputerUseTool()
+        result = await tool.execute()
+        assert not result.success
+        assert "task" in result.error
+
+    @pytest.mark.asyncio
+    async def test_execute_success_path(self):
+        from bantz.tools.computer_use import ComputerUseTool
+        tool = ComputerUseTool()
+        # Inject a loop that immediately succeeds
+        mock_loop = MagicMock()
+        from bantz.vision.computer_use import VisionLoopResult
+        mock_loop.execute = AsyncMock(return_value=VisionLoopResult(
+            success=True,
+            steps=[],
+            final_observation="Done!",
+            extracted_text="page content",
+            total_time_s=0.5,
+        ))
+        tool._loop = mock_loop
+        result = await tool.execute(task="open Firefox")
+        assert result.success
+        assert "Done!" in result.output
+
+    @pytest.mark.asyncio
+    async def test_execute_failure_path(self):
+        from bantz.tools.computer_use import ComputerUseTool
+        from bantz.vision.computer_use import VisionLoopResult
+        tool = ComputerUseTool()
+        mock_loop = MagicMock()
+        mock_loop.execute = AsyncMock(return_value=VisionLoopResult(
+            success=False,
+            steps=[],
+            final_observation="",
+            extracted_text="",
+            total_time_s=1.0,
+            error="max_steps_reached",
+        ))
+        tool._loop = mock_loop
+        result = await tool.execute(task="do impossible thing")
+        assert not result.success
+        assert result.error == "max_steps_reached"
+
+    @pytest.mark.asyncio
+    async def test_execute_exception_returns_error(self):
+        from bantz.tools.computer_use import ComputerUseTool
+        tool = ComputerUseTool()
+        mock_loop = MagicMock()
+        mock_loop.execute = AsyncMock(side_effect=RuntimeError("crash"))
+        tool._loop = mock_loop
+        result = await tool.execute(task="crash test")
+        assert not result.success
+        assert "crash" in result.error
+
+
+# ── Module singletons ─────────────────────────────────────────────────────────
+
+class TestSingletons:
+
+    def test_vision_loop_singleton(self):
+        from bantz.vision.computer_use import vision_loop, AutonomousVisionLoop
+        assert isinstance(vision_loop, AutonomousVisionLoop)
+
+    def test_web_macros_singleton(self):
+        from bantz.vision.computer_use import web_macros, WebNavigationMacros
+        assert isinstance(web_macros, WebNavigationMacros)


### PR DESCRIPTION
## Summary

- Adds `src/bantz/vision/computer_use.py` — the full Observe→Analyze→Act→Verify closed-loop engine
- `AutonomousVisionLoop.execute(goal, on_step)` — main loop up to `max_steps` iterations
- `_decide_action()` — sends screenshot + history to VLM/LLM, parses JSON action
- `_verify_goal()` — checks if success criteria met after each action
- `_execute_action()` — dispatches click/type/scroll/hotkey/wait/read to input_control
- **Safety**: max_steps limit, total timeout, stuck detection (3 identical screenshots → abort), destructive hotkey gate (`alt+f4`, `ctrl+w`, etc.), domain allowlist for URL navigation
- `WebNavigationMacros` — `navigate_to_url`, `search_in_page`, `scroll_and_read`, `wait_for_element` shortcuts
- Butler–Gemini rivalry dialogue on VLM invocation/success/failure
- Adds `src/bantz/tools/computer_use.py` — `ComputerUseTool` registered as `"computer_use"` in tool registry
- Module singletons: `vision_loop`, `web_macros`

## Test plan

- [x] 44 tests in `tests/vision/test_computer_use.py` (requirement: ≥35)
- [x] Goal met on first verify → success
- [x] `action=done` exits loop immediately with success
- [x] Max steps reached → `error="max_steps_reached"`
- [x] `on_step` callback fires per iteration
- [x] Extracted text propagated from `done` action
- [x] `read` action accumulates extracted text
- [x] Stuck detection (3 identical screenshots) → `error="stuck"`
- [x] Timeout → `error="timeout"`
- [x] click/type/scroll/hotkey delegate to input_ctrl
- [x] Destructive hotkeys blocked (`alt+f4`, `ctrl+w`)
- [x] URL not in allowlist blocked
- [x] URL in allowlist allowed
- [x] `_verify_goal` detects done/not-done/error
- [x] `_parse_action_json` handles noise, empty, malformed
- [x] `WebNavigationMacros`: navigate_to_url, search_in_page, scroll_and_read, wait_for_element (found/timeout/no-loop)
- [x] `ComputerUseTool`: name, registered, missing-task error, success/failure/exception paths
- [x] Singleton identity checks
- [x] All 44 tests pass

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)