### PR TITLE
feat: Desktop Automation — unified AT-SPI + input control (#322)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,9 @@ BANTZ_INPUT_CONTROL_ENABLED=false
 BANTZ_INPUT_CONFIRM_DESTRUCTIVE=true
 BANTZ_INPUT_TYPE_INTERVAL_MS=50
 
+# ── Desktop Automation (#322 — AT-SPI tree + element interaction) ─────────────
+BANTZ_DESKTOP_AUTOMATION_ENABLED=false
+
 # ── Gemini Flash 2.0 (optional — used as finalizer for long outputs) ──────────
 BANTZ_GEMINI_ENABLED=false
 BANTZ_GEMINI_API_KEY=

--- a/src/bantz/config.py
+++ b/src/bantz/config.py
@@ -41,6 +41,7 @@ class Config(BaseSettings):
     input_control_enabled: bool = Field(False, alias="BANTZ_INPUT_CONTROL_ENABLED")
     input_confirm_destructive: bool = Field(True, alias="BANTZ_INPUT_CONFIRM_DESTRUCTIVE")
     input_type_interval_ms: int = Field(50, alias="BANTZ_INPUT_TYPE_INTERVAL_MS")
+    desktop_automation_enabled: bool = Field(False, alias="BANTZ_DESKTOP_AUTOMATION_ENABLED")
 
     # ── Gemini (optional) ─────────────────────────────────────────────────
     gemini_enabled: bool = Field(False, alias="BANTZ_GEMINI_ENABLED")

--- a/src/bantz/core/brain.py
+++ b/src/bantz/core/brain.py
@@ -104,6 +104,10 @@ class Brain:
             import bantz.tools.screenshot_tool  # noqa: F401
         except (ImportError, ModuleNotFoundError):
             pass
+        try:
+            import bantz.tools.desktop  # noqa: F401  (#322)
+        except (ImportError, ModuleNotFoundError):
+            pass
         import bantz.tools.summarizer    # noqa: F401  (Architect's Revision)
         self._memory_ready = False
         self._graph_ready = False

--- a/src/bantz/tools/desktop.py
+++ b/src/bantz/tools/desktop.py
@@ -1,0 +1,675 @@
+"""
+Bantz v3 — Desktop Automation Tool (#322)
+
+Unified tool for computer use & desktop automation.  Bridges the AT-SPI
+accessibility tree (read) with input_control (act) to provide a single
+tool that the LLM can invoke for end-to-end desktop tasks.
+
+Architecture::
+
+    Brain → "open Calculator, type 5*9, press Enter"
+        → DesktopTool
+            ├── open_app("gnome-calculator")           — subprocess
+            ├── get_ui_tree()                          — active window AT-SPI
+            ├── interact("name:5", "click")            — find + click
+            ├── interact("name:×", "click")            — find + click
+            ├── interact("name:9", "click")            — find + click
+            ├── press_key("Return")                    — input_control.hotkey
+            └── close_app("gnome-calculator")          — WM close
+
+Locator Format
+--------------
+  ``name:Submit``          — match element name (fuzzy)
+  ``role:push button``     — match element role
+  ``name:OK,role:push button`` — combine name + role
+
+Requires: AT-SPI2 (``python3-gi``, ``gir1.2-atspi-2.0``), input backend
+(``pyautogui`` / ``pynput`` / ``xdotool``).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+import shutil
+import subprocess
+from typing import Any, Optional
+
+from bantz.tools import BaseTool, ToolResult, registry
+
+log = logging.getLogger("bantz.tools.desktop")
+
+# ── Well-known app launchers (name → command) ─────────────────────────────────
+_APP_COMMANDS: dict[str, str] = {
+    "calculator": "gnome-calculator",
+    "calc": "gnome-calculator",
+    "hesap makinesi": "gnome-calculator",
+    "terminal": "gnome-terminal",
+    "konsole": "konsole",
+    "files": "nautilus",
+    "file manager": "nautilus",
+    "dosya yöneticisi": "nautilus",
+    "text editor": "gnome-text-editor",
+    "gedit": "gedit",
+    "notepad": "gnome-text-editor",
+    "firefox": "firefox",
+    "chrome": "google-chrome",
+    "chromium": "chromium",
+    "brave": "brave-browser",
+    "settings": "gnome-control-center",
+    "ayarlar": "gnome-control-center",
+    "system monitor": "gnome-system-monitor",
+    "screenshot": "gnome-screenshot",
+}
+
+
+# ── Locator parsing ──────────────────────────────────────────────────────────
+
+_LOCATOR_RE = re.compile(
+    r"(name|role|id)\s*:\s*(.+?)(?:,|$)", re.IGNORECASE,
+)
+
+
+def parse_locator(locator: str) -> dict[str, str]:
+    """Parse ``name:OK,role:push button`` → ``{'name': 'OK', 'role': 'push button'}``."""
+    parts: dict[str, str] = {}
+    for match in _LOCATOR_RE.finditer(locator):
+        key = match.group(1).lower().strip()
+        val = match.group(2).strip()
+        if val:
+            parts[key] = val
+    # If no key:value found, treat entire string as name search
+    if not parts and locator.strip():
+        parts["name"] = locator.strip()
+    return parts
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _resolve_app_command(name: str) -> str:
+    """Return the actual launch command for an app name."""
+    lower = name.lower().strip()
+    if lower in _APP_COMMANDS:
+        return _APP_COMMANDS[lower]
+    # Check if it's already a valid command
+    if shutil.which(lower):
+        return lower
+    # Try with hyphens/underscores
+    for variant in (lower.replace(" ", "-"), lower.replace(" ", "_")):
+        if shutil.which(variant):
+            return variant
+    return lower  # best effort
+
+
+def _get_active_window_name() -> str:
+    """Return the name of the currently active window via xdotool."""
+    try:
+        result = subprocess.run(
+            ["xdotool", "getactivewindow", "getwindowname"],
+            capture_output=True, text=True, timeout=3,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        pass
+    return ""
+
+
+def _get_active_window_pid() -> int:
+    """Return PID of the active window."""
+    try:
+        result = subprocess.run(
+            ["xdotool", "getactivewindow", "getwindowpid"],
+            capture_output=True, text=True, timeout=3,
+        )
+        if result.returncode == 0:
+            return int(result.stdout.strip())
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError, ValueError):
+        pass
+    return 0
+
+
+def _get_active_app_name() -> str:
+    """Return the process name of the active window's application."""
+    pid = _get_active_window_pid()
+    if pid:
+        try:
+            import psutil
+            return psutil.Process(pid).name()
+        except Exception:
+            pass
+        # Fallback: /proc
+        try:
+            comm = open(f"/proc/{pid}/comm").read().strip()
+            return comm
+        except Exception:
+            pass
+    return ""
+
+
+def _format_tree_compact(
+    node: dict, lines: list[str], indent: int = 0, max_lines: int = 80,
+) -> None:
+    """Compact textual representation of the AT-SPI tree for LLM consumption."""
+    if len(lines) >= max_lines:
+        if len(lines) == max_lines:
+            lines.append("  … (truncated)")
+        return
+
+    name = node.get("name", "")
+    role = node.get("role", "")
+    center = node.get("center")
+    visible = node.get("visible", True)
+    enabled = node.get("enabled", True)
+
+    # Skip invisible / containers without name
+    if not visible:
+        for child in node.get("children", []):
+            _format_tree_compact(child, lines, indent, max_lines)
+        return
+
+    prefix = "  " * indent
+    parts = [f"{prefix}[{role}]"]
+    if name:
+        parts.append(f'"{name}"')
+    if center:
+        parts.append(f"@ ({center[0]}, {center[1]})")
+    if not enabled:
+        parts.append("(disabled)")
+
+    line = " ".join(parts)
+    # Only include lines with meaningful content
+    if name or role not in ("filler", "panel", "section", "redundant object"):
+        lines.append(line)
+
+    for child in node.get("children", []):
+        _format_tree_compact(child, lines, indent + 1, max_lines)
+
+
+# ── Interactive element extraction ────────────────────────────────────────────
+
+_INTERACTIVE_ROLES: frozenset[str] = frozenset({
+    "push button", "toggle button", "check box", "radio button",
+    "entry", "text", "link", "menu item", "combo box", "tab",
+    "slider", "spin button", "menu", "tool bar item",
+    "page tab", "list item", "tree item",
+})
+
+
+def _extract_interactive_elements(
+    node: dict, elements: list[dict], max_elements: int = 100,
+) -> None:
+    """Walk the AT-SPI tree and collect only interactive elements with bounds."""
+    if len(elements) >= max_elements:
+        return
+
+    role = (node.get("role") or "").lower()
+    name = node.get("name", "")
+    center = node.get("center")
+    visible = node.get("visible", True)
+    enabled = node.get("enabled", True)
+
+    if visible and enabled and role in _INTERACTIVE_ROLES and center:
+        elements.append({
+            "name": name,
+            "role": node.get("role", ""),
+            "center": center,
+            "bounds": node.get("bounds"),
+        })
+
+    for child in node.get("children", []):
+        _extract_interactive_elements(child, elements, max_elements)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  Desktop Tool
+# ══════════════════════════════════════════════════════════════════════════════
+
+class DesktopTool(BaseTool):
+    """Unified desktop automation: read UI tree + interact with elements."""
+
+    name = "desktop"
+    description = (
+        "Desktop automation tool for controlling native applications. "
+        "Actions:\n"
+        "  get_ui_tree — list interactive UI elements of the active window\n"
+        "  interact    — find a UI element by locator and act on it "
+        "(click/double_click/right_click/type)\n"
+        "  click       — shorthand: find element by locator and click it\n"
+        "  type_text   — type text into the currently focused element\n"
+        "  press_key   — press a keyboard shortcut (e.g. 'ctrl+s', 'Return')\n"
+        "  open_app    — launch a desktop application by name\n"
+        "  close_app   — close the currently focused or named application\n"
+        "  list_windows — list all accessible application windows\n"
+        "  active_window — get info about the currently focused window\n"
+        "Params: action (str), app (str), locator (str, e.g. 'name:Send' or "
+        "'role:push button'), text (str), keys (str, e.g. 'ctrl+c').\n"
+        "Locator format: 'name:Submit', 'role:entry', 'name:OK,role:push button'."
+    )
+    risk_level = "moderate"
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        action = str(kwargs.get("action", "get_ui_tree")).strip().lower()
+
+        dispatch = {
+            "get_ui_tree": self._get_ui_tree,
+            "ui_tree": self._get_ui_tree,
+            "tree": self._get_ui_tree,
+            "interact": self._interact,
+            "click": self._click,
+            "type_text": self._type_text,
+            "type": self._type_text,
+            "press_key": self._press_key,
+            "hotkey": self._press_key,
+            "open_app": self._open_app,
+            "open": self._open_app,
+            "close_app": self._close_app,
+            "close": self._close_app,
+            "list_windows": self._list_windows,
+            "active_window": self._active_window,
+        }
+
+        handler = dispatch.get(action)
+        if handler is None:
+            return ToolResult(
+                success=False, output="",
+                error=(
+                    f"Unknown action: '{action}'. Available: "
+                    f"{', '.join(sorted(set(dispatch.keys())))}"
+                ),
+            )
+
+        try:
+            return await handler(kwargs)
+        except Exception as exc:
+            log.exception("DesktopTool.%s failed", action)
+            return ToolResult(success=False, output="", error=f"Desktop action '{action}' failed: {exc}")
+
+    # ── get_ui_tree ───────────────────────────────────────────────────────
+
+    async def _get_ui_tree(self, kwargs: dict) -> ToolResult:
+        """Return interactive elements for the active (or named) window."""
+        app_name = str(kwargs.get("app", "")).strip()
+
+        if not app_name:
+            app_name = _get_active_app_name() or _get_active_window_name()
+        if not app_name:
+            return ToolResult(
+                success=False, output="",
+                error="Could not determine the active window. Specify 'app' parameter.",
+            )
+
+        try:
+            from bantz.tools.accessibility import get_element_tree
+        except ImportError:
+            return ToolResult(
+                success=False, output="",
+                error="AT-SPI2 is not available. Install: sudo apt install python3-gi gir1.2-atspi-2.0",
+            )
+
+        tree = get_element_tree(app_name)
+        if tree is None:
+            return ToolResult(
+                success=False, output="",
+                error=f"No accessibility tree found for '{app_name}'. Is the app running and accessible?",
+            )
+
+        # Extract interactive elements
+        elements: list[dict] = []
+        _extract_interactive_elements(tree, elements)
+
+        if not elements:
+            # Fall back to showing the full tree
+            lines = [f"🌳 UI tree for '{app_name}' (no interactive elements detected):"]
+            _format_tree_compact(tree, lines, max_lines=60)
+            return ToolResult(
+                success=True, output="\n".join(lines),
+                data={"app": app_name, "tree": tree, "elements": []},
+            )
+
+        lines = [f"🖥️ {len(elements)} interactive elements in '{app_name}':"]
+        for i, elem in enumerate(elements, 1):
+            name = elem["name"] or "(unnamed)"
+            role = elem["role"]
+            cx, cy = elem["center"]
+            lines.append(f"  {i}. [{role}] \"{name}\" @ ({cx}, {cy})")
+
+        return ToolResult(
+            success=True, output="\n".join(lines),
+            data={"app": app_name, "elements": elements, "count": len(elements)},
+        )
+
+    # ── interact ──────────────────────────────────────────────────────────
+
+    async def _interact(self, kwargs: dict) -> ToolResult:
+        """Find element by locator, then perform action (click/type/etc.)."""
+        locator_str = str(kwargs.get("locator", "")).strip()
+        interact_action = str(kwargs.get("interact_action", "click")).strip().lower()
+        text = str(kwargs.get("text", ""))
+        app_name = str(kwargs.get("app", "")).strip()
+
+        if not locator_str:
+            return ToolResult(success=False, output="", error="Locator is required. Use 'name:Submit' or 'role:entry'.")
+
+        locator = parse_locator(locator_str)
+        label = locator.get("name", "")
+        role_filter = locator.get("role")
+
+        if not app_name:
+            app_name = _get_active_app_name() or _get_active_window_name()
+
+        if not app_name:
+            return ToolResult(success=False, output="", error="Could not determine active window. Specify 'app' parameter.")
+
+        # Find the element via AT-SPI
+        try:
+            from bantz.tools.accessibility import find_element
+        except ImportError:
+            return ToolResult(success=False, output="", error="AT-SPI2 is not available.")
+
+        if not label and role_filter:
+            label = role_filter
+
+        element = find_element(app_name, label, role_filter=role_filter)
+        if element is None:
+            return ToolResult(
+                success=False, output="",
+                error=f"Element '{locator_str}' not found in '{app_name}'.",
+            )
+
+        cx, cy = element["center"]
+        score = element.get("score", 0.0)
+
+        # Perform the action
+        if interact_action in ("click", "left_click"):
+            return await self._do_click(cx, cy, element, "click", app_name, locator_str)
+        elif interact_action == "double_click":
+            return await self._do_click(cx, cy, element, "double_click", app_name, locator_str)
+        elif interact_action == "right_click":
+            return await self._do_click(cx, cy, element, "right_click", app_name, locator_str)
+        elif interact_action in ("type", "type_text"):
+            return await self._do_type_at(cx, cy, text, element, app_name, locator_str)
+        else:
+            return ToolResult(
+                success=False, output="",
+                error=f"Unknown interact action: '{interact_action}'. Use: click, double_click, right_click, type.",
+            )
+
+    # ── click (shorthand) ──────────────────────────────────────────────────
+
+    async def _click(self, kwargs: dict) -> ToolResult:
+        """Shorthand: find element by locator and click it."""
+        locator_str = str(kwargs.get("locator", kwargs.get("target", ""))).strip()
+        if not locator_str:
+            return ToolResult(success=False, output="", error="Specify 'locator' (e.g. 'name:OK') or 'target'.")
+        kwargs["locator"] = locator_str
+        kwargs["interact_action"] = "click"
+        return await self._interact(kwargs)
+
+    # ── type_text ─────────────────────────────────────────────────────────
+
+    async def _type_text(self, kwargs: dict) -> ToolResult:
+        """Type text. If locator given, click element first."""
+        text = str(kwargs.get("text", "")).strip()
+        if not text:
+            return ToolResult(success=False, output="", error="Specify 'text' to type.")
+
+        locator_str = str(kwargs.get("locator", "")).strip()
+
+        if locator_str:
+            # Click element first, then type
+            kwargs["interact_action"] = "click"
+            click_result = await self._interact(kwargs)
+            if not click_result.success:
+                return click_result
+            await asyncio.sleep(0.15)
+
+        # Type the text
+        try:
+            import bantz.tools.input_control as ic
+            await ic.type_text(text)
+        except Exception as exc:
+            return ToolResult(success=False, output="", error=f"Failed to type text: {exc}")
+
+        display = text[:80] + "…" if len(text) > 80 else text
+        return ToolResult(
+            success=True,
+            output=f"⌨️  Typed: \"{display}\" ({len(text)} chars)",
+            data={"text": text, "length": len(text)},
+        )
+
+    # ── press_key ─────────────────────────────────────────────────────────
+
+    async def _press_key(self, kwargs: dict) -> ToolResult:
+        """Press a keyboard shortcut (e.g. 'ctrl+s', 'Return', 'alt+f4')."""
+        keys_raw = str(kwargs.get("keys", kwargs.get("key", ""))).strip()
+        if not keys_raw:
+            return ToolResult(success=False, output="", error="Specify 'keys' (e.g. 'ctrl+s', 'Return').")
+
+        key_list = [k.strip() for k in keys_raw.split("+") if k.strip()]
+
+        try:
+            import bantz.tools.input_control as ic
+            await ic.hotkey(*key_list)
+        except Exception as exc:
+            return ToolResult(success=False, output="", error=f"Failed to press key: {exc}")
+
+        combo = "+".join(key_list)
+        return ToolResult(
+            success=True,
+            output=f"⌨️  Pressed: {combo}",
+            data={"keys": key_list, "combo": combo},
+        )
+
+    # ── open_app ──────────────────────────────────────────────────────────
+
+    async def _open_app(self, kwargs: dict) -> ToolResult:
+        """Launch a desktop application by name."""
+        app_name = str(kwargs.get("app", kwargs.get("name", ""))).strip()
+        if not app_name:
+            return ToolResult(success=False, output="", error="Specify 'app' name to open.")
+
+        command = _resolve_app_command(app_name)
+        log.info("Opening app: %s → %s", app_name, command)
+
+        try:
+            # Try xdg-open for .desktop entries first
+            proc = await asyncio.create_subprocess_exec(
+                command,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+                start_new_session=True,
+            )
+            # Give the app a moment to start
+            await asyncio.sleep(1.0)
+
+            # Check if process is still alive (didn't crash immediately)
+            if proc.returncode is not None and proc.returncode != 0:
+                return ToolResult(
+                    success=False, output="",
+                    error=f"Application '{command}' exited with code {proc.returncode}.",
+                )
+
+            return ToolResult(
+                success=True,
+                output=f"🚀 Launched '{app_name}' (command: {command}, pid: {proc.pid})",
+                data={"app": app_name, "command": command, "pid": proc.pid},
+            )
+        except FileNotFoundError:
+            return ToolResult(
+                success=False, output="",
+                error=f"Application '{command}' not found. Is it installed?",
+            )
+        except Exception as exc:
+            return ToolResult(success=False, output="", error=f"Failed to open '{app_name}': {exc}")
+
+    # ── close_app ─────────────────────────────────────────────────────────
+
+    async def _close_app(self, kwargs: dict) -> ToolResult:
+        """Close an application by name or the active window."""
+        app_name = str(kwargs.get("app", "")).strip()
+
+        if app_name:
+            # Try wmctrl first
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    "wmctrl", "-c", app_name,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                await asyncio.wait_for(proc.communicate(), timeout=3)
+                if proc.returncode == 0:
+                    return ToolResult(
+                        success=True,
+                        output=f"✓ Closed '{app_name}'.",
+                        data={"app": app_name, "method": "wmctrl"},
+                    )
+            except (FileNotFoundError, asyncio.TimeoutError):
+                pass
+
+            # xdotool fallback
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    "xdotool", "search", "--name", app_name,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=3)
+                wids = stdout.decode().strip().split("\n")
+                if wids and wids[0]:
+                    await asyncio.create_subprocess_exec(
+                        "xdotool", "windowactivate", "--sync", wids[0],
+                    )
+                    await asyncio.sleep(0.2)
+            except (FileNotFoundError, asyncio.TimeoutError):
+                pass
+
+        # Send Alt+F4 to close active window
+        try:
+            import bantz.tools.input_control as ic
+            await ic.hotkey("alt", "F4")
+        except Exception as exc:
+            return ToolResult(success=False, output="", error=f"Failed to close: {exc}")
+
+        target = app_name or "active window"
+        return ToolResult(
+            success=True,
+            output=f"✓ Sent close signal to '{target}'.",
+            data={"app": target, "method": "alt+f4"},
+        )
+
+    # ── list_windows ──────────────────────────────────────────────────────
+
+    async def _list_windows(self, kwargs: dict) -> ToolResult:
+        """List all accessible applications/windows."""
+        try:
+            from bantz.tools.accessibility import list_applications
+        except ImportError:
+            return ToolResult(success=False, output="", error="AT-SPI2 is not available.")
+
+        apps = list_applications()
+        if not apps:
+            return ToolResult(
+                success=True,
+                output="No accessible applications found.",
+                data={"apps": []},
+            )
+
+        lines = [f"📋 {len(apps)} accessible applications:"]
+        for app in sorted(apps):
+            lines.append(f"  • {app}")
+
+        return ToolResult(
+            success=True, output="\n".join(lines),
+            data={"apps": sorted(apps), "count": len(apps)},
+        )
+
+    # ── active_window ─────────────────────────────────────────────────────
+
+    async def _active_window(self, kwargs: dict) -> ToolResult:
+        """Get information about the currently focused window."""
+        title = _get_active_window_name()
+        app = _get_active_app_name()
+        pid = _get_active_window_pid()
+
+        if not title and not app:
+            return ToolResult(success=False, output="", error="Could not determine the active window.")
+
+        output = f"🖥️ Active window: {title or '(unknown title)'}"
+        if app:
+            output += f"\n   Application: {app}"
+        if pid:
+            output += f"\n   PID: {pid}"
+
+        return ToolResult(
+            success=True, output=output,
+            data={"title": title, "app": app, "pid": pid},
+        )
+
+    # ── Internal helpers ──────────────────────────────────────────────────
+
+    async def _do_click(
+        self, x: int, y: int, element: dict, click_type: str,
+        app_name: str, locator_str: str,
+    ) -> ToolResult:
+        """Execute a click at the resolved coordinates."""
+        try:
+            import bantz.tools.input_control as ic
+            fn = getattr(ic, click_type)
+            await fn(x, y)
+        except Exception as exc:
+            return ToolResult(
+                success=False, output="",
+                error=f"Found '{locator_str}' at ({x}, {y}) but click failed: {exc}",
+            )
+
+        action_past = {
+            "click": "Clicked",
+            "double_click": "Double-clicked",
+            "right_click": "Right-clicked",
+        }
+        verb = action_past.get(click_type, "Acted on")
+        name = element.get("name", locator_str)
+        role = element.get("role", "")
+
+        return ToolResult(
+            success=True,
+            output=f"🎯 {verb} '{name}' ({role}) at ({x}, {y}) in {app_name}",
+            data={"x": x, "y": y, "element": element, "action": click_type},
+        )
+
+    async def _do_type_at(
+        self, x: int, y: int, text: str, element: dict,
+        app_name: str, locator_str: str,
+    ) -> ToolResult:
+        """Click an element, then type text into it."""
+        if not text:
+            return ToolResult(success=False, output="", error="Specify 'text' to type.")
+
+        # Click first to focus the element
+        try:
+            import bantz.tools.input_control as ic
+            await ic.click(x, y)
+            await asyncio.sleep(0.15)
+            await ic.type_text(text)
+        except Exception as exc:
+            return ToolResult(
+                success=False, output="",
+                error=f"Failed to type into '{locator_str}': {exc}",
+            )
+
+        display = text[:80] + "…" if len(text) > 80 else text
+        name = element.get("name", locator_str)
+        return ToolResult(
+            success=True,
+            output=f"⌨️  Typed \"{display}\" into '{name}' at ({x}, {y}) in {app_name}",
+            data={"x": x, "y": y, "text": text, "element": element},
+        )
+
+
+# ── Auto-register ─────────────────────────────────────────────────────────────
+try:
+    registry.register(DesktopTool())
+except Exception:
+    pass

