### PR TITLE
feat: GUITool — pyautogui + xdotool desktop automation bridge

### DIFF
--- a/src/bantz/core/intent.py
+++ b/src/bantz/core/intent.py
@@ -57,6 +57,7 @@ _ROUTING_HINTS: dict[str, str] = {
     "browser": "Advanced web page parsing: HTML, CSS selectors, image extraction",
     "feed": "Fetch and parse RSS/Atom feeds. action=fetch url=<feed_url> for a direct URL, action=category category=<name> for a group (tech, world, tr_news, science, gaming), action=list to show available categories.",
     "image": "Download, cache, and render images. action=render url=<image_url> for ANSI terminal art via chafa, action=download to cache only, action=raw for Telegram send_photo bytes.",
+    "gui": "Desktop GUI automation via pyautogui + xdotool. action=click x=<int> y=<int>, action=click_image template=<path>, action=type text=<str>, action=focus_window title=<pattern> wm_class=<class>, action=screenshot region=<x,y,w,h>, action=scroll x=<int> y=<int> clicks=<int>, action=action_log to inspect recorded actions.",
 }
 
 

--- a/src/bantz/tools/gui_tool.py
+++ b/src/bantz/tools/gui_tool.py
@@ -1,0 +1,311 @@
+"""
+Bantz v2 — GUITool: pyautogui + xdotool desktop automation bridge (#292)
+
+Low-level input execution layer for desktop GUI automation.
+Handles the actual mouse clicks, keystrokes, scrolling, window focus,
+and screenshot capture once a higher-level navigator resolves target
+coordinates.
+
+Key design decisions (from issue #292 discussion):
+ • _dry_run as @property — checked at call time, not import time.
+ • pyautogui.FAILSAFE = False — agent mouse moves are intentional,
+   corner clicks are legitimate actions, not panic signals.
+ • pyautogui.PAUSE = 0 — timing is controlled via DELAY (300 ms).
+ • click_image guards against non-existent paths (prevents OpenCV
+   C++ assertion crash on hallucinated file paths).
+ • focus_window prefers --class over --name with fallback chain.
+ • Every action is timestamped in _action_log for replay / debug.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pyautogui
+
+from bantz.tools import BaseTool, ToolResult, registry
+
+# ── pyautogui global config ──────────────────────────────────────────────────
+pyautogui.FAILSAFE = False
+pyautogui.PAUSE = 0
+
+logger = logging.getLogger(__name__)
+
+CACHE_DIR = Path.home() / ".bantz" / "cache"
+CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+# ── Custom exception ─────────────────────────────────────────────────────────
+
+class GUIToolError(RuntimeError):
+    """Raised on recoverable GUI automation failures."""
+
+
+# ── Core GUITool ─────────────────────────────────────────────────────────────
+
+class GUITool(BaseTool):
+    name = "gui"
+    description = (
+        "Desktop GUI automation: click, type, scroll, focus windows, "
+        "screenshot, and template-image matching via pyautogui + xdotool"
+    )
+    risk_level = "destructive"
+
+    DELAY: float = 0.3  # 300 ms safety delay before every action
+
+    def __init__(self) -> None:
+        self._action_log: list[dict[str, Any]] = []
+
+    # ── helpers ───────────────────────────────────────────────────────────
+
+    @property
+    def _dry_run(self) -> bool:
+        """Checked at call time so toggling the env var takes effect immediately."""
+        return os.getenv("BANTZ_DRY_RUN", "0") == "1"
+
+    def _log_action(self, action: str, **params: Any) -> None:
+        entry = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "action": action,
+            **params,
+        }
+        self._action_log.append(entry)
+        logger.debug("gui_action: %s", entry)
+
+    # ── click ─────────────────────────────────────────────────────────────
+
+    def click(self, x: int, y: int) -> None:
+        """Click at exact screen coordinates."""
+        self._log_action("click", x=x, y=y)
+        time.sleep(self.DELAY)
+        if self._dry_run:
+            logger.info("[DRY_RUN] click(%d, %d)", x, y)
+            return
+        pyautogui.click(x, y)
+
+    # ── click_image ───────────────────────────────────────────────────────
+
+    def click_image(
+        self, template_path: str, confidence: float = 0.9
+    ) -> tuple[int, int]:
+        """Locate *template_path* on screen and click its centre.
+
+        Guards:
+        • FileNotFoundError on disk  → GUIToolError (prevents OpenCV crash)
+        • NotImplementedError        → GUIToolError (OpenCV missing)
+        • ImageNotFoundException     → GUIToolError (modern pyautogui)
+        • None return                → GUIToolError (legacy pyautogui)
+        """
+        if not Path(template_path).exists():
+            raise GUIToolError(
+                f"Template image not found on disk: {template_path}"
+            )
+        self._log_action("click_image", template=template_path, confidence=confidence)
+        time.sleep(self.DELAY)
+        if self._dry_run:
+            logger.info("[DRY_RUN] click_image(%s)", template_path)
+            return (0, 0)
+        try:
+            location = pyautogui.locateOnScreen(
+                template_path, confidence=confidence
+            )
+        except NotImplementedError:
+            raise GUIToolError(
+                "OpenCV is required for confidence matching. "
+                "Run: pip install opencv-python"
+            )
+        except pyautogui.ImageNotFoundException:
+            raise GUIToolError(f"Image not found on screen: {template_path}")
+        if location is None:
+            raise GUIToolError(f"Image not found on screen: {template_path}")
+        center = pyautogui.center(location)
+        pyautogui.click(center)
+        return (center.x, center.y)
+
+    # ── type ──────────────────────────────────────────────────────────────
+
+    def type_text(self, text: str, interval: float = 0.05) -> None:
+        """Type *text* with realistic keystroke delay."""
+        self._log_action("type", text=text, interval=interval)
+        time.sleep(self.DELAY)
+        if self._dry_run:
+            logger.info("[DRY_RUN] type(%r)", text)
+            return
+        pyautogui.typewrite(text, interval=interval)
+
+    # ── focus_window ──────────────────────────────────────────────────────
+
+    def focus_window(self, title: str, wm_class: str | None = None) -> None:
+        """Focus a window using xdotool.
+
+        Prefers ``--class`` when *wm_class* is provided, falls back to
+        ``--name`` on mismatch.  Handles xdotool absence gracefully.
+        """
+        self._log_action("focus_window", title=title, wm_class=wm_class)
+        if self._dry_run:
+            logger.info("[DRY_RUN] focus_window('%s')", title)
+            return
+        try:
+            query = ["--class", wm_class] if wm_class else ["--name", title]
+            subprocess.run(
+                ["xdotool", "search"] + query + ["windowactivate", "--sync"],
+                check=True,
+                timeout=5,
+            )
+        except subprocess.CalledProcessError:
+            if wm_class:
+                # Fallback: try by name
+                try:
+                    subprocess.run(
+                        [
+                            "xdotool", "search", "--name", title,
+                            "windowactivate", "--sync",
+                        ],
+                        check=True,
+                        timeout=5,
+                    )
+                except subprocess.CalledProcessError:
+                    raise GUIToolError(
+                        f"Window not found by class or name: '{title}'"
+                    )
+                except subprocess.TimeoutExpired:
+                    raise GUIToolError(
+                        f"xdotool timed out focusing '{title}' (name fallback)"
+                    )
+            else:
+                raise GUIToolError(f"Window not found: '{title}'")
+        except FileNotFoundError:
+            logger.warning("xdotool not available — window focus skipped")
+        except subprocess.TimeoutExpired:
+            raise GUIToolError(f"xdotool timed out focusing '{title}'")
+
+    # ── screenshot ────────────────────────────────────────────────────────
+
+    def screenshot(
+        self, region: tuple[int, int, int, int] | None = None
+    ) -> str:
+        """Capture full screen or *region* → saved to cache, returns path."""
+        self._log_action("screenshot", region=region)
+        if self._dry_run:
+            logger.info("[DRY_RUN] screenshot(region=%s)", region)
+            return str(CACHE_DIR / "dry_run_screenshot.png")
+        img = pyautogui.screenshot(region=region)
+        ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S_%f")
+        path = CACHE_DIR / f"screenshot_{ts}.png"
+        img.save(str(path))
+        return str(path)
+
+    # ── scroll ────────────────────────────────────────────────────────────
+
+    def scroll(self, x: int, y: int, clicks: int) -> None:
+        """Scroll *clicks* at screen coordinates (*x*, *y*)."""
+        self._log_action("scroll", x=x, y=y, clicks=clicks)
+        time.sleep(self.DELAY)
+        if self._dry_run:
+            logger.info("[DRY_RUN] scroll(%d, %d, %d)", x, y, clicks)
+            return
+        pyautogui.moveTo(x, y)
+        pyautogui.scroll(clicks)
+
+    # ── action log access ─────────────────────────────────────────────────
+
+    def get_action_log(self) -> list[dict[str, Any]]:
+        """Return a copy of the timestamped action log."""
+        return list(self._action_log)
+
+    def clear_action_log(self) -> int:
+        """Clear the action log and return how many entries were removed."""
+        n = len(self._action_log)
+        self._action_log.clear()
+        return n
+
+    # ── BaseTool interface ────────────────────────────────────────────────
+
+    async def execute(self, **kwargs: Any) -> ToolResult:  # noqa: C901
+        action = kwargs.get("action", "click")
+        try:
+            if action == "click":
+                x, y = int(kwargs["x"]), int(kwargs["y"])
+                self.click(x, y)
+                return ToolResult(success=True, output=f"Clicked ({x}, {y})")
+
+            if action == "click_image":
+                template = kwargs["template"]
+                confidence = float(kwargs.get("confidence", 0.9))
+                cx, cy = self.click_image(template, confidence)
+                return ToolResult(
+                    success=True,
+                    output=f"Clicked image match at ({cx}, {cy})",
+                    data={"x": cx, "y": cy},
+                )
+
+            if action == "type":
+                text = kwargs["text"]
+                interval = float(kwargs.get("interval", 0.05))
+                self.type_text(text, interval)
+                return ToolResult(
+                    success=True, output=f"Typed {len(text)} characters"
+                )
+
+            if action == "focus_window":
+                title = kwargs["title"]
+                wm_class = kwargs.get("wm_class")
+                self.focus_window(title, wm_class)
+                return ToolResult(
+                    success=True, output=f"Focused window '{title}'"
+                )
+
+            if action == "screenshot":
+                region = kwargs.get("region")
+                if region is not None:
+                    region = tuple(int(v) for v in region)
+                path = self.screenshot(region)
+                return ToolResult(
+                    success=True,
+                    output=f"Screenshot saved to {path}",
+                    data={"path": path},
+                )
+
+            if action == "scroll":
+                x, y = int(kwargs["x"]), int(kwargs["y"])
+                clicks = int(kwargs["clicks"])
+                self.scroll(x, y, clicks)
+                return ToolResult(
+                    success=True, output=f"Scrolled {clicks} at ({x}, {y})"
+                )
+
+            if action == "action_log":
+                log = self.get_action_log()
+                return ToolResult(
+                    success=True,
+                    output=f"{len(log)} recorded actions",
+                    data={"log": log},
+                )
+
+            if action == "clear_log":
+                n = self.clear_action_log()
+                return ToolResult(
+                    success=True, output=f"Cleared {n} action log entries"
+                )
+
+            return ToolResult(
+                success=False, output="", error=f"Unknown action: {action}"
+            )
+
+        except GUIToolError as exc:
+            return ToolResult(success=False, output="", error=str(exc))
+        except KeyError as exc:
+            return ToolResult(
+                success=False, output="",
+                error=f"Missing required parameter: {exc}",
+            )
+
+
+# ── Auto-register ────────────────────────────────────────────────────────────
+gui_tool = GUITool()
+registry.register(gui_tool)

--- a/tests/tools/test_gui_tool.py
+++ b/tests/tools/test_gui_tool.py
@@ -1,0 +1,446 @@
+"""Tests for GUITool (#292)."""
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from bantz.tools.gui_tool import (
+    CACHE_DIR,
+    GUITool,
+    GUIToolError,
+    gui_tool,
+)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def tool():
+    """Fresh GUITool with empty action log."""
+    t = GUITool()
+    return t
+
+
+@pytest.fixture
+def dry(monkeypatch):
+    """Enable DRY_RUN mode."""
+    monkeypatch.setenv("BANTZ_DRY_RUN", "1")
+
+
+@pytest.fixture
+def no_dry(monkeypatch):
+    """Ensure DRY_RUN is off."""
+    monkeypatch.setenv("BANTZ_DRY_RUN", "0")
+
+
+@pytest.fixture
+def fake_template(tmp_path):
+    """Create a fake template image on disk."""
+    p = tmp_path / "button.png"
+    p.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 50)
+    return str(p)
+
+
+# ── Tests: _dry_run property ─────────────────────────────────────────────────
+
+class TestDryRun:
+    def test_dry_run_off_by_default(self, tool, no_dry):
+        assert tool._dry_run is False
+
+    def test_dry_run_on(self, tool, dry):
+        assert tool._dry_run is True
+
+    def test_dry_run_checked_at_call_time(self, tool, monkeypatch):
+        """Verify that _dry_run is NOT cached at import time."""
+        monkeypatch.setenv("BANTZ_DRY_RUN", "0")
+        assert tool._dry_run is False
+        monkeypatch.setenv("BANTZ_DRY_RUN", "1")
+        assert tool._dry_run is True
+
+
+# ── Tests: click ──────────────────────────────────────────────────────────────
+
+class TestClick:
+    @patch("bantz.tools.gui_tool.pyautogui")
+    @patch("bantz.tools.gui_tool.time")
+    def test_click_calls_pyautogui(self, mock_time, mock_pag, tool, no_dry):
+        tool.click(100, 200)
+        mock_time.sleep.assert_called_once_with(0.3)
+        mock_pag.click.assert_called_once_with(100, 200)
+
+    @patch("bantz.tools.gui_tool.pyautogui")
+    def test_click_dry_run(self, mock_pag, tool, dry):
+        tool.click(100, 200)
+        mock_pag.click.assert_not_called()
+
+    def test_click_logs_action(self, tool, dry):
+        tool.click(50, 60)
+        log = tool.get_action_log()
+        assert len(log) == 1
+        assert log[0]["action"] == "click"
+        assert log[0]["x"] == 50
+        assert log[0]["y"] == 60
+        assert "ts" in log[0]
+
+
+# ── Tests: click_image ────────────────────────────────────────────────────────
+
+class TestClickImage:
+    def test_missing_template_raises(self, tool, no_dry):
+        with pytest.raises(GUIToolError, match="not found on disk"):
+            tool.click_image("/nonexistent/image.png")
+
+    def test_dry_run_returns_origin(self, tool, dry, fake_template):
+        result = tool.click_image(fake_template)
+        assert result == (0, 0)
+
+    @patch("bantz.tools.gui_tool.pyautogui")
+    def test_not_implemented_opencv(self, mock_pag, tool, no_dry, fake_template):
+        mock_pag.locateOnScreen.side_effect = NotImplementedError
+        with pytest.raises(GUIToolError, match="OpenCV is required"):
+            tool.click_image(fake_template)
+
+    @patch("bantz.tools.gui_tool.pyautogui")
+    def test_image_not_found_exception(self, mock_pag, tool, no_dry, fake_template):
+        mock_pag.ImageNotFoundException = type("ImageNotFoundException", (Exception,), {})
+        mock_pag.locateOnScreen.side_effect = mock_pag.ImageNotFoundException
+        with pytest.raises(GUIToolError, match="Image not found on screen"):
+            tool.click_image(fake_template)
+
+    @patch("bantz.tools.gui_tool.pyautogui")
+    def test_image_not_found_none(self, mock_pag, tool, no_dry, fake_template):
+        """Legacy pyautogui returns None instead of raising."""
+        mock_pag.locateOnScreen.return_value = None
+        mock_pag.ImageNotFoundException = type("ImageNotFoundException", (Exception,), {})
+        with pytest.raises(GUIToolError, match="Image not found on screen"):
+            tool.click_image(fake_template)
+
+    @patch("bantz.tools.gui_tool.pyautogui")
+    def test_click_image_success(self, mock_pag, tool, no_dry, fake_template):
+        mock_pag.ImageNotFoundException = type("ImageNotFoundException", (Exception,), {})
+        mock_loc = MagicMock()
+        mock_pag.locateOnScreen.return_value = mock_loc
+        mock_center = SimpleNamespace(x=150, y=250)
+        mock_pag.center.return_value = mock_center
+
+        result = tool.click_image(fake_template, confidence=0.8)
+
+        mock_pag.locateOnScreen.assert_called_once_with(
+            fake_template, confidence=0.8
+        )
+        mock_pag.center.assert_called_once_with(mock_loc)
+        mock_pag.click.assert_called_once_with(mock_center)
+        assert result == (150, 250)
+
+    def test_click_image_logs_action(self, tool, dry, fake_template):
+        tool.click_image(fake_template)
+        log = tool.get_action_log()
+        assert log[-1]["action"] == "click_image"
+        assert log[-1]["template"] == fake_template
+
+
+# ── Tests: type_text ──────────────────────────────────────────────────────────
+
+class TestTypeText:
+    @patch("bantz.tools.gui_tool.pyautogui")
+    @patch("bantz.tools.gui_tool.time")
+    def test_type_calls_typewrite(self, mock_time, mock_pag, tool, no_dry):
+        tool.type_text("hello", interval=0.1)
+        mock_time.sleep.assert_called_once_with(0.3)
+        mock_pag.typewrite.assert_called_once_with("hello", interval=0.1)
+
+    @patch("bantz.tools.gui_tool.pyautogui")
+    def test_type_dry_run(self, mock_pag, tool, dry):
+        tool.type_text("secret")
+        mock_pag.typewrite.assert_not_called()
+
+    def test_type_logs_action(self, tool, dry):
+        tool.type_text("hi")
+        log = tool.get_action_log()
+        assert log[-1]["action"] == "type"
+        assert log[-1]["text"] == "hi"
+
+
+# ── Tests: focus_window ──────────────────────────────────────────────────────
+
+class TestFocusWindow:
+    @patch("bantz.tools.gui_tool.subprocess")
+    def test_focus_by_name(self, mock_sub, tool, no_dry):
+        mock_sub.CalledProcessError = subprocess.CalledProcessError
+        mock_sub.TimeoutExpired = subprocess.TimeoutExpired
+        tool.focus_window("Firefox")
+        mock_sub.run.assert_called_once_with(
+            ["xdotool", "search", "--name", "Firefox",
+             "windowactivate", "--sync"],
+            check=True, timeout=5,
+        )
+
+    @patch("bantz.tools.gui_tool.subprocess")
+    def test_focus_by_class(self, mock_sub, tool, no_dry):
+        mock_sub.CalledProcessError = subprocess.CalledProcessError
+        mock_sub.TimeoutExpired = subprocess.TimeoutExpired
+        tool.focus_window("Firefox", wm_class="Navigator")
+        mock_sub.run.assert_called_once_with(
+            ["xdotool", "search", "--class", "Navigator",
+             "windowactivate", "--sync"],
+            check=True, timeout=5,
+        )
+
+    @patch("bantz.tools.gui_tool.subprocess")
+    def test_focus_class_fallback_to_name(self, mock_sub, tool, no_dry):
+        """When --class fails, falls back to --name."""
+        mock_sub.CalledProcessError = subprocess.CalledProcessError
+        mock_sub.TimeoutExpired = subprocess.TimeoutExpired
+        mock_sub.run.side_effect = [
+            subprocess.CalledProcessError(1, "xdotool"),  # --class fails
+            None,  # --name succeeds
+        ]
+        tool.focus_window("Firefox", wm_class="Navigator")
+        assert mock_sub.run.call_count == 2
+
+    @patch("bantz.tools.gui_tool.subprocess")
+    def test_focus_class_and_name_fail(self, mock_sub, tool, no_dry):
+        mock_sub.CalledProcessError = subprocess.CalledProcessError
+        mock_sub.TimeoutExpired = subprocess.TimeoutExpired
+        mock_sub.run.side_effect = subprocess.CalledProcessError(1, "xdotool")
+        with pytest.raises(GUIToolError, match="not found by class or name"):
+            tool.focus_window("Firefox", wm_class="Navigator")
+
+    @patch("bantz.tools.gui_tool.subprocess")
+    def test_focus_name_only_fail(self, mock_sub, tool, no_dry):
+        mock_sub.CalledProcessError = subprocess.CalledProcessError
+        mock_sub.TimeoutExpired = subprocess.TimeoutExpired
+        mock_sub.run.side_effect = subprocess.CalledProcessError(1, "xdotool")
+        with pytest.raises(GUIToolError, match="Window not found: 'Firefox'"):
+            tool.focus_window("Firefox")
+
+    @patch("bantz.tools.gui_tool.subprocess")
+    def test_focus_xdotool_missing(self, mock_sub, tool, no_dry):
+        """xdotool not installed → warning, no crash."""
+        mock_sub.CalledProcessError = subprocess.CalledProcessError
+        mock_sub.TimeoutExpired = subprocess.TimeoutExpired
+        mock_sub.run.side_effect = FileNotFoundError
+        tool.focus_window("Firefox")  # should NOT raise
+
+    @patch("bantz.tools.gui_tool.subprocess")
+    def test_focus_timeout(self, mock_sub, tool, no_dry):
+        mock_sub.CalledProcessError = subprocess.CalledProcessError
+        mock_sub.TimeoutExpired = subprocess.TimeoutExpired
+        mock_sub.run.side_effect = subprocess.TimeoutExpired("xdotool", 5)
+        with pytest.raises(GUIToolError, match="timed out"):
+            tool.focus_window("Firefox")
+
+    @patch("bantz.tools.gui_tool.subprocess")
+    def test_focus_class_fail_name_timeout(self, mock_sub, tool, no_dry):
+        """--class fails, --name times out."""
+        mock_sub.CalledProcessError = subprocess.CalledProcessError
+        mock_sub.TimeoutExpired = subprocess.TimeoutExpired
+        mock_sub.run.side_effect = [
+            subprocess.CalledProcessError(1, "xdotool"),
+            subprocess.TimeoutExpired("xdotool", 5),
+        ]
+        with pytest.raises(GUIToolError, match="timed out"):
+            tool.focus_window("Firefox", wm_class="Navigator")
+
+    def test_focus_dry_run(self, tool, dry):
+        tool.focus_window("Firefox")  # should NOT raise or call subprocess
+
+    def test_focus_logs_action(self, tool, dry):
+        tool.focus_window("Firefox", wm_class="Nav")
+        log = tool.get_action_log()
+        assert log[-1]["action"] == "focus_window"
+        assert log[-1]["wm_class"] == "Nav"
+
+
+# ── Tests: screenshot ────────────────────────────────────────────────────────
+
+class TestScreenshot:
+    @patch("bantz.tools.gui_tool.pyautogui")
+    def test_screenshot_full(self, mock_pag, tool, no_dry, tmp_path, monkeypatch):
+        import bantz.tools.gui_tool as mod
+        monkeypatch.setattr(mod, "CACHE_DIR", tmp_path)
+
+        mock_img = MagicMock()
+        mock_pag.screenshot.return_value = mock_img
+
+        path = tool.screenshot()
+
+        mock_pag.screenshot.assert_called_once_with(region=None)
+        assert path.startswith(str(tmp_path))
+        assert path.endswith(".png")
+        mock_img.save.assert_called_once()
+
+    @patch("bantz.tools.gui_tool.pyautogui")
+    def test_screenshot_region(self, mock_pag, tool, no_dry, tmp_path, monkeypatch):
+        import bantz.tools.gui_tool as mod
+        monkeypatch.setattr(mod, "CACHE_DIR", tmp_path)
+
+        mock_img = MagicMock()
+        mock_pag.screenshot.return_value = mock_img
+        region = (10, 20, 300, 400)
+
+        path = tool.screenshot(region=region)
+
+        mock_pag.screenshot.assert_called_once_with(region=region)
+
+    def test_screenshot_dry_run(self, tool, dry):
+        path = tool.screenshot()
+        assert "dry_run_screenshot" in path
+
+    def test_screenshot_logs_action(self, tool, dry):
+        tool.screenshot(region=(1, 2, 3, 4))
+        log = tool.get_action_log()
+        assert log[-1]["action"] == "screenshot"
+        assert log[-1]["region"] == (1, 2, 3, 4)
+
+
+# ── Tests: scroll ────────────────────────────────────────────────────────────
+
+class TestScroll:
+    @patch("bantz.tools.gui_tool.pyautogui")
+    @patch("bantz.tools.gui_tool.time")
+    def test_scroll_calls_pyautogui(self, mock_time, mock_pag, tool, no_dry):
+        tool.scroll(100, 200, 5)
+        mock_time.sleep.assert_called_once_with(0.3)
+        mock_pag.moveTo.assert_called_once_with(100, 200)
+        mock_pag.scroll.assert_called_once_with(5)
+
+    @patch("bantz.tools.gui_tool.pyautogui")
+    def test_scroll_dry_run(self, mock_pag, tool, dry):
+        tool.scroll(100, 200, 5)
+        mock_pag.moveTo.assert_not_called()
+        mock_pag.scroll.assert_not_called()
+
+    def test_scroll_logs_action(self, tool, dry):
+        tool.scroll(10, 20, -3)
+        log = tool.get_action_log()
+        assert log[-1]["action"] == "scroll"
+        assert log[-1]["clicks"] == -3
+
+
+# ── Tests: action log ────────────────────────────────────────────────────────
+
+class TestActionLog:
+    def test_empty_log(self, tool):
+        assert tool.get_action_log() == []
+
+    def test_log_accumulates(self, tool, dry):
+        tool.click(1, 2)
+        tool.type_text("a")
+        tool.scroll(3, 4, 1)
+        assert len(tool.get_action_log()) == 3
+
+    def test_clear_log(self, tool, dry):
+        tool.click(1, 2)
+        tool.click(3, 4)
+        n = tool.clear_action_log()
+        assert n == 2
+        assert tool.get_action_log() == []
+
+    def test_get_log_returns_copy(self, tool, dry):
+        tool.click(1, 2)
+        log1 = tool.get_action_log()
+        log1.clear()
+        assert len(tool.get_action_log()) == 1  # internal not affected
+
+
+# ── Tests: execute (BaseTool interface) ───────────────────────────────────────
+
+class TestExecute:
+    @pytest.mark.asyncio
+    @patch("bantz.tools.gui_tool.pyautogui")
+    async def test_execute_click(self, mock_pag, tool, no_dry):
+        r = await tool.execute(action="click", x=10, y=20)
+        assert r.success is True
+        assert "10" in r.output and "20" in r.output
+
+    @pytest.mark.asyncio
+    async def test_execute_click_missing_param(self, tool, no_dry):
+        r = await tool.execute(action="click")  # no x, y
+        assert r.success is False
+        assert "Missing required parameter" in r.error
+
+    @pytest.mark.asyncio
+    async def test_execute_type(self, tool, dry):
+        r = await tool.execute(action="type", text="hello")
+        assert r.success is True
+        assert "5" in r.output  # 5 characters
+
+    @pytest.mark.asyncio
+    async def test_execute_focus_window(self, tool, dry):
+        r = await tool.execute(action="focus_window", title="Firefox")
+        assert r.success is True
+        assert "Firefox" in r.output
+
+    @pytest.mark.asyncio
+    async def test_execute_screenshot_dry(self, tool, dry):
+        r = await tool.execute(action="screenshot")
+        assert r.success is True
+        assert "path" in r.data
+
+    @pytest.mark.asyncio
+    async def test_execute_scroll(self, tool, dry):
+        r = await tool.execute(action="scroll", x=50, y=60, clicks=3)
+        assert r.success is True
+
+    @pytest.mark.asyncio
+    async def test_execute_action_log(self, tool, dry):
+        await tool.execute(action="click", x=1, y=2)
+        r = await tool.execute(action="action_log")
+        assert r.success is True
+        assert len(r.data["log"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_execute_clear_log(self, tool, dry):
+        await tool.execute(action="click", x=1, y=2)
+        r = await tool.execute(action="clear_log")
+        assert r.success is True
+        assert "Cleared 1" in r.output
+
+    @pytest.mark.asyncio
+    async def test_execute_unknown_action(self, tool):
+        r = await tool.execute(action="dance")
+        assert r.success is False
+        assert "Unknown action" in r.error
+
+    @pytest.mark.asyncio
+    async def test_execute_click_image_missing_file(self, tool, no_dry):
+        r = await tool.execute(action="click_image", template="/nope.png")
+        assert r.success is False
+        assert "not found on disk" in r.error
+
+    @pytest.mark.asyncio
+    async def test_execute_screenshot_with_region(self, tool, dry):
+        r = await tool.execute(action="screenshot", region=[0, 0, 100, 100])
+        assert r.success is True
+
+
+# ── Tests: registration ──────────────────────────────────────────────────────
+
+class TestRegistration:
+    def test_registered_in_global_registry(self):
+        from bantz.tools import registry
+        assert registry.get("gui") is not None
+
+    def test_schema(self):
+        s = gui_tool.schema()
+        assert s["name"] == "gui"
+        assert s["risk_level"] == "destructive"
+
+
+# ── Tests: pyautogui global config ───────────────────────────────────────────
+
+class TestPyautoguiConfig:
+    def test_failsafe_disabled(self):
+        import pyautogui
+        assert pyautogui.FAILSAFE is False
+
+    def test_pause_zero(self):
+        import pyautogui
+        assert pyautogui.PAUSE == 0


### PR DESCRIPTION
## Summary
Implements `GUITool` — the low-level input execution layer for desktop GUI automation via `pyautogui` + `xdotool`.

## What's included
- **`click(x, y)`** — click at exact screen coordinates with 300ms safety delay
- **`click_image(template, confidence)`** — template matching with OpenCV; guards against missing files (prevents C++ assertion crash), missing OpenCV, and both modern (`ImageNotFoundException`) + legacy (`None` return) pyautogui
- **`type_text(text, interval)`** — realistic keystroke delay via `typewrite`
- **`focus_window(title, wm_class)`** — `xdotool` with `--class` preferred, `--name` fallback; graceful `FileNotFoundError` handling when xdotool absent
- **`screenshot(region)`** — full screen or region, saved to `~/.bantz/cache/`
- **`scroll(x, y, clicks)`** — mouse scroll at position
- **`BANTZ_DRY_RUN=1`** — runtime `@property` (not import-time constant), logs intended actions without executing
- **Timestamped action log** — every action recorded with UTC timestamp for replay/debug
- **`pyautogui.FAILSAFE=False`, `PAUSE=0`** — agent mouse moves are intentional; timing controlled via `DELAY`
- **`GUIToolError`** — custom exception for recoverable failures
- Routing hint added to `intent.py`

## Design decisions (from issue discussion)
- `_dry_run` as `@property` — not cached at import time (owner fix #1)
- `FAILSAFE=False` — corner clicks are legitimate agent actions (owner fix #2)
- `click_image` with full error chain — prevents LLM hallucinated paths crashing OpenCV (owner fix #3)
- `focus_window` prefers `--class` over `--name` with fallback (m13v suggestion, owner-approved)
- Timestamped action logging for replay/debug (m13v suggestion, owner-approved)

## Tests
52 tests covering all actions, dry-run mode, fallback chains, edge cases, registration, and pyautogui config.

Closes #292