### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSRF vulnerability in GPS server

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** Argument injection via f-strings passing user-provided URLs to `shlex.split` before `subprocess.run` in `BrowserTool.fetch` and `BrowserTool.extract_text`. An attacker could inject flags (e.g. `-o /tmp/evil`) into the `curl` or `readability-cli` commands.
 **Learning:** `shlex.split(f"cmd {var}")` splits variables containing spaces, causing injected options to be parsed as actual arguments to the binary.
 **Prevention:** Avoid formatting unvalidated variables into shell-like strings destined for `shlex.split`. Always use `list[str]` format explicitly for `subprocess.run` or use `shlex.quote()` when forced to use strings.
+## 2026-04-11 - [GPS Server CSRF/SSRF Mitigation]
+**Vulnerability:** The local GPS server's `/update` POST endpoint accepted arbitrary Content-Types (allowing simple POST requests to bypass some CSRF protections) and indiscriminately responded with wildcard CORS headers (`Access-Control-Allow-Origin: *`).
+**Learning:** Returning wildcard CORS headers on local servers allows any website to read responses (SSRF risk). Accepting non-JSON content-types for JSON endpoints allows simple cross-site POSTs to execute state-changing actions.
+**Prevention:** Strictly validate `Content-Type: application/json` on endpoints expecting JSON payloads to enforce pre-flight requests from browsers. Avoid returning `Access-Control-Allow-Origin: *` on local servers.

--- a/src/bantz/core/gps_server.py
+++ b/src/bantz/core/gps_server.py
@@ -584,7 +584,6 @@ class _GPSHandler(BaseHTTPRequestHandler):
                 .replace("%%DIRECT_URL%%", srv.url))
         self.send_response(200)
         self.send_header("Content-Type", "text/html; charset=utf-8")
-        self.send_header("Access-Control-Allow-Origin", "*")
         self.end_headers()
         self.wfile.write(html.encode())
 
@@ -606,7 +605,6 @@ class _GPSHandler(BaseHTTPRequestHandler):
         html = _PHONE_APP_TEMPLATE.replace("%%RELAY_TOPIC%%", srv.relay_topic)
         self.send_response(200)
         self.send_header("Content-Type", "text/html; charset=utf-8")
-        self.send_header("Access-Control-Allow-Origin", "*")
         self.end_headers()
         self.wfile.write(html.encode())
 
@@ -628,7 +626,6 @@ class _GPSHandler(BaseHTTPRequestHandler):
         })
         self.send_response(200)
         self.send_header("Content-Type", "application/manifest+json")
-        self.send_header("Access-Control-Allow-Origin", "*")
         self.end_headers()
         self.wfile.write(manifest.encode())
 
@@ -654,19 +651,22 @@ class _GPSHandler(BaseHTTPRequestHandler):
         self.send_response(200)
         self.send_header("Content-Type", "application/javascript")
         self.send_header("Service-Worker-Allowed", "/")
-        self.send_header("Access-Control-Allow-Origin", "*")
         self.end_headers()
         self.wfile.write(sw_js.encode())
 
     def _json_response(self, data: dict, code: int = 200):
         self.send_response(code)
         self.send_header("Content-Type", "application/json")
-        self.send_header("Access-Control-Allow-Origin", "*")
         self.end_headers()
         self.wfile.write(json.dumps(data).encode())
 
     def do_POST(self):
         if self.path == "/update":
+            content_type = self.headers.get("Content-Type", "")
+            if not content_type.startswith("application/json"):
+                self._json_response({"error": "Unsupported Media Type"}, 415)
+                return
+
             length = int(self.headers.get("Content-Length", 0))
             body = self.rfile.read(length)
             try:
@@ -681,7 +681,6 @@ class _GPSHandler(BaseHTTPRequestHandler):
 
     def do_OPTIONS(self):
         self.send_response(200)
-        self.send_header("Access-Control-Allow-Origin", "*")
         self.send_header("Access-Control-Allow-Methods", "POST, GET, OPTIONS")
         self.send_header("Access-Control-Allow-Headers", "Content-Type")
         self.end_headers()


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The local GPS server's `/update` POST endpoint accepted arbitrary Content-Types and indiscriminately returned wildcard CORS headers (`Access-Control-Allow-Origin: *`). 
🎯 Impact: This created a high risk of SSRF (a malicious site reading local GPS data) and simple CSRF (a cross-site POST form bypassing pre-flight to update the location state) since it's a locally-hosted server interface.
🔧 Fix: Removed `Access-Control-Allow-Origin: *` headers from all endpoints and strictly validated `Content-Type: application/json` on the `/update` endpoint to require CORS pre-flight validation.
✅ Verification: Ran unit tests to verify GPS server functionality locally and checked for accurate server response headers on `POST`s and `GET`s.

---
*PR created automatically by Jules for task [11477237957417444558](https://jules.google.com/task/11477237957417444558) started by @miclaldogan*