--- a/tests/tools/test_desktop.py
+++ b/tests/tools/test_desktop.py
@@ -1,0 +1,776 @@
+"""Tests for DesktopTool (#322 — Computer Use & Desktop Automation).
+
+Covers:
+  1. parse_locator — locator string parsing (name:X, role:Y, combined)
+  2. _resolve_app_command — app name → command resolution
+  3. _format_tree_compact — tree formatting
+  4. _extract_interactive_elements — element extraction from AT-SPI tree
+  5. DesktopTool.get_ui_tree — tree retrieval + interactive element listing
+  6. DesktopTool.interact — find + act (click/type/double_click/right_click)
+  7. DesktopTool.click — shorthand click via locator
+  8. DesktopTool.type_text — text input with optional locator
+  9. DesktopTool.press_key — keyboard shortcuts
+  10. DesktopTool.open_app — app launching
+  11. DesktopTool.close_app — app closing
+  12. DesktopTool.list_windows — accessible window listing
+  13. DesktopTool.active_window — active window info
+  14. Error handling & edge cases
+  15. Tool registration
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
+
+import pytest
+
+from bantz.tools.desktop import (
+    DesktopTool,
+    parse_locator,
+    _resolve_app_command,
+    _format_tree_compact,
+    _extract_interactive_elements,
+    _APP_COMMANDS,
+)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def tool():
+    return DesktopTool()
+
+
+@pytest.fixture
+def sample_tree():
+    """A realistic AT-SPI UI tree for testing."""
+    return {
+        "name": "Calculator",
+        "role": "frame",
+        "visible": True,
+        "enabled": True,
+        "bounds": {"x": 100, "y": 100, "width": 400, "height": 500},
+        "center": (300, 350),
+        "children": [
+            {
+                "name": "",
+                "role": "panel",
+                "visible": True,
+                "enabled": True,
+                "children": [
+                    {
+                        "name": "5",
+                        "role": "push button",
+                        "visible": True,
+                        "enabled": True,
+                        "bounds": {"x": 150, "y": 300, "width": 60, "height": 60},
+                        "center": (180, 330),
+                    },
+                    {
+                        "name": "9",
+                        "role": "push button",
+                        "visible": True,
+                        "enabled": True,
+                        "bounds": {"x": 270, "y": 300, "width": 60, "height": 60},
+                        "center": (300, 330),
+                    },
+                    {
+                        "name": "×",
+                        "role": "push button",
+                        "visible": True,
+                        "enabled": True,
+                        "bounds": {"x": 330, "y": 300, "width": 60, "height": 60},
+                        "center": (360, 330),
+                    },
+                    {
+                        "name": "=",
+                        "role": "push button",
+                        "visible": True,
+                        "enabled": True,
+                        "bounds": {"x": 330, "y": 420, "width": 60, "height": 60},
+                        "center": (360, 450),
+                    },
+                    {
+                        "name": "Result",
+                        "role": "entry",
+                        "visible": True,
+                        "enabled": True,
+                        "bounds": {"x": 120, "y": 120, "width": 350, "height": 50},
+                        "center": (295, 145),
+                    },
+                    {
+                        "name": "Hidden",
+                        "role": "push button",
+                        "visible": False,
+                        "enabled": True,
+                        "bounds": {"x": 0, "y": 0, "width": 0, "height": 0},
+                        "center": (0, 0),
+                    },
+                    {
+                        "name": "Disabled",
+                        "role": "push button",
+                        "visible": True,
+                        "enabled": False,
+                        "bounds": {"x": 400, "y": 400, "width": 60, "height": 60},
+                        "center": (430, 430),
+                    },
+                ],
+            },
+        ],
+    }
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  1. parse_locator
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestParseLocator:
+    def test_name_only(self):
+        result = parse_locator("name:Submit")
+        assert result == {"name": "Submit"}
+
+    def test_role_only(self):
+        result = parse_locator("role:push button")
+        assert result == {"role": "push button"}
+
+    def test_name_and_role(self):
+        result = parse_locator("name:OK,role:push button")
+        assert result == {"name": "OK", "role": "push button"}
+
+    def test_case_insensitive_keys(self):
+        result = parse_locator("Name:Send,Role:entry")
+        assert result == {"name": "Send", "role": "entry"}
+
+    def test_bare_string_becomes_name(self):
+        result = parse_locator("Send button")
+        assert result == {"name": "Send button"}
+
+    def test_empty_string(self):
+        result = parse_locator("")
+        assert result == {}
+
+    def test_whitespace_trimmed(self):
+        result = parse_locator("  name:  OK  , role:  push button  ")
+        assert result == {"name": "OK", "role": "push button"}
+
+    def test_id_locator(self):
+        result = parse_locator("id:btn_submit")
+        assert result == {"id": "btn_submit"}
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  2. _resolve_app_command
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestResolveAppCommand:
+    def test_known_app(self):
+        assert _resolve_app_command("calculator") == "gnome-calculator"
+
+    def test_known_app_case_insensitive(self):
+        assert _resolve_app_command("Calculator") == "gnome-calculator"
+
+    def test_known_app_turkish(self):
+        assert _resolve_app_command("hesap makinesi") == "gnome-calculator"
+
+    def test_unknown_returns_as_is(self):
+        assert _resolve_app_command("some-weird-app") == "some-weird-app"
+
+    def test_which_found(self):
+        with patch("bantz.tools.desktop.shutil.which", return_value="/usr/bin/ls"):
+            result = _resolve_app_command("ls")
+            assert result == "ls"
+
+    def test_firefox(self):
+        assert _resolve_app_command("firefox") == "firefox"
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  3. _format_tree_compact
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestFormatTreeCompact:
+    def test_basic_formatting(self, sample_tree):
+        lines: list[str] = []
+        _format_tree_compact(sample_tree, lines)
+        text = "\n".join(lines)
+        assert "[frame]" in text
+        assert '"Calculator"' in text
+        assert '"5"' in text
+        assert '"×"' in text
+
+    def test_hidden_elements_skipped(self, sample_tree):
+        lines: list[str] = []
+        _format_tree_compact(sample_tree, lines)
+        text = "\n".join(lines)
+        assert '"Hidden"' not in text
+
+    def test_disabled_shown_with_marker(self, sample_tree):
+        lines: list[str] = []
+        _format_tree_compact(sample_tree, lines)
+        text = "\n".join(lines)
+        assert "(disabled)" in text
+
+    def test_truncation(self):
+        tree = {
+            "name": "root", "role": "frame", "visible": True,
+            "enabled": True,
+            "children": [
+                {"name": f"item{i}", "role": "push button", "visible": True,
+                 "enabled": True, "center": (i, i)}
+                for i in range(200)
+            ],
+        }
+        lines: list[str] = []
+        _format_tree_compact(tree, lines, max_lines=10)
+        assert len(lines) <= 11  # 10 + truncation message
+        assert "truncated" in lines[-1]
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  4. _extract_interactive_elements
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestExtractInteractiveElements:
+    def test_extracts_buttons_and_entry(self, sample_tree):
+        elements: list[dict] = []
+        _extract_interactive_elements(sample_tree, elements)
+        names = [e["name"] for e in elements]
+        assert "5" in names
+        assert "9" in names
+        assert "×" in names
+        assert "=" in names
+        assert "Result" in names
+
+    def test_hidden_excluded(self, sample_tree):
+        elements: list[dict] = []
+        _extract_interactive_elements(sample_tree, elements)
+        names = [e["name"] for e in elements]
+        assert "Hidden" not in names
+
+    def test_disabled_excluded(self, sample_tree):
+        elements: list[dict] = []
+        _extract_interactive_elements(sample_tree, elements)
+        names = [e["name"] for e in elements]
+        assert "Disabled" not in names
+
+    def test_max_elements_limit(self, sample_tree):
+        elements: list[dict] = []
+        _extract_interactive_elements(sample_tree, elements, max_elements=2)
+        assert len(elements) == 2
+
+    def test_all_have_center(self, sample_tree):
+        elements: list[dict] = []
+        _extract_interactive_elements(sample_tree, elements)
+        for elem in elements:
+            assert "center" in elem
+            assert len(elem["center"]) == 2
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  5. get_ui_tree
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestGetUiTree:
+    @pytest.mark.asyncio
+    async def test_returns_interactive_elements(self, tool, sample_tree):
+        with patch("bantz.tools.desktop._get_active_app_name", return_value="gnome-calculator"), \
+             patch("bantz.tools.accessibility.get_element_tree", return_value=sample_tree):
+            result = await tool.execute(action="get_ui_tree")
+        assert result.success is True
+        assert "interactive elements" in result.output
+        assert "5" in result.output
+        assert result.data["count"] == 5  # 5, 9, ×, =, Result
+
+    @pytest.mark.asyncio
+    async def test_with_explicit_app(self, tool, sample_tree):
+        with patch("bantz.tools.accessibility.get_element_tree", return_value=sample_tree):
+            result = await tool.execute(action="get_ui_tree", app="Calculator")
+        assert result.success is True
+        assert "Calculator" in result.output
+
+    @pytest.mark.asyncio
+    async def test_no_active_window(self, tool):
+        with patch("bantz.tools.desktop._get_active_app_name", return_value=""), \
+             patch("bantz.tools.desktop._get_active_window_name", return_value=""):
+            result = await tool.execute(action="get_ui_tree")
+        assert result.success is False
+        assert "could not determine" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_atspi_unavailable(self, tool):
+        with patch("bantz.tools.desktop._get_active_app_name", return_value="firefox"), \
+             patch.dict("sys.modules", {"bantz.tools.accessibility": None}):
+            result = await tool.execute(action="get_ui_tree")
+        assert result.success is False
+        assert "AT-SPI2" in result.error
+
+    @pytest.mark.asyncio
+    async def test_tree_not_found(self, tool):
+        with patch("bantz.tools.desktop._get_active_app_name", return_value="ghost"), \
+             patch("bantz.tools.accessibility.get_element_tree", return_value=None):
+            result = await tool.execute(action="get_ui_tree")
+        assert result.success is False
+        assert "no accessibility tree" in result.error.lower()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  6. interact — find + act
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestInteract:
+    @pytest.mark.asyncio
+    async def test_click_by_name(self, tool):
+        fake_element = {
+            "name": "Submit", "role": "push button",
+            "center": (200, 300), "bounds": {"x": 180, "y": 280, "width": 40, "height": 40},
+            "score": 0.95,
+        }
+        mock_click = AsyncMock()
+        with patch("bantz.tools.desktop._get_active_app_name", return_value="firefox"), \
+             patch("bantz.tools.accessibility.find_element", return_value=fake_element), \
+             patch("bantz.tools.input_control.click", mock_click):
+            result = await tool.execute(action="interact", locator="name:Submit")
+        assert result.success is True
+        assert "Clicked" in result.output
+        assert "Submit" in result.output
+        mock_click.assert_called_once_with(200, 300)
+
+    @pytest.mark.asyncio
+    async def test_double_click(self, tool):
+        fake_element = {
+            "name": "file.txt", "role": "list item",
+            "center": (150, 200), "bounds": {"x": 100, "y": 180, "width": 100, "height": 40},
+            "score": 0.90,
+        }
+        mock_dbl = AsyncMock()
+        with patch("bantz.tools.desktop._get_active_app_name", return_value="nautilus"), \
+             patch("bantz.tools.accessibility.find_element", return_value=fake_element), \
+             patch("bantz.tools.input_control.double_click", mock_dbl):
+            result = await tool.execute(action="interact", locator="name:file.txt", interact_action="double_click")
+        assert result.success is True
+        assert "Double-clicked" in result.output
+        mock_dbl.assert_called_once_with(150, 200)
+
+    @pytest.mark.asyncio
+    async def test_right_click(self, tool):
+        fake_element = {
+            "name": "Desktop", "role": "panel",
+            "center": (500, 400), "bounds": {"x": 0, "y": 0, "width": 1920, "height": 1080},
+            "score": 0.80,
+        }
+        mock_rc = AsyncMock()
+        with patch("bantz.tools.desktop._get_active_app_name", return_value="desktop"), \
+             patch("bantz.tools.accessibility.find_element", return_value=fake_element), \
+             patch("bantz.tools.input_control.right_click", mock_rc):
+            result = await tool.execute(action="interact", locator="name:Desktop", interact_action="right_click")
+        assert result.success is True
+        assert "Right-clicked" in result.output
+        mock_rc.assert_called_once_with(500, 400)
+
+    @pytest.mark.asyncio
+    async def test_type_into_element(self, tool):
+        fake_element = {
+            "name": "Search", "role": "entry",
+            "center": (400, 50), "bounds": {"x": 300, "y": 30, "width": 200, "height": 40},
+            "score": 0.92,
+        }
+        mock_click = AsyncMock()
+        mock_type = AsyncMock()
+        with patch("bantz.tools.desktop._get_active_app_name", return_value="firefox"), \
+             patch("bantz.tools.accessibility.find_element", return_value=fake_element), \
+             patch("bantz.tools.input_control.click", mock_click), \
+             patch("bantz.tools.input_control.type_text", mock_type):
+            result = await tool.execute(
+                action="interact", locator="name:Search",
+                interact_action="type", text="hello world",
+            )
+        assert result.success is True
+        assert "Typed" in result.output
+        mock_click.assert_called_once_with(400, 50)
+        mock_type.assert_called_once_with("hello world")
+
+    @pytest.mark.asyncio
+    async def test_missing_locator(self, tool):
+        result = await tool.execute(action="interact", locator="")
+        assert result.success is False
+        assert "locator is required" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_element_not_found(self, tool):
+        with patch("bantz.tools.desktop._get_active_app_name", return_value="firefox"), \
+             patch("bantz.tools.accessibility.find_element", return_value=None):
+            result = await tool.execute(action="interact", locator="name:Phantom")
+        assert result.success is False
+        assert "not found" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_unknown_interact_action(self, tool):
+        fake_element = {
+            "name": "OK", "role": "push button",
+            "center": (100, 100), "bounds": {"x": 80, "y": 80, "width": 40, "height": 40},
+            "score": 1.0,
+        }
+        with patch("bantz.tools.desktop._get_active_app_name", return_value="dialog"), \
+             patch("bantz.tools.accessibility.find_element", return_value=fake_element):
+            result = await tool.execute(action="interact", locator="name:OK", interact_action="smash")
+        assert result.success is False
+        assert "unknown interact action" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_click_failure_caught(self, tool):
+        fake_element = {
+            "name": "OK", "role": "push button",
+            "center": (100, 100), "bounds": {"x": 80, "y": 80, "width": 40, "height": 40},
+            "score": 1.0,
+        }
+        with patch("bantz.tools.desktop._get_active_app_name", return_value="dialog"), \
+             patch("bantz.tools.accessibility.find_element", return_value=fake_element), \
+             patch("bantz.tools.input_control.click", AsyncMock(side_effect=OSError("Display error"))):
+            result = await tool.execute(action="interact", locator="name:OK")
+        assert result.success is False
+        assert "click failed" in result.error.lower()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  7. click (shorthand)
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestClickShorthand:
+    @pytest.mark.asyncio
+    async def test_click_with_locator(self, tool):
+        fake_element = {
+            "name": "OK", "role": "push button",
+            "center": (300, 200), "bounds": {"x": 280, "y": 180, "width": 40, "height": 40},
+            "score": 1.0,
+        }
+        mock_click = AsyncMock()
+        with patch("bantz.tools.desktop._get_active_app_name", return_value="dialog"), \
+             patch("bantz.tools.accessibility.find_element", return_value=fake_element), \
+             patch("bantz.tools.input_control.click", mock_click):
+            result = await tool.execute(action="click", locator="name:OK")
+        assert result.success is True
+        mock_click.assert_called_once_with(300, 200)
+
+    @pytest.mark.asyncio
+    async def test_click_with_target(self, tool):
+        fake_element = {
+            "name": "Cancel", "role": "push button",
+            "center": (400, 200), "bounds": {"x": 380, "y": 180, "width": 40, "height": 40},
+            "score": 1.0,
+        }
+        mock_click = AsyncMock()
+        with patch("bantz.tools.desktop._get_active_app_name", return_value="dialog"), \
+             patch("bantz.tools.accessibility.find_element", return_value=fake_element), \
+             patch("bantz.tools.input_control.click", mock_click):
+            result = await tool.execute(action="click", target="Cancel")
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_click_no_locator(self, tool):
+        result = await tool.execute(action="click")
+        assert result.success is False
+        assert "locator" in result.error.lower() or "target" in result.error.lower()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  8. type_text
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestTypeText:
+    @pytest.mark.asyncio
+    async def test_type_without_locator(self, tool):
+        mock_type = AsyncMock()
+        with patch("bantz.tools.input_control.type_text", mock_type):
+            result = await tool.execute(action="type_text", text="hello world")
+        assert result.success is True
+        assert "Typed" in result.output
+        assert "11 chars" in result.output
+        mock_type.assert_called_once_with("hello world")
+
+    @pytest.mark.asyncio
+    async def test_type_with_locator(self, tool):
+        fake_element = {
+            "name": "Search", "role": "entry",
+            "center": (200, 50), "bounds": {"x": 100, "y": 30, "width": 200, "height": 40},
+            "score": 0.95,
+        }
+        mock_click = AsyncMock()
+        mock_type = AsyncMock()
+        with patch("bantz.tools.desktop._get_active_app_name", return_value="firefox"), \
+             patch("bantz.tools.accessibility.find_element", return_value=fake_element), \
+             patch("bantz.tools.input_control.click", mock_click), \
+             patch("bantz.tools.input_control.type_text", mock_type):
+            result = await tool.execute(action="type_text", text="query", locator="name:Search")
+        assert result.success is True
+        mock_click.assert_called_once_with(200, 50)  # Focus first
+        mock_type.assert_called_once_with("query")
+
+    @pytest.mark.asyncio
+    async def test_type_empty_text(self, tool):
+        result = await tool.execute(action="type_text", text="")
+        assert result.success is False
+        assert "text" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_type_long_text_truncated_in_output(self, tool):
+        mock_type = AsyncMock()
+        long_text = "x" * 200
+        with patch("bantz.tools.input_control.type_text", mock_type):
+            result = await tool.execute(action="type_text", text=long_text)
+        assert result.success is True
+        assert "…" in result.output
+        assert "200 chars" in result.output
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  9. press_key
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestPressKey:
+    @pytest.mark.asyncio
+    async def test_single_key(self, tool):
+        mock_hk = AsyncMock()
+        with patch("bantz.tools.input_control.hotkey", mock_hk):
+            result = await tool.execute(action="press_key", keys="Return")
+        assert result.success is True
+        assert "Return" in result.output
+        mock_hk.assert_called_once_with("Return")
+
+    @pytest.mark.asyncio
+    async def test_combo_key(self, tool):
+        mock_hk = AsyncMock()
+        with patch("bantz.tools.input_control.hotkey", mock_hk):
+            result = await tool.execute(action="press_key", keys="ctrl+s")
+        assert result.success is True
+        assert "ctrl+s" in result.output
+        mock_hk.assert_called_once_with("ctrl", "s")
+
+    @pytest.mark.asyncio
+    async def test_key_alias(self, tool):
+        """Action 'hotkey' should also work."""
+        mock_hk = AsyncMock()
+        with patch("bantz.tools.input_control.hotkey", mock_hk):
+            result = await tool.execute(action="hotkey", keys="alt+tab")
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_missing_keys(self, tool):
+        result = await tool.execute(action="press_key")
+        assert result.success is False
+        assert "keys" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_key_error_caught(self, tool):
+        with patch("bantz.tools.input_control.hotkey", AsyncMock(side_effect=RuntimeError("No backend"))):
+            result = await tool.execute(action="press_key", keys="ctrl+z")
+        assert result.success is False
+        assert "failed to press" in result.error.lower()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  10. open_app
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestOpenApp:
+    @pytest.mark.asyncio
+    async def test_open_known_app(self, tool):
+        mock_proc = AsyncMock()
+        mock_proc.returncode = None  # still running
+        mock_proc.pid = 12345
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec, \
+             patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await tool.execute(action="open_app", app="calculator")
+        assert result.success is True
+        assert "Launched" in result.output
+        assert result.data["command"] == "gnome-calculator"
+        assert result.data["pid"] == 12345
+
+    @pytest.mark.asyncio
+    async def test_open_app_not_found(self, tool):
+        with patch("asyncio.create_subprocess_exec", side_effect=FileNotFoundError), \
+             patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await tool.execute(action="open_app", app="nonexistent-app-xyz")
+        assert result.success is False
+        assert "not found" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_open_app_crashes_immediately(self, tool):
+        mock_proc = AsyncMock()
+        mock_proc.returncode = 1
+        mock_proc.pid = 99999
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc), \
+             patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await tool.execute(action="open_app", app="calculator")
+        assert result.success is False
+        assert "exited" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_open_app_missing_name(self, tool):
+        result = await tool.execute(action="open_app")
+        assert result.success is False
+        assert "app" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_open_alias(self, tool):
+        """'open' action should work as alias."""
+        mock_proc = AsyncMock()
+        mock_proc.returncode = None
+        mock_proc.pid = 42
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc), \
+             patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await tool.execute(action="open", app="firefox")
+        assert result.success is True
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  11. close_app
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestCloseApp:
+    @pytest.mark.asyncio
+    async def test_close_via_wmctrl(self, tool):
+        mock_proc = AsyncMock()
+        mock_proc.returncode = 0
+        mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc), \
+             patch("asyncio.wait_for", return_value=None):
+            result = await tool.execute(action="close_app", app="Calculator")
+        assert result.success is True
+        assert "Closed" in result.output
+
+    @pytest.mark.asyncio
+    async def test_close_via_alt_f4(self, tool):
+        mock_hk = AsyncMock()
+        with patch("asyncio.create_subprocess_exec", side_effect=FileNotFoundError), \
+             patch("bantz.tools.input_control.hotkey", mock_hk):
+            result = await tool.execute(action="close_app", app="SomeApp")
+        assert result.success is True
+        assert "close signal" in result.output.lower()
+        mock_hk.assert_called_once_with("alt", "F4")
+
+    @pytest.mark.asyncio
+    async def test_close_active_window(self, tool):
+        mock_hk = AsyncMock()
+        with patch("bantz.tools.input_control.hotkey", mock_hk):
+            result = await tool.execute(action="close_app")
+        assert result.success is True
+        assert "active window" in result.output.lower()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  12. list_windows
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestListWindows:
+    @pytest.mark.asyncio
+    async def test_list_windows_success(self, tool):
+        with patch("bantz.tools.accessibility.list_applications", return_value=["Firefox", "Terminal", "VS Code"]):
+            result = await tool.execute(action="list_windows")
+        assert result.success is True
+        assert "3" in result.output
+        assert "Firefox" in result.output
+        assert result.data["count"] == 3
+
+    @pytest.mark.asyncio
+    async def test_list_windows_empty(self, tool):
+        with patch("bantz.tools.accessibility.list_applications", return_value=[]):
+            result = await tool.execute(action="list_windows")
+        assert result.success is True
+        assert "no accessible" in result.output.lower()
+
+    @pytest.mark.asyncio
+    async def test_list_windows_atspi_unavailable(self, tool):
+        with patch.dict("sys.modules", {"bantz.tools.accessibility": None}):
+            result = await tool.execute(action="list_windows")
+        assert result.success is False
+        assert "AT-SPI2" in result.error
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  13. active_window
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestActiveWindow:
+    @pytest.mark.asyncio
+    async def test_active_window_info(self, tool):
+        with patch("bantz.tools.desktop._get_active_window_name", return_value="main.py — VS Code"), \
+             patch("bantz.tools.desktop._get_active_app_name", return_value="code"), \
+             patch("bantz.tools.desktop._get_active_window_pid", return_value=5678):
+            result = await tool.execute(action="active_window")
+        assert result.success is True
+        assert "VS Code" in result.output
+        assert "code" in result.output
+        assert result.data["pid"] == 5678
+
+    @pytest.mark.asyncio
+    async def test_active_window_no_window(self, tool):
+        with patch("bantz.tools.desktop._get_active_window_name", return_value=""), \
+             patch("bantz.tools.desktop._get_active_app_name", return_value=""), \
+             patch("bantz.tools.desktop._get_active_window_pid", return_value=0):
+            result = await tool.execute(action="active_window")
+        assert result.success is False
+        assert "could not determine" in result.error.lower()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  14. Error handling & edge cases
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestErrorHandling:
+    @pytest.mark.asyncio
+    async def test_unknown_action(self, tool):
+        result = await tool.execute(action="dance")
+        assert result.success is False
+        assert "unknown action" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_action_aliases(self, tool):
+        """All alias actions should dispatch correctly."""
+        # tree aliases
+        for alias in ("get_ui_tree", "ui_tree", "tree"):
+            with patch("bantz.tools.desktop._get_active_app_name", return_value=""), \
+                 patch("bantz.tools.desktop._get_active_window_name", return_value=""):
+                result = await tool.execute(action=alias)
+                # Should fail because no window, but should dispatch correctly
+                assert "could not determine" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_handler_exception_caught(self, tool):
+        """Unexpected exception in handler should be caught."""
+        with patch.object(tool, "_get_ui_tree", side_effect=RuntimeError("boom")):
+            result = await tool.execute(action="get_ui_tree")
+        assert result.success is False
+        assert "boom" in result.error
+
+    @pytest.mark.asyncio
+    async def test_default_action_is_get_ui_tree(self, tool):
+        """No action specified should default to get_ui_tree."""
+        with patch("bantz.tools.desktop._get_active_app_name", return_value=""), \
+             patch("bantz.tools.desktop._get_active_window_name", return_value=""):
+            result = await tool.execute()
+        assert "could not determine" in result.error.lower()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+#  15. Tool registration
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestRegistration:
+    def test_registered_in_global_registry(self):
+        from bantz.tools import registry
+        tool = registry.get("desktop")
+        assert tool is not None
+        assert tool.name == "desktop"
+
+    def test_risk_level(self):
+        from bantz.tools import registry
+        tool = registry.get("desktop")
+        assert tool.risk_level == "moderate"
+
+    def test_schema_has_description(self):
+        from bantz.tools import registry
+        tool = registry.get("desktop")
+        schema = tool.schema()
+        assert "desktop" in schema["description"].lower() or "automation" in schema["description"].lower()
+        assert "get_ui_tree" in schema["description"]
+        assert "interact" in schema["description"]
+        assert "open_app" in schema["description"]


### PR DESCRIPTION
## Summary
Implements the Computer Use & Desktop Automation epic (issue #322) — a unified `DesktopTool` that bridges the AT-SPI accessibility tree (read) with input_control (act) for end-to-end desktop automation.

## New: src/bantz/tools/desktop.py (676 lines)

| Action | Description |
|---|---|
| `get_ui_tree` | List interactive UI elements of the active/named window via AT-SPI |
| `interact` | Find element by locator string + execute action (click/double_click/right_click/type) |
| `click` | Shorthand: find element by locator and click it |
| `type_text` | Type text into the currently focused element, or find element first via locator |
| `press_key` | Press keyboard shortcuts (e.g. `ctrl+s`, `Return`, `alt+f4`) |
| `open_app` | Launch a desktop application by name (20+ well-known aliases EN+TR) |
| `close_app` | Close app via wmctrl/xdotool/alt+f4 cascade |
| `list_windows` | List all accessible application windows |
| `active_window` | Get info about the currently focused window |

### Locator Format
- `name:Submit` — fuzzy match by element name
- `role:push button` — match by AT-SPI role
- `name:OK,role:push button` — combine criteria
- Bare strings treated as name search

### Key Components
- `parse_locator()` — structured locator string parsing
- `_resolve_app_command()` — app name to launch command resolution (20+ aliases)
- `_extract_interactive_elements()` — walk AT-SPI tree, collect only clickable/typeable elements
- `_format_tree_compact()` — readable tree output for LLM consumption
- Active window auto-detection via xdotool + psutil

## Acceptance Criteria (from issue)
- [x] Bantz can retrieve a list of interactive elements for the currently active window (`get_ui_tree`)
- [x] Desktop control tools (`click`, `type_text`, `press_key`) available to the agent
- [x] Agent can open an application, type/perform actions, and close it (`open_app` + `interact` + `close_app`)

## Modified Files
- `brain.py` — import `bantz.tools.desktop` (try/except for optional deps)
- `config.py` — `desktop_automation_enabled` field (default: false)
- `.env.example` — `BANTZ_DESKTOP_AUTOMATION_ENABLED=false`

## Tests: 68 tests — all passing (0.58s)
15 test classes: TestParseLocator(8), TestResolveAppCommand(6), TestFormatTreeCompact(4), TestExtractInteractiveElements(5), TestGetUiTree(5), TestInteract(8), TestClickShorthand(3), TestTypeText(4), TestPressKey(5), TestOpenApp(5), TestCloseApp(3), TestListWindows(3), TestActiveWindow(2), TestErrorHandling(4), TestRegistration(3)

Closes #322
