### PR TITLE
feat: FeedTool — RSS/Atom feed parser (#289)

### DIFF
--- a/config/feeds.yaml
+++ b/config/feeds.yaml
@@ -1,0 +1,38 @@
+# Bantz Feed Registry (#289)
+# Edit this file to add/remove RSS/Atom feeds without code changes.
+# Categories group related feeds — use any name you like.
+#
+# Usage: the FeedTool reads this file at startup.
+#   action=category category=tech   → fetches all tech feeds
+#   action=list                     → shows available categories
+
+feeds:
+  tech:
+    - name: Hacker News
+      url: https://hnrss.org/frontpage
+    - name: Ars Technica
+      url: https://feeds.arstechnica.com/arstechnica/index
+    - name: The Verge
+      url: https://www.theverge.com/rss/index.xml
+
+  world:
+    - name: BBC World
+      url: https://feeds.bbci.co.uk/news/world/rss.xml
+    - name: Al Jazeera
+      url: https://www.aljazeera.com/xml/rss/all.xml
+
+  tr_news:
+    - name: NTV
+      url: https://www.ntv.com.tr/son-dakika.rss
+    - name: Habertürk
+      url: https://www.haberturk.com/rss
+
+  science:
+    - name: Nature
+      url: https://www.nature.com/nature.rss
+    - name: Science Daily
+      url: https://www.sciencedaily.com/rss/all.xml
+
+  gaming:
+    - name: Ars Technica Gaming
+      url: https://feeds.arstechnica.com/arstechnica/gaming

--- a/src/bantz/core/intent.py
+++ b/src/bantz/core/intent.py
@@ -55,6 +55,7 @@ _ROUTING_HINTS: dict[str, str] = {
     "gui_action": "Interact with a specific labeled UI element in a desktop app",
     "computer_use": "Autonomous multi-step desktop automation using screen vision",
     "browser": "Advanced web page parsing: HTML, CSS selectors, image extraction",
+    "feed": "Fetch and parse RSS/Atom feeds. action=fetch url=<feed_url> for a direct URL, action=category category=<name> for a group (tech, world, tr_news, science, gaming), action=list to show available categories.",
 }
 
 

--- a/src/bantz/tools/feed_tool.py
+++ b/src/bantz/tools/feed_tool.py
@@ -1,0 +1,461 @@
+"""
+Bantz v2 — FeedTool: RSS/Atom feed parser (#289)
+
+Fetches and parses RSS/Atom feeds using ``curl`` + ``xml.etree.ElementTree``
+— replacing any news API dependency with direct feed consumption.
+
+Supports:
+  - RSS 2.0 (``<item>`` nodes)
+  - Atom 1.0 (``<entry>`` nodes)
+  - Image extraction from ``<media:content>``, ``<enclosure>``, ``<media:thumbnail>``
+  - Feed URL registry in ``config/feeds.yaml``
+
+Usage:
+    from bantz.tools.feed_tool import feed_tool
+    result = await feed_tool.execute(action="fetch", category="tech")
+"""
+from __future__ import annotations
+
+import logging
+import subprocess
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from datetime import datetime
+from email.utils import parsedate_to_datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from bantz.tools import BaseTool, ToolResult, registry
+
+log = logging.getLogger("bantz.tool.feed")
+
+# ── Feed registry paths ──────────────────────────────────────────────────────
+
+# Look for feeds.yaml in these locations (first match wins):
+#   1. <project_root>/config/feeds.yaml  (dev / repo checkout)
+#   2. ~/.config/bantz/feeds.yaml        (user override)
+_PROJECT_ROOT = Path(__file__).resolve().parents[3]  # src/bantz/tools → project root
+_REGISTRY_PATHS = [
+    _PROJECT_ROOT / "config" / "feeds.yaml",
+    Path.home() / ".config" / "bantz" / "feeds.yaml",
+]
+
+# ── Default feeds (used when no feeds.yaml exists) ────────────────────────────
+
+_DEFAULT_FEEDS: dict[str, list[dict[str, str]]] = {
+    "tech": [
+        {"name": "Hacker News", "url": "https://hnrss.org/frontpage"},
+        {"name": "Ars Technica", "url": "https://feeds.arstechnica.com/arstechnica/index"},
+    ],
+    "world": [
+        {"name": "BBC World", "url": "https://feeds.bbci.co.uk/news/world/rss.xml"},
+        {"name": "Reuters Top News", "url": "https://www.reutersagency.com/feed/"},
+    ],
+    "tr_news": [
+        {"name": "NTV", "url": "https://www.ntv.com.tr/son-dakika.rss"},
+        {"name": "Habertürk", "url": "https://www.haberturk.com/rss"},
+    ],
+}
+
+
+# ── Data classes ──────────────────────────────────────────────────────────────
+
+class FeedToolError(Exception):
+    """Raised when feed fetching or parsing fails."""
+
+
+@dataclass
+class FeedItem:
+    """A single item from an RSS/Atom feed."""
+    title: str
+    link: str
+    summary: str
+    image_url: str | None = None
+    published_at: datetime | None = None
+    source_name: str = ""
+
+
+# ── Feed registry ─────────────────────────────────────────────────────────────
+
+def _load_feed_registry() -> dict[str, list[dict[str, str]]]:
+    """Load feed registry from YAML, falling back to defaults."""
+    for path in _REGISTRY_PATHS:
+        if path.is_file():
+            try:
+                data = yaml.safe_load(path.read_text(encoding="utf-8"))
+                if isinstance(data, dict) and "feeds" in data:
+                    log.debug("Loaded feed registry from %s", path)
+                    return data["feeds"]
+            except Exception as exc:
+                log.warning("Failed to load %s: %s", path, exc)
+
+    log.debug("No feeds.yaml found, using defaults")
+    return _DEFAULT_FEEDS
+
+
+# ── XML parsing ───────────────────────────────────────────────────────────────
+
+# Namespace map for media:content / media:thumbnail
+_NS = {
+    "media": "http://search.yahoo.com/mrss/",
+    "atom": "http://www.w3.org/2005/Atom",
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "content": "http://purl.org/rss/1.0/modules/content/",
+}
+
+
+def _parse_date(date_str: str | None) -> datetime | None:
+    """Parse RFC 2822 (RSS) or ISO 8601 (Atom) dates.
+
+    Always returns a naive (UTC) datetime to avoid sorting issues
+    between timezone-aware and naive datetimes.
+    """
+    if not date_str:
+        return None
+    date_str = date_str.strip()
+
+    def _to_naive(dt: datetime) -> datetime:
+        """Convert to naive UTC datetime."""
+        if dt.tzinfo is not None:
+            from datetime import timezone
+            dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+        return dt
+
+    # RFC 2822 (RSS pubDate): "Mon, 01 Jan 2024 12:00:00 GMT"
+    try:
+        return _to_naive(parsedate_to_datetime(date_str))
+    except Exception:
+        pass
+
+    # ISO 8601 (Atom updated/published): "2024-01-01T12:00:00Z"
+    for fmt in ("%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%d"):
+        try:
+            return _to_naive(datetime.strptime(date_str, fmt))
+        except ValueError:
+            continue
+
+    return None
+
+
+def _extract_image(node: ET.Element, ns: dict[str, str]) -> str | None:
+    """Extract image URL from media:content, media:thumbnail, or enclosure."""
+    # media:content
+    media = node.find("media:content", ns)
+    if media is not None:
+        url = media.get("url")
+        if url:
+            return url
+
+    # media:thumbnail
+    thumb = node.find("media:thumbnail", ns)
+    if thumb is not None:
+        url = thumb.get("url")
+        if url:
+            return url
+
+    # enclosure (often used for podcast art / news images)
+    enclosure = node.find("enclosure")
+    if enclosure is not None:
+        mime = enclosure.get("type", "")
+        url = enclosure.get("url")
+        if url and ("image" in mime or not mime):
+            return url
+
+    return None
+
+
+def _strip_html(text: str) -> str:
+    """Rough HTML tag stripping for feed descriptions."""
+    import re
+    text = re.sub(r"<[^>]+>", "", text)
+    text = re.sub(r"&nbsp;", " ", text)
+    text = re.sub(r"&amp;", "&", text)
+    text = re.sub(r"&lt;", "<", text)
+    text = re.sub(r"&gt;", ">", text)
+    text = re.sub(r"&quot;", '"', text)
+    text = re.sub(r"&#\d+;", "", text)
+    return text.strip()
+
+
+def _parse_rss(root: ET.Element, source_name: str = "") -> list[FeedItem]:
+    """Parse RSS 2.0 feed (//channel/item nodes)."""
+    items: list[FeedItem] = []
+    for item in root.findall(".//item"):
+        title = item.findtext("title") or ""
+        link = item.findtext("link") or ""
+        summary = item.findtext("description") or ""
+        pub_date = item.findtext("pubDate") or item.findtext("dc:date", namespaces=_NS)
+        image = _extract_image(item, _NS)
+
+        items.append(FeedItem(
+            title=title.strip(),
+            link=link.strip(),
+            summary=_strip_html(summary)[:300],
+            image_url=image,
+            published_at=_parse_date(pub_date),
+            source_name=source_name,
+        ))
+    return items
+
+
+def _parse_atom(root: ET.Element, source_name: str = "") -> list[FeedItem]:
+    """Parse Atom 1.0 feed (//entry nodes)."""
+    items: list[FeedItem] = []
+    # Atom may have default namespace
+    ns = ""
+    if root.tag.startswith("{"):
+        ns = root.tag.split("}")[0] + "}"
+
+    for entry in root.findall(f".//{ns}entry"):
+        title = entry.findtext(f"{ns}title") or ""
+
+        # Atom link is an attribute, not text
+        link = ""
+        link_elem = entry.find(f"{ns}link[@rel='alternate']")
+        if link_elem is None:
+            link_elem = entry.find(f"{ns}link")
+        if link_elem is not None:
+            link = link_elem.get("href", "")
+
+        summary = entry.findtext(f"{ns}summary") or entry.findtext(f"{ns}content") or ""
+        published = entry.findtext(f"{ns}published") or entry.findtext(f"{ns}updated") or ""
+        image = _extract_image(entry, _NS)
+
+        items.append(FeedItem(
+            title=title.strip(),
+            link=link.strip(),
+            summary=_strip_html(summary)[:300],
+            image_url=image,
+            published_at=_parse_date(published),
+            source_name=source_name,
+        ))
+    return items
+
+
+def parse_feed(xml_text: str, source_name: str = "") -> list[FeedItem]:
+    """Parse an XML feed string (RSS 2.0 or Atom 1.0).
+
+    Raises ``FeedToolError`` if the XML cannot be parsed.
+    """
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError as exc:
+        raise FeedToolError(
+            f"Failed to parse feed XML: {exc}. "
+            "Expected valid RSS/Atom — got invalid data (captive portal or dead domain?)."
+        ) from exc
+
+    # Detect format: RSS has <channel>/<item>, Atom has <entry>
+    if root.findall(".//item"):
+        items = _parse_rss(root, source_name)
+    elif root.tag.endswith("feed") or root.findall(".//{http://www.w3.org/2005/Atom}entry"):
+        items = _parse_atom(root, source_name)
+    else:
+        # Try RSS anyway (some feeds have unusual structure)
+        items = _parse_rss(root, source_name)
+
+    return sorted(
+        items,
+        key=lambda x: x.published_at or datetime.min,
+        reverse=True,
+    )
+
+
+# ── Feed fetcher ──────────────────────────────────────────────────────────────
+
+def _fetch_raw(url: str, timeout: int = 12) -> str:
+    """Fetch raw XML from a feed URL using curl."""
+    try:
+        result = subprocess.run(
+            ["curl", "-sL", "--max-time", str(timeout), url],
+            capture_output=True,
+            text=True,
+            timeout=timeout + 3,
+        )
+        if result.returncode != 0:
+            raise FeedToolError(f"curl failed for {url}: exit {result.returncode}")
+        if not result.stdout.strip():
+            raise FeedToolError(f"Empty response from {url}")
+        return result.stdout
+    except subprocess.TimeoutExpired:
+        raise FeedToolError(f"Timeout fetching {url}")
+
+
+# ── Tool class ────────────────────────────────────────────────────────────────
+
+class FeedTool(BaseTool):
+    """Fetch and parse RSS/Atom feeds.
+
+    Actions:
+      - ``fetch``: Fetch a specific feed URL
+      - ``category``: Fetch all feeds in a category (from feeds.yaml)
+      - ``list``: List available categories
+    """
+
+    name = "feed"
+    description = (
+        "Fetch and parse RSS/Atom feeds for news, blogs, and content. "
+        "Params: action (fetch|category|list), "
+        "url (str) = direct feed URL for action=fetch, "
+        "category (str) = feed category from registry for action=category, "
+        "limit (int) = max items to return (default 10). "
+        "Use for: 'fetch RSS feed', 'show tech news from feeds', 'list feed categories'."
+    )
+    risk_level = "safe"
+
+    def __init__(self) -> None:
+        self._registry: dict[str, list[dict[str, str]]] | None = None
+
+    @property
+    def feed_registry(self) -> dict[str, list[dict[str, str]]]:
+        if self._registry is None:
+            self._registry = _load_feed_registry()
+        return self._registry
+
+    def reload_registry(self) -> None:
+        """Force reload of feed registry from disk."""
+        self._registry = None
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        action = kwargs.get("action", "fetch")
+        limit = int(kwargs.get("limit", 10))
+
+        if action == "list":
+            return self._list_categories()
+        elif action == "category":
+            category = kwargs.get("category", "")
+            return await self._fetch_category(category, limit)
+        else:  # "fetch" or default
+            url = kwargs.get("url", "")
+            if not url:
+                # If no URL, try to treat it as category
+                category = kwargs.get("category", "")
+                if category:
+                    return await self._fetch_category(category, limit)
+                return ToolResult(
+                    success=False, output="",
+                    error="Please provide a feed URL or category name.",
+                )
+            return await self._fetch_url(url, limit)
+
+    def _list_categories(self) -> ToolResult:
+        """List available feed categories."""
+        reg = self.feed_registry
+        if not reg:
+            return ToolResult(success=True, output="No feed categories configured.")
+
+        lines = ["📡 Available feed categories:"]
+        for cat, feeds in reg.items():
+            names = ", ".join(f["name"] for f in feeds)
+            lines.append(f"  • {cat}: {names}")
+        return ToolResult(success=True, output="\n".join(lines))
+
+    async def _fetch_url(self, url: str, limit: int) -> ToolResult:
+        """Fetch and parse a single feed URL."""
+        try:
+            raw = _fetch_raw(url)
+            items = parse_feed(raw)
+            return self._format_items(items[:limit])
+        except FeedToolError as exc:
+            return ToolResult(success=False, output="", error=str(exc))
+        except Exception as exc:
+            log.warning("FeedTool error: %s", exc)
+            return ToolResult(
+                success=False, output="",
+                error=f"Feed fetch failed: {exc}",
+            )
+
+    async def _fetch_category(self, category: str, limit: int) -> ToolResult:
+        """Fetch all feeds in a category."""
+        reg = self.feed_registry
+        cat_key = category.strip().lower().replace(" ", "_")
+
+        if cat_key not in reg:
+            available = ", ".join(reg.keys())
+            return ToolResult(
+                success=False, output="",
+                error=f"Unknown category '{category}'. Available: {available}",
+            )
+
+        all_items: list[FeedItem] = []
+        errors: list[str] = []
+
+        for feed_def in reg[cat_key]:
+            name = feed_def.get("name", "")
+            url = feed_def.get("url", "")
+            if not url:
+                continue
+            try:
+                raw = _fetch_raw(url)
+                items = parse_feed(raw, source_name=name)
+                all_items.extend(items)
+            except FeedToolError as exc:
+                errors.append(f"{name}: {exc}")
+                log.debug("Feed error for %s: %s", name, exc)
+
+        if not all_items and errors:
+            return ToolResult(
+                success=False, output="",
+                error=f"All feeds failed in '{category}': {'; '.join(errors)}",
+            )
+
+        # Re-sort merged items by date
+        all_items.sort(
+            key=lambda x: x.published_at or datetime.min,
+            reverse=True,
+        )
+
+        result = self._format_items(all_items[:limit])
+        if errors:
+            result.output += f"\n\n⚠ Some feeds failed: {'; '.join(errors)}"
+        return result
+
+    @staticmethod
+    def _format_items(items: list[FeedItem]) -> ToolResult:
+        """Format feed items into readable text output."""
+        if not items:
+            return ToolResult(success=True, output="No items found in feed.")
+
+        lines: list[str] = []
+        for i, item in enumerate(items, 1):
+            source = f" [{item.source_name}]" if item.source_name else ""
+            date = ""
+            if item.published_at:
+                date = f" ({item.published_at.strftime('%d %b %H:%M')})"
+
+            line = f"{i}. {item.title}{source}{date}"
+            if item.summary:
+                # Truncate summary for readability
+                summary = item.summary[:150]
+                if len(item.summary) > 150:
+                    summary += "…"
+                line += f"\n   {summary}"
+            if item.link:
+                line += f"\n   {item.link}"
+            lines.append(line)
+
+        header = f"📰 {len(items)} feed items:"
+        output = header + "\n\n" + "\n\n".join(lines)
+
+        # Include image URLs in data for downstream consumers
+        data: dict[str, Any] = {
+            "items": [
+                {
+                    "title": it.title,
+                    "link": it.link,
+                    "image_url": it.image_url,
+                    "published_at": it.published_at.isoformat() if it.published_at else None,
+                    "source": it.source_name,
+                }
+                for it in items
+            ],
+        }
+
+        return ToolResult(success=True, output=output, data=data)
+
+
+# ── Auto-register ─────────────────────────────────────────────────────────────
+feed_tool = FeedTool()
+registry.register(feed_tool)

--- a/tests/tools/test_feed_tool.py
+++ b/tests/tools/test_feed_tool.py
@@ -1,0 +1,233 @@
+"""Tests for FeedTool (#289)."""
+from __future__ import annotations
+
+import textwrap
+from datetime import datetime
+
+import pytest
+
+from bantz.tools.feed_tool import (
+    FeedItem,
+    FeedTool,
+    FeedToolError,
+    _parse_date,
+    _strip_html,
+    parse_feed,
+)
+
+
+# ── Sample feeds ──────────────────────────────────────────────────────────────
+
+RSS_SAMPLE = textwrap.dedent("""\
+    <?xml version="1.0" encoding="UTF-8"?>
+    <rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+      <channel>
+        <title>Test Feed</title>
+        <item>
+          <title>First Article</title>
+          <link>https://example.com/1</link>
+          <description>Summary of the first article.</description>
+          <pubDate>Mon, 01 Jan 2024 12:00:00 GMT</pubDate>
+          <media:content url="https://example.com/img1.jpg" medium="image"/>
+        </item>
+        <item>
+          <title>Second Article</title>
+          <link>https://example.com/2</link>
+          <description>&lt;p&gt;HTML in summary&lt;/p&gt;</description>
+          <pubDate>Tue, 02 Jan 2024 08:00:00 GMT</pubDate>
+          <enclosure url="https://example.com/img2.jpg" type="image/jpeg"/>
+        </item>
+        <item>
+          <title>No Date Article</title>
+          <link>https://example.com/3</link>
+          <description></description>
+        </item>
+      </channel>
+    </rss>
+""")
+
+ATOM_SAMPLE = textwrap.dedent("""\
+    <?xml version="1.0" encoding="UTF-8"?>
+    <feed xmlns="http://www.w3.org/2005/Atom">
+      <title>Atom Test Feed</title>
+      <entry>
+        <title>Atom Entry One</title>
+        <link rel="alternate" href="https://example.com/atom/1"/>
+        <summary>First atom entry.</summary>
+        <published>2024-03-15T10:00:00Z</published>
+      </entry>
+      <entry>
+        <title>Atom Entry Two</title>
+        <link href="https://example.com/atom/2"/>
+        <content>Content of entry two.</content>
+        <updated>2024-03-14T08:00:00Z</updated>
+      </entry>
+    </feed>
+""")
+
+INVALID_XML = "<not><valid xml"
+
+
+# ── Tests: parse_feed ─────────────────────────────────────────────────────────
+
+class TestParseFeed:
+    def test_rss_basic(self):
+        items = parse_feed(RSS_SAMPLE, source_name="TestFeed")
+        assert len(items) == 3
+        # Sorted by date descending: Second (Jan 2), First (Jan 1), No Date (min)
+        assert items[0].title == "Second Article"
+        assert items[1].title == "First Article"
+        assert items[2].title == "No Date Article"
+
+    def test_rss_fields(self):
+        items = parse_feed(RSS_SAMPLE)
+        first = next(i for i in items if i.title == "First Article")
+        assert first.link == "https://example.com/1"
+        assert "first article" in first.summary.lower()
+        assert first.image_url == "https://example.com/img1.jpg"
+        assert first.published_at is not None
+        assert first.published_at.year == 2024
+
+    def test_rss_enclosure_image(self):
+        items = parse_feed(RSS_SAMPLE)
+        second = next(i for i in items if i.title == "Second Article")
+        assert second.image_url == "https://example.com/img2.jpg"
+
+    def test_rss_html_stripped(self):
+        items = parse_feed(RSS_SAMPLE)
+        second = next(i for i in items if i.title == "Second Article")
+        assert "<p>" not in second.summary
+        assert "HTML in summary" in second.summary
+
+    def test_rss_missing_description(self):
+        items = parse_feed(RSS_SAMPLE)
+        no_date = next(i for i in items if i.title == "No Date Article")
+        assert no_date.summary == ""
+        assert no_date.published_at is None
+        assert no_date.image_url is None
+
+    def test_rss_source_name(self):
+        items = parse_feed(RSS_SAMPLE, source_name="MySource")
+        assert all(i.source_name == "MySource" for i in items)
+
+    def test_atom_basic(self):
+        items = parse_feed(ATOM_SAMPLE)
+        assert len(items) == 2
+        # Sorted by date descending
+        assert items[0].title == "Atom Entry One"
+        assert items[1].title == "Atom Entry Two"
+
+    def test_atom_fields(self):
+        items = parse_feed(ATOM_SAMPLE)
+        first = items[0]
+        assert first.link == "https://example.com/atom/1"
+        assert "first atom entry" in first.summary.lower()
+        assert first.published_at is not None
+
+    def test_atom_content_fallback(self):
+        items = parse_feed(ATOM_SAMPLE)
+        second = items[1]
+        assert "Content of entry two" in second.summary
+
+    def test_invalid_xml_raises(self):
+        with pytest.raises(FeedToolError, match="Failed to parse"):
+            parse_feed(INVALID_XML)
+
+    def test_empty_feed(self):
+        xml = '<?xml version="1.0"?><rss><channel></channel></rss>'
+        items = parse_feed(xml)
+        assert items == []
+
+    def test_sorted_by_date_descending(self):
+        items = parse_feed(RSS_SAMPLE)
+        dates = [i.published_at for i in items if i.published_at]
+        assert dates == sorted(dates, reverse=True)
+
+
+# ── Tests: _parse_date ────────────────────────────────────────────────────────
+
+class TestParseDate:
+    def test_rfc2822(self):
+        dt = _parse_date("Mon, 01 Jan 2024 12:00:00 GMT")
+        assert dt is not None
+        assert dt.year == 2024
+
+    def test_iso8601(self):
+        dt = _parse_date("2024-03-15T10:00:00Z")
+        assert dt is not None
+        assert dt.month == 3
+
+    def test_date_only(self):
+        dt = _parse_date("2024-01-15")
+        assert dt is not None
+        assert dt.day == 15
+
+    def test_none_input(self):
+        assert _parse_date(None) is None
+
+    def test_empty_string(self):
+        assert _parse_date("") is None
+
+    def test_garbage(self):
+        assert _parse_date("not a date") is None
+
+
+# ── Tests: _strip_html ───────────────────────────────────────────────────────
+
+class TestStripHtml:
+    def test_basic_tags(self):
+        assert _strip_html("<p>Hello</p>") == "Hello"
+
+    def test_entities(self):
+        assert _strip_html("&amp; &lt; &gt;") == "& < >"
+
+    def test_nested(self):
+        assert _strip_html("<div><b>Bold</b> text</div>") == "Bold text"
+
+    def test_plain_text(self):
+        assert _strip_html("No HTML here") == "No HTML here"
+
+
+# ── Tests: FeedTool actions ───────────────────────────────────────────────────
+
+class TestFeedTool:
+    def test_list_categories(self):
+        tool = FeedTool()
+        result = tool._list_categories()
+        assert result.success
+        assert "tech" in result.output.lower() or "Available" in result.output
+
+    @pytest.mark.asyncio
+    async def test_fetch_no_url(self):
+        tool = FeedTool()
+        result = await tool.execute(action="fetch")
+        assert not result.success
+        assert "url" in result.error.lower() or "category" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_unknown_category(self):
+        tool = FeedTool()
+        result = await tool.execute(action="category", category="nonexistent")
+        assert not result.success
+        assert "Unknown category" in result.error
+
+    def test_format_items(self):
+        items = [
+            FeedItem(
+                title="Test",
+                link="https://example.com",
+                summary="A test summary",
+                published_at=datetime(2024, 1, 1, 12, 0),
+                source_name="Source",
+            ),
+        ]
+        result = FeedTool._format_items(items)
+        assert result.success
+        assert "Test" in result.output
+        assert "Source" in result.output
+        assert "items" in result.data
+
+    def test_format_empty_items(self):
+        result = FeedTool._format_items([])
+        assert result.success
+        assert "No items" in result.output


### PR DESCRIPTION
## Summary
Implements `FeedTool` that fetches and parses RSS/Atom feeds using `curl` + `xml.etree.ElementTree`.

## Changes
- **`src/bantz/tools/feed_tool.py`**: Full FeedTool implementation
  - RSS 2.0 (`<item>`) and Atom 1.0 (`<entry>`) support
  - Node-by-node parsing (no array misalignment — per owner's comment)
  - Image extraction: `media:content`, `media:thumbnail`, `enclosure`
  - `FeedItem(title, link, summary, image_url, published_at)` dataclass
  - Results sorted by `published_at` descending
  - Graceful handling of missing fields, invalid XML
  - Actions: `fetch` (direct URL), `category` (from registry), `list` (show categories)
- **`config/feeds.yaml`**: Feed URL registry (tech, world, tr_news, science, gaming)
- **`tests/tools/test_feed_tool.py`**: 27 unit tests — all passing
- **`src/bantz/core/intent.py`**: Added `feed` tool routing hint

## Acceptance Criteria
- [x] `FeedTool.fetch(feed_url)` → list of `FeedItem`
- [x] RSS 2.0 and Atom 1.0 support
- [x] `image_url` from `media:content` / `enclosure`
- [x] Sorted by `published_at` descending
- [x] Feed registry in `config/feeds.yaml`
- [x] Graceful missing field handling

Closes #289