### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSRF vulnerability in local GPS Server

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** Argument injection via f-strings passing user-provided URLs to `shlex.split` before `subprocess.run` in `BrowserTool.fetch` and `BrowserTool.extract_text`. An attacker could inject flags (e.g. `-o /tmp/evil`) into the `curl` or `readability-cli` commands.
 **Learning:** `shlex.split(f"cmd {var}")` splits variables containing spaces, causing injected options to be parsed as actual arguments to the binary.
 **Prevention:** Avoid formatting unvalidated variables into shell-like strings destined for `shlex.split`. Always use `list[str]` format explicitly for `subprocess.run` or use `shlex.quote()` when forced to use strings.
+## 2024-05-24 - [Overly Permissive CORS and Missing CSRF Validation]
+**Vulnerability:** The local GPS server allowed wildcard CORS (`Access-Control-Allow-Origin: *`) across all endpoints and lacked `Content-Type` validation on its state-changing `/update` POST endpoint, exposing users to CSRF and SSRF attacks from malicious websites.
+**Learning:** Local servers, even those intended only for LAN use, are accessible from any origin in a standard browser unless restricted by CORS. An HTML `<form>` submission bypasses CORS preflight checks, meaning lack of `Content-Type` validation on POST endpoints enables trivial CSRF attacks.
+**Prevention:** Never use `Access-Control-Allow-Origin: *` for state-changing local APIs unless strictly necessary. Always enforce `Content-Type: application/json` for JSON APIs to block simple HTML form submissions.

--- a/src/bantz/core/gps_server.py
+++ b/src/bantz/core/gps_server.py
@@ -584,7 +584,6 @@ class _GPSHandler(BaseHTTPRequestHandler):
                 .replace("%%DIRECT_URL%%", srv.url))
         self.send_response(200)
         self.send_header("Content-Type", "text/html; charset=utf-8")
-        self.send_header("Access-Control-Allow-Origin", "*")
         self.end_headers()
         self.wfile.write(html.encode())
 
@@ -606,7 +605,6 @@ class _GPSHandler(BaseHTTPRequestHandler):
         html = _PHONE_APP_TEMPLATE.replace("%%RELAY_TOPIC%%", srv.relay_topic)
         self.send_response(200)
         self.send_header("Content-Type", "text/html; charset=utf-8")
-        self.send_header("Access-Control-Allow-Origin", "*")
         self.end_headers()
         self.wfile.write(html.encode())
 
@@ -628,7 +626,6 @@ class _GPSHandler(BaseHTTPRequestHandler):
         })
         self.send_response(200)
         self.send_header("Content-Type", "application/manifest+json")
-        self.send_header("Access-Control-Allow-Origin", "*")
         self.end_headers()
         self.wfile.write(manifest.encode())
 
@@ -654,19 +651,22 @@ class _GPSHandler(BaseHTTPRequestHandler):
         self.send_response(200)
         self.send_header("Content-Type", "application/javascript")
         self.send_header("Service-Worker-Allowed", "/")
-        self.send_header("Access-Control-Allow-Origin", "*")
         self.end_headers()
         self.wfile.write(sw_js.encode())
 
     def _json_response(self, data: dict, code: int = 200):
         self.send_response(code)
         self.send_header("Content-Type", "application/json")
-        self.send_header("Access-Control-Allow-Origin", "*")
         self.end_headers()
         self.wfile.write(json.dumps(data).encode())
 
     def do_POST(self):
         if self.path == "/update":
+            content_type = self.headers.get("Content-Type", "")
+            if not content_type.startswith("application/json"):
+                self._json_response({"error": "Invalid Content-Type"}, 415)
+                return
+
             length = int(self.headers.get("Content-Length", 0))
             body = self.rfile.read(length)
             try:
@@ -681,9 +681,6 @@ class _GPSHandler(BaseHTTPRequestHandler):
 
     def do_OPTIONS(self):
         self.send_response(200)
-        self.send_header("Access-Control-Allow-Origin", "*")
-        self.send_header("Access-Control-Allow-Methods", "POST, GET, OPTIONS")
-        self.send_header("Access-Control-Allow-Headers", "Content-Type")
         self.end_headers()
 
     def log_message(self, fmt, *args):


### PR DESCRIPTION
This PR fixes a critical security vulnerability in the local GPS Server that exposed users to Cross-Site Request Forgery (CSRF) and Server-Side Request Forgery (SSRF) attacks.

**🚨 Severity:** HIGH
**💡 Vulnerability:** The local GPS server was serving all HTTP responses with `Access-Control-Allow-Origin: *`, allowing any malicious website visited by the user to make cross-origin requests to the local Bantz GPS server. Furthermore, the state-changing `/update` POST endpoint did not validate the `Content-Type` header, allowing attackers to bypass CORS preflights entirely by submitting simple HTML `<form>` requests.
**🎯 Impact:** A malicious website could silently push false GPS coordinates to the local Bantz instance, disrupting location-based automations, or potentially read state if other endpoints were exposed.
**🔧 Fix:** Removed the wildcard CORS headers from all responses (as the frontend is served from the same origin, they are unnecessary). Enforced `Content-Type: application/json` validation on the `/update` POST endpoint.
**✅ Verification:** Verified that `pytest tests/` continues to pass, indicating no regressions in functionality.

---
*PR created automatically by Jules for task [9257852360931266949](https://jules.google.com/task/9257852360931266949) started by @miclaldogan*