### PR TITLE
feat(#321): Multi-Agent Hierarchy — SubAgent, AgentManager, delegate_task

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -240,6 +240,13 @@ TELEGRAM_SCREENSHOT_QUALITY=75
 TELEGRAM_SCREENSHOT_MAX_DIM=1920
 SCREENSHOT_AUTO_AFTER_ACTION=false
 
+# ── Multi-Agent Hierarchy (#321 — JARVIS-inspired sub-agents) ───────────────
+# Enables delegate_task tool: the Brain can spin up Researcher, Developer,
+# or Reviewer sub-agents for focused sub-tasks.
+BANTZ_MULTI_AGENT_ENABLED=false
+BANTZ_MULTI_AGENT_MAX_CONCURRENT=3
+BANTZ_MULTI_AGENT_TIMEOUT=120
+
 # ── Continuous Awareness (#325) ─────────────────────────────────────────────
 # Captures active window, clipboard, and screenshot every N seconds.
 # Injects desktop context into the system prompt automatically.

--- a/src/bantz/agent/agent_manager.py
+++ b/src/bantz/agent/agent_manager.py
@@ -104,7 +104,12 @@ class AgentManager:
         from bantz.config import config
         self._enabled = getattr(config, "multi_agent_enabled", False)
         if self._enabled:
-            log.info("AgentManager initialised — %d roles available", len(AGENT_ROLES))
+            self.MAX_CONCURRENT = getattr(config, "multi_agent_max_concurrent", 3)
+            self.DELEGATION_TIMEOUT = float(getattr(config, "multi_agent_timeout", 120))
+            log.info(
+                "AgentManager initialised — %d roles, max_concurrent=%d, timeout=%.0fs",
+                len(AGENT_ROLES), self.MAX_CONCURRENT, self.DELEGATION_TIMEOUT,
+            )
 
     @property
     def total_delegations(self) -> int:
@@ -194,13 +199,24 @@ class AgentManager:
             agent.display_name, task[:80], self._active,
         )
 
-        # Toast notification
+        # Toast notification + event bus for TUI
         try:
             from bantz.core.notification_manager import notify_toast
             notify_toast(
                 f"🤖 Delegating to {agent.display_name}",
                 task[:60],
                 "info",
+            )
+        except Exception:
+            pass
+        try:
+            from bantz.core.event_bus import bus as _bus
+            await _bus.emit(
+                "delegation_start",
+                role=canonical,
+                display_name=agent.display_name,
+                task=task[:80],
+                active=self._active,
             )
         except Exception:
             pass
@@ -237,6 +253,37 @@ class AgentManager:
             record.duration_s,
             result.tools_used,
         )
+
+        # Completion event for TUI + toast
+        try:
+            from bantz.core.event_bus import bus as _bus
+            await _bus.emit(
+                "delegation_done",
+                role=canonical,
+                display_name=agent.display_name,
+                success=result.success,
+                duration_s=round(record.duration_s, 1),
+                tools_used=result.tools_used,
+                error=result.error,
+            )
+        except Exception:
+            pass
+        try:
+            from bantz.core.notification_manager import notify_toast
+            if result.success:
+                notify_toast(
+                    f"✅ {agent.display_name} finished",
+                    result.summary[:60],
+                    "info",
+                )
+            else:
+                notify_toast(
+                    f"❌ {agent.display_name} failed",
+                    result.error[:60],
+                    "warning",
+                )
+        except Exception:
+            pass
 
         return result
 

--- a/src/bantz/agent/agent_manager.py
+++ b/src/bantz/agent/agent_manager.py
@@ -1,0 +1,257 @@
+"""
+Bantz — Agent Manager (Orchestrator for Sub-Agents) (#321)
+
+The AgentManager coordinates delegation to specialised sub-agents.
+It tracks active delegations, enforces rate limits, and provides
+the interface that the ``delegate_task`` tool uses.
+
+Thread safety: AgentManager is a singleton, but sub-agents are
+ephemeral — each ``delegate()`` call creates a fresh instance.
+No shared mutable state between sub-agents.
+
+Rate limiting: max ``MAX_CONCURRENT`` delegations at once (configurable
+via config), max ``MAX_PER_CONVERSATION`` per conversation session to
+prevent runaway loops.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from bantz.agent.sub_agent import (
+    SubAgent,
+    SubAgentResult,
+    create_agent,
+    resolve_role,
+    available_roles,
+    AGENT_ROLES,
+)
+
+log = logging.getLogger("bantz.agent_manager")
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Delegation record
+# ═══════════════════════════════════════════════════════════════════════════
+
+@dataclass
+class DelegationRecord:
+    """Tracks a single delegation for auditing and rate-limiting."""
+    role: str
+    task: str
+    started_at: float
+    finished_at: float = 0.0
+    success: bool = False
+    summary: str = ""
+    tools_used: list[str] = field(default_factory=list)
+    error: str = ""
+
+    @property
+    def duration_s(self) -> float:
+        if self.finished_at > 0:
+            return self.finished_at - self.started_at
+        return time.monotonic() - self.started_at
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "role": self.role,
+            "task": self.task[:200],
+            "duration_s": round(self.duration_s, 2),
+            "success": self.success,
+            "summary": self.summary[:500],
+            "tools_used": self.tools_used,
+            "error": self.error,
+        }
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Agent Manager
+# ═══════════════════════════════════════════════════════════════════════════
+
+class AgentManager:
+    """Orchestrator for the multi-agent hierarchy.
+
+    Usage::
+
+        result = await agent_manager.delegate("researcher", "Find the GDP of Turkey", {"year": 2025})
+        print(result.summary)
+
+    Rate limits:
+      • MAX_CONCURRENT — max simultaneous delegations (default 3)
+      • MAX_PER_CONVERSATION — max total delegations per session (default 20)
+      • DELEGATION_TIMEOUT — max seconds per delegation (default 120)
+    """
+
+    MAX_CONCURRENT: int = 3
+    MAX_PER_CONVERSATION: int = 20
+    DELEGATION_TIMEOUT: float = 120.0
+
+    def __init__(self) -> None:
+        self._active: int = 0
+        self._history: list[DelegationRecord] = []
+        self._lock = asyncio.Lock()
+        self._enabled: bool = False
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def init(self) -> None:
+        """Enable the agent manager (called from brain on startup)."""
+        from bantz.config import config
+        self._enabled = getattr(config, "multi_agent_enabled", False)
+        if self._enabled:
+            log.info("AgentManager initialised — %d roles available", len(AGENT_ROLES))
+
+    @property
+    def total_delegations(self) -> int:
+        return len(self._history)
+
+    @property
+    def active_count(self) -> int:
+        return self._active
+
+    @property
+    def history(self) -> list[DelegationRecord]:
+        return list(self._history)
+
+    def stats(self) -> dict[str, Any]:
+        """Return manager statistics for diagnostics."""
+        return {
+            "enabled": self._enabled,
+            "active": self._active,
+            "total_delegations": len(self._history),
+            "successful": sum(1 for r in self._history if r.success),
+            "failed": sum(1 for r in self._history if not r.success),
+            "available_roles": [r for r in AGENT_ROLES],
+        }
+
+    async def delegate(
+        self,
+        role: str,
+        task: str,
+        context: dict[str, Any] | None = None,
+    ) -> SubAgentResult:
+        """Delegate a task to a sub-agent.
+
+        This is the main entry point for the multi-agent system.
+
+        Args:
+            role: Agent role name or alias (e.g. "researcher", "dev").
+            task: Natural language task description.
+            context: Optional context dict from the orchestrator (memory
+                     snippets, prior results, user preferences, etc.).
+
+        Returns:
+            SubAgentResult with the agent's findings/output.
+
+        Raises:
+            ValueError: If the role is invalid or rate limits exceeded.
+            TimeoutError: If the agent takes too long.
+        """
+        if not self._enabled:
+            return SubAgentResult.failure("Multi-agent system is disabled.")
+
+        # Resolve role
+        canonical = resolve_role(role)
+        if canonical is None:
+            roles_str = ", ".join(AGENT_ROLES.keys())
+            return SubAgentResult.failure(
+                f"Unknown agent role: '{role}'. Available: {roles_str}"
+            )
+
+        # Rate limit checks
+        if self._active >= self.MAX_CONCURRENT:
+            return SubAgentResult.failure(
+                f"Too many concurrent delegations ({self._active}/{self.MAX_CONCURRENT}). "
+                "Wait for current tasks to finish."
+            )
+        if len(self._history) >= self.MAX_PER_CONVERSATION:
+            return SubAgentResult.failure(
+                f"Delegation limit reached ({self.MAX_PER_CONVERSATION} per session). "
+                "Start a new conversation."
+            )
+
+        # Create ephemeral agent
+        agent = create_agent(canonical)
+        if agent is None:
+            return SubAgentResult.failure(f"Failed to create agent for role: {canonical}")
+
+        record = DelegationRecord(
+            role=canonical,
+            task=task,
+            started_at=time.monotonic(),
+        )
+
+        async with self._lock:
+            self._active += 1
+
+        log.info(
+            "Delegating to %s agent: %s (active: %d)",
+            agent.display_name, task[:80], self._active,
+        )
+
+        # Toast notification
+        try:
+            from bantz.core.notification_manager import notify_toast
+            notify_toast(
+                f"🤖 Delegating to {agent.display_name}",
+                task[:60],
+                "info",
+            )
+        except Exception:
+            pass
+
+        try:
+            result = await asyncio.wait_for(
+                agent.run(task, context),
+                timeout=self.DELEGATION_TIMEOUT,
+            )
+        except asyncio.TimeoutError:
+            result = SubAgentResult.failure(
+                f"{agent.display_name} agent timed out after {self.DELEGATION_TIMEOUT}s."
+            )
+        except Exception as exc:
+            result = SubAgentResult.failure(
+                f"{agent.display_name} agent crashed: {type(exc).__name__}: {exc}"
+            )
+        finally:
+            async with self._lock:
+                self._active -= 1
+
+        # Record result
+        record.finished_at = time.monotonic()
+        record.success = result.success
+        record.summary = result.summary[:500]
+        record.tools_used = result.tools_used
+        record.error = result.error
+        self._history.append(record)
+
+        log.info(
+            "Delegation complete: %s → %s (%.1fs, tools: %s)",
+            canonical,
+            "success" if result.success else "failed",
+            record.duration_s,
+            result.tools_used,
+        )
+
+        return result
+
+    def list_roles(self) -> list[dict[str, str]]:
+        """Return available roles (for the delegate_task tool schema)."""
+        return available_roles()
+
+    def reset(self) -> None:
+        """Reset delegation history (for testing / new session)."""
+        self._history.clear()
+        self._active = 0
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Module singleton
+# ═══════════════════════════════════════════════════════════════════════════
+
+agent_manager = AgentManager()

--- a/src/bantz/agent/planner.py
+++ b/src/bantz/agent/planner.py
@@ -55,6 +55,11 @@ TOOL REFERENCE:
   • action=screenshot → capture current screen state
   Use for: "open firefox", "go to a website", "search on YouTube", "click a button", "type in a form", any GUI automation.
   (Legacy alias: "process_text" also accepted by the executor.)
+- delegate_task: delegate a sub-task to a specialist agent. Params: {{"agent_role": "researcher|developer|reviewer", "task_description": "...", "context": {{...optional extra context}}}}
+  • researcher = web search, reading, information synthesis
+  • developer = shell, filesystem, code tasks
+  • reviewer = analysis, validation, quality checking
+  Use for: focused sub-tasks that need specialist expertise. Sub-agents have their own tool access and return structured results.
 
 CRITICAL TOOL RULES:
 - NEVER use `web_search` or `news` to summarize, rewrite, translate, or analyze text. Those tools are STRICTLY for fetching new external information.

--- a/src/bantz/agent/sub_agent.py
+++ b/src/bantz/agent/sub_agent.py
@@ -1,0 +1,519 @@
+"""
+Bantz — Sub-Agent Base & Specialized Roles (#321)
+
+Multi-Agent Hierarchy inspired by JARVIS.  The main Brain orchestrator
+can delegate sub-tasks to specialized agents that have their own system
+prompts, restricted tool access, and isolated message history.
+
+Architecture
+────────────
+    Brain (Orchestrator)
+      └── AgentManager.delegate(role, task, context)
+              ├── ResearcherAgent   — web search, reading, summarisation
+              ├── DeveloperAgent    — shell, filesystem, code tasks
+              └── ReviewerAgent     — analysis, checking, validation
+
+Design decisions:
+  • Sub-agents do NOT share the Brain's conversation history.  The
+    orchestrator passes a synthesised ``context`` dict — no token waste.
+  • Sub-agents return a structured ``SubAgentResult`` (JSON-serialisable).
+  • Each role has a curated ``allowed_tools`` set — sub-agents CANNOT
+    access dangerous tools like ``manage_agents`` or destructive shell.
+  • LLM call reuses the same Gemini-first-Ollama-fallback pattern.
+  • Sub-agents are ephemeral — created per task, no persistent state.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
+
+log = logging.getLogger("bantz.sub_agent")
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Result type
+# ═══════════════════════════════════════════════════════════════════════════
+
+@dataclass
+class SubAgentResult:
+    """Structured response from a sub-agent execution.
+
+    The orchestrator (Brain) reads ``summary`` for the user-facing answer
+    and ``data`` for any structured payload (URLs, code blocks, etc.).
+    """
+    success: bool
+    summary: str
+    data: dict[str, Any] = field(default_factory=dict)
+    error: str = ""
+    tools_used: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "success": self.success,
+            "summary": self.summary,
+            "data": self.data,
+            "error": self.error,
+            "tools_used": self.tools_used,
+        }
+
+    @classmethod
+    def failure(cls, error: str) -> "SubAgentResult":
+        return cls(success=False, summary="", error=error)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Base Sub-Agent
+# ═══════════════════════════════════════════════════════════════════════════
+
+class SubAgent(ABC):
+    """Base class for all specialised sub-agents.
+
+    Subclasses must define:
+      • ``role``          — unique identifier (e.g. "researcher")
+      • ``display_name``  — human-friendly label
+      • ``system_prompt``  — LLM system instructions
+      • ``allowed_tools`` — set of tool names this agent may invoke
+
+    The ``run()`` method:
+      1. Builds a minimal message array from the task + context
+      2. Calls the LLM for a structured JSON plan
+      3. Executes any tool calls in sequence
+      4. Calls the LLM again with tool results to produce a final summary
+      5. Returns ``SubAgentResult``
+    """
+
+    role: str
+    display_name: str
+    system_prompt: str
+    allowed_tools: set[str]
+    max_tool_calls: int = 5  # circuit breaker — prevent infinite loops
+
+    @abstractmethod
+    def _build_system(self, task: str, context: dict[str, Any]) -> str:
+        """Build the full system prompt with task-specific context."""
+        ...
+
+    async def run(
+        self,
+        task: str,
+        context: dict[str, Any] | None = None,
+    ) -> SubAgentResult:
+        """Execute the sub-agent's task.
+
+        1. Ask LLM to plan which tools to use (JSON response).
+        2. Execute tools sequentially.
+        3. Ask LLM to synthesise a final answer from tool results.
+        4. Return structured SubAgentResult.
+        """
+        context = context or {}
+        system = self._build_system(task, context)
+        tools_used: list[str] = []
+
+        # ── Phase 1: Plan (ask LLM what tools to call) ──────────
+        plan_messages = [
+            {"role": "system", "content": system},
+            {"role": "user", "content": self._format_task_prompt(task, context)},
+        ]
+
+        try:
+            plan_raw = await self._llm_chat(plan_messages)
+        except Exception as exc:
+            return SubAgentResult.failure(f"LLM error during planning: {exc}")
+
+        tool_calls = self._parse_tool_calls(plan_raw)
+
+        # ── Phase 2: Execute tools ──────────────────────────────
+        tool_results: list[dict[str, Any]] = []
+        if tool_calls:
+            from bantz.tools import registry
+
+            for i, call in enumerate(tool_calls[: self.max_tool_calls]):
+                tool_name = call.get("tool", "")
+                tool_args = call.get("args", {})
+
+                if tool_name not in self.allowed_tools:
+                    tool_results.append({
+                        "tool": tool_name,
+                        "success": False,
+                        "output": f"Tool '{tool_name}' not permitted for {self.role} agent.",
+                    })
+                    continue
+
+                tool = registry.get(tool_name)
+                if not tool:
+                    tool_results.append({
+                        "tool": tool_name,
+                        "success": False,
+                        "output": f"Tool '{tool_name}' not found in registry.",
+                    })
+                    continue
+
+                try:
+                    tr = await tool.execute(**tool_args)
+                    tool_results.append({
+                        "tool": tool_name,
+                        "success": tr.success,
+                        "output": tr.output[:3000],  # cap output to save tokens
+                    })
+                    tools_used.append(tool_name)
+                except Exception as exc:
+                    tool_results.append({
+                        "tool": tool_name,
+                        "success": False,
+                        "output": f"Execution error: {exc}",
+                    })
+
+        # ── Phase 3: Synthesise (LLM produces final answer) ─────
+        synth_messages = list(plan_messages)
+        synth_messages.append({"role": "assistant", "content": plan_raw})
+
+        if tool_results:
+            tool_summary = json.dumps(tool_results, ensure_ascii=False, indent=2)
+            synth_messages.append({
+                "role": "user",
+                "content": (
+                    f"Tool results:\n```json\n{tool_summary}\n```\n\n"
+                    "Now synthesise a final answer based on these results. "
+                    "Respond with a JSON object: "
+                    '{"summary": "...", "data": {...optional structured data}}'
+                ),
+            })
+        else:
+            # No tools needed — the plan response IS the answer
+            synth_messages.append({
+                "role": "user",
+                "content": (
+                    "Now provide your final answer. "
+                    "Respond with a JSON object: "
+                    '{"summary": "...", "data": {...optional structured data}}'
+                ),
+            })
+
+        try:
+            final_raw = await self._llm_chat(synth_messages)
+        except Exception as exc:
+            # If synthesis fails but we have tool results, return those
+            if tool_results:
+                combined = "\n".join(
+                    f"[{r['tool']}] {r['output'][:500]}"
+                    for r in tool_results if r.get("success")
+                )
+                return SubAgentResult(
+                    success=True,
+                    summary=combined or "Tools executed but synthesis failed.",
+                    tools_used=tools_used,
+                )
+            return SubAgentResult.failure(f"LLM error during synthesis: {exc}")
+
+        return self._parse_final_result(final_raw, tools_used)
+
+    # ── LLM Abstraction ──────────────────────────────────────────
+
+    async def _llm_chat(self, messages: list[dict[str, str]]) -> str:
+        """Gemini-first, Ollama-fallback — mirrors Brain's pattern."""
+        try:
+            from bantz.llm.gemini import gemini
+            if gemini.is_enabled():
+                result = await gemini.chat(messages)
+                if result and result.strip():
+                    return result
+        except Exception:
+            pass
+
+        from bantz.llm.ollama import ollama
+        return await ollama.chat(messages)
+
+    # ── Parsing Helpers ──────────────────────────────────────────
+
+    def _format_task_prompt(self, task: str, context: dict[str, Any]) -> str:
+        """Format the user prompt with task and any injected context."""
+        parts = [f"Task: {task}"]
+        if context:
+            ctx_str = json.dumps(context, ensure_ascii=False, indent=2)
+            parts.append(f"\nContext from the orchestrator:\n```json\n{ctx_str}\n```")
+        return "\n".join(parts)
+
+    def _parse_tool_calls(self, raw: str) -> list[dict[str, Any]]:
+        """Extract tool call instructions from LLM response.
+
+        Expected format (inside a JSON array):
+        [{"tool": "web_search", "args": {"query": "..."}}]
+
+        Also handles the response being wrapped in markdown code fences.
+        """
+        # Strip thinking blocks
+        raw = re.sub(r"<thinking>.*?</thinking>", "", raw, flags=re.DOTALL)
+
+        # Try to find JSON array
+        json_match = re.search(r"\[.*\]", raw, re.DOTALL)
+        if json_match:
+            try:
+                parsed = json.loads(json_match.group())
+                if isinstance(parsed, list):
+                    return [
+                        item for item in parsed
+                        if isinstance(item, dict) and "tool" in item
+                    ]
+            except json.JSONDecodeError:
+                pass
+
+        # Try JSON object with "tools" key
+        obj_match = re.search(r"\{.*\}", raw, re.DOTALL)
+        if obj_match:
+            try:
+                parsed = json.loads(obj_match.group())
+                if isinstance(parsed, dict):
+                    tools = parsed.get("tools") or parsed.get("tool_calls", [])
+                    if isinstance(tools, list):
+                        return [t for t in tools if isinstance(t, dict) and "tool" in t]
+            except json.JSONDecodeError:
+                pass
+
+        # No tool calls — pure reasoning response
+        return []
+
+    def _parse_final_result(
+        self, raw: str, tools_used: list[str],
+    ) -> SubAgentResult:
+        """Parse the LLM's final synthesis into a SubAgentResult."""
+        # Strip thinking/code fences
+        cleaned = re.sub(r"<thinking>.*?</thinking>", "", raw, flags=re.DOTALL)
+        cleaned = re.sub(r"```json\s*", "", cleaned)
+        cleaned = re.sub(r"```\s*", "", cleaned)
+
+        # Try JSON parse
+        json_match = re.search(r"\{.*\}", cleaned, re.DOTALL)
+        if json_match:
+            try:
+                parsed = json.loads(json_match.group())
+                if isinstance(parsed, dict):
+                    return SubAgentResult(
+                        success=True,
+                        summary=parsed.get("summary", raw.strip()),
+                        data=parsed.get("data", {}),
+                        tools_used=tools_used,
+                    )
+            except json.JSONDecodeError:
+                pass
+
+        # Fallback: use raw text as summary
+        return SubAgentResult(
+            success=True,
+            summary=cleaned.strip() or raw.strip(),
+            tools_used=tools_used,
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Specialized Roles
+# ═══════════════════════════════════════════════════════════════════════════
+
+class ResearcherAgent(SubAgent):
+    """Specialised in web search, reading, and information synthesis.
+
+    Has access to search, URL reading, and summarisation tools.
+    No shell, filesystem, or destructive capabilities.
+    """
+
+    role = "researcher"
+    display_name = "Researcher"
+    allowed_tools = {
+        "web_search",
+        "read_url",
+        "summarizer",
+        "news",
+        "feed",
+    }
+
+    system_prompt = """\
+You are a Research Agent — a specialised sub-agent within the Bantz system.
+Your job is to find accurate, up-to-date information using web search and
+URL reading tools.
+
+RULES:
+1. Always verify claims using multiple sources when possible.
+2. Cite URLs in your findings.
+3. Prefer recent sources over old ones.
+4. If the search returns no useful results, say so honestly.
+5. NEVER fabricate information — if you can't find it, say "not found".
+
+TOOL USAGE:
+To use tools, respond with a JSON array of tool calls:
+[{"tool": "web_search", "args": {"query": "your search query"}}]
+
+Available tools: web_search, read_url, summarizer, news, feed.
+
+After receiving tool results, synthesise a clear, factual answer.
+"""
+
+    def _build_system(self, task: str, context: dict[str, Any]) -> str:
+        parts = [self.system_prompt]
+        if context.get("user_language"):
+            parts.append(f"\nThe user's language is: {context['user_language']}")
+        if context.get("prior_findings"):
+            parts.append(f"\nPrior findings: {context['prior_findings']}")
+        return "\n".join(parts)
+
+
+class DeveloperAgent(SubAgent):
+    """Specialised in code execution, file operations, and system commands.
+
+    Has access to shell, filesystem, and document tools.
+    Shell commands are sandboxed — no destructive system operations.
+    """
+
+    role = "developer"
+    display_name = "Developer"
+    allowed_tools = {
+        "shell",
+        "filesystem",
+        "document",
+        "system_info",
+        "summarizer",
+    }
+
+    system_prompt = """\
+You are a Developer Agent — a specialised sub-agent within the Bantz system.
+Your job is to write code, run shell commands, and handle file operations.
+
+RULES:
+1. Write clean, idiomatic code with comments.
+2. Test your work — run the code to verify it works before reporting.
+3. Handle errors gracefully and report what went wrong.
+4. NEVER run destructive commands (rm -rf, format, etc.) without explicit confirmation in the task.
+5. Prefer small, focused scripts over monolithic ones.
+
+TOOL USAGE:
+To use tools, respond with a JSON array of tool calls:
+[{"tool": "shell", "args": {"command": "ls -la"}}]
+
+Available tools: shell, filesystem, document, system_info, summarizer.
+
+After executing tools, report what you did and the outcome.
+"""
+
+    def _build_system(self, task: str, context: dict[str, Any]) -> str:
+        parts = [self.system_prompt]
+        if context.get("working_directory"):
+            parts.append(f"\nWorking directory: {context['working_directory']}")
+        if context.get("language"):
+            parts.append(f"\nPreferred language: {context['language']}")
+        if context.get("existing_code"):
+            parts.append(f"\nExisting code context:\n{context['existing_code']}")
+        return "\n".join(parts)
+
+
+class ReviewerAgent(SubAgent):
+    """Specialised in analysis, validation, and quality checking.
+
+    Has read-only access to filesystem and web for verification.
+    No execution or modification capabilities.
+    """
+
+    role = "reviewer"
+    display_name = "Reviewer"
+    allowed_tools = {
+        "filesystem",
+        "read_url",
+        "web_search",
+        "summarizer",
+    }
+    max_tool_calls = 3  # reviewers should be focused
+
+    system_prompt = """\
+You are a Reviewer Agent — a specialised sub-agent within the Bantz system.
+Your job is to check work quality, validate information, and provide
+constructive feedback.
+
+RULES:
+1. Be thorough but concise in your review.
+2. Check for correctness, completeness, and potential issues.
+3. Provide specific, actionable feedback — not vague complaints.
+4. If reviewing code, look for bugs, security issues, and edge cases.
+5. If reviewing research, check source reliability and factual accuracy.
+6. Rate confidence as: HIGH, MEDIUM, or LOW with justification.
+
+TOOL USAGE:
+To verify facts or read files, respond with a JSON array of tool calls:
+[{"tool": "web_search", "args": {"query": "verify claim X"}}]
+
+Available tools: filesystem (read-only), read_url, web_search, summarizer.
+
+After reviewing, provide a structured assessment with:
+- verdict: "pass" | "fail" | "needs_revision"
+- issues: list of specific problems found
+- suggestions: list of improvements
+"""
+
+    def _build_system(self, task: str, context: dict[str, Any]) -> str:
+        parts = [self.system_prompt]
+        if context.get("artifact"):
+            parts.append(f"\nContent to review:\n{context['artifact']}")
+        if context.get("criteria"):
+            parts.append(f"\nReview criteria: {context['criteria']}")
+        return "\n".join(parts)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Role Registry
+# ═══════════════════════════════════════════════════════════════════════════
+
+# All available sub-agent roles — keyed by their role identifier
+AGENT_ROLES: dict[str, type[SubAgent]] = {
+    "researcher": ResearcherAgent,
+    "developer": DeveloperAgent,
+    "reviewer": ReviewerAgent,
+}
+
+# Human-friendly aliases for flexible delegation
+ROLE_ALIASES: dict[str, str] = {
+    "research": "researcher",
+    "search": "researcher",
+    "lookup": "researcher",
+    "find": "researcher",
+    "dev": "developer",
+    "coder": "developer",
+    "code": "developer",
+    "programmer": "developer",
+    "sysadmin": "developer",
+    "review": "reviewer",
+    "check": "reviewer",
+    "validate": "reviewer",
+    "audit": "reviewer",
+    "verify": "reviewer",
+}
+
+
+def resolve_role(name: str) -> str | None:
+    """Resolve a role name (or alias) to a canonical role identifier.
+
+    Returns None if the role is not recognised.
+    """
+    norm = name.strip().lower().replace("-", "_").replace(" ", "_")
+    if norm in AGENT_ROLES:
+        return norm
+    return ROLE_ALIASES.get(norm)
+
+
+def create_agent(role: str) -> SubAgent | None:
+    """Create an ephemeral sub-agent instance for the given role.
+
+    Returns None if the role is not recognised.
+    """
+    canonical = resolve_role(role)
+    if canonical is None:
+        return None
+    cls = AGENT_ROLES[canonical]
+    return cls()
+
+
+def available_roles() -> list[dict[str, str]]:
+    """Return list of available roles with display names for LLM routing."""
+    return [
+        {"role": role, "display_name": cls.display_name}
+        for role, cls in AGENT_ROLES.items()
+    ]

--- a/src/bantz/config.py
+++ b/src/bantz/config.py
@@ -224,6 +224,11 @@ class Config(BaseSettings):
     deep_memory_threshold: float = Field(0.72, alias="BANTZ_DEEP_MEMORY_THRESHOLD")
     deep_memory_max_results: int = Field(3, alias="BANTZ_DEEP_MEMORY_MAX_RESULTS")
 
+    # ── Multi-Agent Hierarchy (#321) ──────────────────────────────────────
+    multi_agent_enabled: bool = Field(False, alias="BANTZ_MULTI_AGENT_ENABLED")
+    multi_agent_max_concurrent: int = Field(3, alias="BANTZ_MULTI_AGENT_MAX_CONCURRENT")
+    multi_agent_timeout: int = Field(120, alias="BANTZ_MULTI_AGENT_TIMEOUT")
+
     # ── Continuous Awareness (#325) ───────────────────────────────────────
     awareness_enabled: bool = Field(False, alias="BANTZ_AWARENESS_ENABLED")
     awareness_interval_s: float = Field(15.0, alias="BANTZ_AWARENESS_INTERVAL_S")

--- a/src/bantz/core/brain.py
+++ b/src/bantz/core/brain.py
@@ -108,6 +108,10 @@ class Brain:
             import bantz.tools.desktop  # noqa: F401  (#322)
         except (ImportError, ModuleNotFoundError):
             pass
+        try:
+            import bantz.tools.delegate_task  # noqa: F401  (#321)
+        except (ImportError, ModuleNotFoundError):
+            pass
         import bantz.tools.summarizer    # noqa: F401  (Architect's Revision)
         self._memory_ready = False
         self._graph_ready = False
@@ -133,6 +137,13 @@ class Brain:
         if not self._memory_ready:
             data_layer.init(config)
             self._memory_ready = True
+            # Initialise multi-agent subsystem (#321)
+            if config.multi_agent_enabled:
+                try:
+                    from bantz.agent.agent_manager import agent_manager
+                    agent_manager.init()
+                except Exception as exc:
+                    log.warning("Failed to initialise multi-agent: %s", exc)
             # Start continuous awareness collector on first process() call (#325)
             if config.awareness_enabled:
                 self._start_awareness()

--- a/src/bantz/core/brain.py
+++ b/src/bantz/core/brain.py
@@ -775,6 +775,7 @@ class Brain:
             "accessibility":    "Analysing the screen...",
             "browser_control":  "Operating the browser for you...",
             "classroom":     "Checking your assignments...",
+            "delegate_task":    "Delegating to a specialist agent...",
         }
         pre_line = _PRE_TOOL_LINES.get(tool_name)
         if pre_line:

--- a/src/bantz/core/intent.py
+++ b/src/bantz/core/intent.py
@@ -56,6 +56,7 @@ _ROUTING_HINTS: dict[str, str] = {
     "computer_use": "Autonomous multi-step desktop automation using screen vision",
     "browser": "Advanced web page parsing: HTML, CSS selectors, image extraction",
     "feed": "Fetch and parse RSS/Atom feeds. action=fetch url=<feed_url> for a direct URL, action=category category=<name> for a group (tech, world, tr_news, science, gaming), action=list to show available categories.",
+    "delegate_task": "Delegate a complex sub-task to a specialist agent. Roles: researcher (web search & synthesis), developer (code, shell, files), reviewer (validation, quality check). Use when a task needs focused multi-step expertise.",
     "image": "Download, cache, and render images. action=render url=<image_url> for ANSI terminal art via chafa, action=download to cache only, action=raw for Telegram send_photo bytes.",
     "gui": "Desktop GUI automation via pyautogui + xdotool. action=click x=<int> y=<int>, action=click_image template=<path>, action=type text=<str>, action=focus_window title=<pattern> wm_class=<class>, action=screenshot region=<x,y,w,h>, action=scroll x=<int> y=<int> clicks=<int>, action=action_log to inspect recorded actions.",
 }
@@ -100,6 +101,7 @@ RULES:
 - Literal bash commands (ls, df, top) → shell.
 - Multi-step with "then" / "and" / "after that" → route="planner".
 - Requests involving "research", "detailed summary", "write to file", or "in-depth analysis" → route="planner".
+- "delegate this to researcher/developer/reviewer" or "have the researcher look into X" → delegate_task with the specified role.
 - Do NOT hallucinate data — always route to the real tool.
 - browser_control action names are EXACT: find_and_click (not 'click'), navigate (not 'navigate_to'), type_in_element (not 'type_in').
 - Tool name must be EXACT registry name. Never invent tool names like "cancel_reminder" or "delete_event". Use the base tool with the right action param.

--- a/src/bantz/interface/live_ui.py
+++ b/src/bantz/interface/live_ui.py
@@ -659,6 +659,8 @@ class LiveUI:
         bus.on("ghost_loop_idle", self._on_bus_ghost_idle)
         bus.on("stt_model_ready", self._on_bus_stt_ready)
         bus.on("stt_model_failed", self._on_bus_stt_failed)
+        bus.on("delegation_start", self._on_bus_delegation_start)
+        bus.on("delegation_done", self._on_bus_delegation_done)
         logger.debug("EventBus → LiveUI bridge active")
 
     def _on_bus_voice_input(self, event: Event) -> None:
@@ -706,6 +708,23 @@ class LiveUI:
     def _on_bus_stt_failed(self, event: Event) -> None:
         error = event.data.get("error", "unknown")
         self.add_chat("error", f"Speech recognition failed: {error}")
+
+    def _on_bus_delegation_start(self, event: Event) -> None:
+        name = event.data.get("display_name", "Agent")
+        task = event.data.get("task", "")[:60]
+        self.add_log(f"🤖 [bold cyan]{name}[/] agent started: {task}")
+
+    def _on_bus_delegation_done(self, event: Event) -> None:
+        name = event.data.get("display_name", "Agent")
+        ok = event.data.get("success", False)
+        dur = event.data.get("duration_s", 0)
+        tools = event.data.get("tools_used", [])
+        if ok:
+            t_str = f" (tools: {', '.join(tools)})" if tools else ""
+            self.add_log(f"✅ [bold green]{name}[/] finished in {dur}s{t_str}")
+        else:
+            err = event.data.get("error", "unknown")[:60]
+            self.add_log(f"❌ [bold red]{name}[/] failed: {err}")
 
     # ══════════════════════════════════════════════════════════════
     # Chat loop

--- a/src/bantz/interface/live_ui.py
+++ b/src/bantz/interface/live_ui.py
@@ -251,6 +251,7 @@ class LiveUI:
 
         # ── UI state ─────────────────────────────────────────────
         self._scroll_offset: int = 0
+        self._chat_scroll_offset: int = 0
         self._running: bool = True
         self._live: Live | None = None
         self._busy: bool = False
@@ -265,14 +266,14 @@ class LiveUI:
     # ── Scroll callback ───────────────────────────────────────────
 
     def _on_scroll(self, direction: int) -> None:
-        """Adjust log-panel scroll offset.  +1 = up, −1 = down."""
+        """Adjust chat-panel scroll offset.  +1 = up, −1 = down."""
         if direction > 0:
-            self._scroll_offset = min(
-                self._scroll_offset + 3,
-                max(0, len(self._log_lines) - 1),
+            self._chat_scroll_offset = min(
+                self._chat_scroll_offset + 3,
+                max(0, len(self._chat_lines) - 1),
             )
         else:
-            self._scroll_offset = max(self._scroll_offset - 3, 0)
+            self._chat_scroll_offset = max(self._chat_scroll_offset - 3, 0)
 
     # ── Layout ────────────────────────────────────────────────────
 
@@ -280,11 +281,11 @@ class LiveUI:
         layout = Layout()
         layout.split_column(
             Layout(name="header", size=3),
-            Layout(name="main", ratio=1),
-            Layout(name="chat", size=14),
+            Layout(name="chat", ratio=3),
+            Layout(name="bottom", ratio=1, minimum_size=7),
         )
-        layout["main"].split_row(
-            Layout(name="stats", size=30),
+        layout["bottom"].split_row(
+            Layout(name="stats", size=28),
             Layout(name="logs", ratio=1),
         )
         return layout
@@ -304,32 +305,27 @@ class LiveUI:
 
     def _render_stats(self) -> Panel:
         lines: list[str] = [
-            f"  [dim]CPU [/] {_bar(self._cpu)}  {self._cpu:5.1f}%",
-            f"  [dim]RAM [/] {_bar(self._ram_pct)}  "
-            f"{self._ram_used_gb:.1f}/{self._ram_total_gb:.0f}GB",
-            f"  [dim]DISK[/] {_bar(self._disk_pct)}  "
-            f"{self._disk_used_gb:.0f}/{self._disk_total_gb:.0f}GB",
+            f" [dim]CPU [/]{_bar(self._cpu)} {self._cpu:4.0f}%",
+            f" [dim]RAM [/]{_bar(self._ram_pct)} "
+            f"{self._ram_used_gb:.1f}/{self._ram_total_gb:.0f}G",
+            f" [dim]DISK[/]{_bar(self._disk_pct)} "
+            f"{self._disk_used_gb:.0f}/{self._disk_total_gb:.0f}G",
         ]
         if self._vram_available:
             lines.append(
-                f"  [dim]VRAM[/] {_bar(self._vram_pct)}  "
-                f"{self._vram_used_mb:.0f}/{self._vram_total_mb:.0f}MB"
+                f" [dim]VRAM[/]{_bar(self._vram_pct)} "
+                f"{self._vram_used_mb:.0f}/{self._vram_total_mb:.0f}M"
             )
-
-        now = datetime.now()
-        lines.append("")
-        lines.append(f"  [bold]{now.strftime('%H:%M:%S')}[/]")
-        lines.append(f"  [dim]{now.strftime('%A, %d %B %Y')}[/]")
         return Panel(
             Text.from_markup("\n".join(lines)),
-            title="[bold cyan]SYSTEM[/]",
+            title="[bold cyan]SYS[/]",
             border_style="cyan",
         )
 
     def _render_logs(self) -> Panel:
         lines = list(self._log_lines)
         total = len(lines)
-        visible_count = 40
+        visible_count = 15
 
         if self._scroll_offset > 0 and total > 0:
             end = max(0, total - self._scroll_offset)
@@ -358,15 +354,28 @@ class LiveUI:
 
     def _render_chat(self) -> Panel:
         parts: list[Any] = []
-        recent = list(self._chat_lines)[-20:]
+        all_msgs = list(self._chat_lines)
+        total = len(all_msgs)
+        visible_count = 40
 
-        for role, msg in recent:
+        if self._chat_scroll_offset > 0 and total > 0:
+            end = max(0, total - self._chat_scroll_offset)
+            start = max(0, end - visible_count)
+            recent = all_msgs[start:end]
+        else:
+            recent = all_msgs[-visible_count:]
+
+        for i, (role, msg) in enumerate(recent):
             if role == "user":
+                if i > 0:
+                    parts.append(Text(""))
                 parts.append(
-                    Text.from_markup(f"[bold green]▶ You[/]   {escape(msg)}")
+                    Text.from_markup(f"[bold green]▶ You[/]  {escape(msg)}")
                 )
             elif role == "bantz":
-                if "```" in msg or len(msg) > 300:
+                if i > 0:
+                    parts.append(Text(""))
+                if "```" in msg or len(msg) > 120:
                     parts.append(Text.from_markup("[bold cyan]◆ Bantz[/]"))
                     parts.append(Markdown(msg))
                 else:
@@ -389,6 +398,7 @@ class LiveUI:
                 )
 
         if self._streaming_text is not None:
+            parts.append(Text(""))
             parts.append(
                 Text.from_markup(
                     f"[bold cyan]◆ Bantz[/]  {escape(self._streaming_text)}▌"
@@ -397,15 +407,23 @@ class LiveUI:
         elif self._busy:
             parts.append(Text("  ⟳ thinking...", style="dim cyan"))
 
+        scroll_hint = ""
+        if self._chat_scroll_offset > 0:
+            scroll_hint = f" [dim](↑{self._chat_scroll_offset})[/]"
+
         content = Group(*parts) if parts else Text("")
         return Panel(
-            content, title="[bold cyan]CHAT[/]", border_style="cyan",
+            content,
+            title=f"[bold cyan]CHAT[/]{scroll_hint}",
+            border_style="cyan",
+            subtitle="[dim]scroll ↑↓ to browse history[/]" if total > visible_count else None,
+            subtitle_align="right",
         )
 
     def _update_panels(self, layout: Layout) -> None:
         layout["header"].update(self._render_header())
-        layout["main"]["stats"].update(self._render_stats())
-        layout["main"]["logs"].update(self._render_logs())
+        layout["bottom"]["stats"].update(self._render_stats())
+        layout["bottom"]["logs"].update(self._render_logs())
         layout["chat"].update(self._render_chat())
 
     # ── Data helpers ──────────────────────────────────────────────
@@ -413,6 +431,7 @@ class LiveUI:
     def add_chat(self, role: str, msg: str) -> None:
         """Append a message to the chat panel."""
         self._chat_lines.append((role, msg))
+        self._chat_scroll_offset = 0  # auto-scroll to newest
 
     def add_log(self, msg: str) -> None:
         """Append a timestamped line to the log panel (auto-scroll)."""

--- a/src/bantz/interface/live_ui.py
+++ b/src/bantz/interface/live_ui.py
@@ -152,6 +152,14 @@ class _MouseReader:
     def active(self) -> bool:
         return self._active
 
+    @staticmethod
+    def _raw_write(data: bytes) -> None:
+        """Write bytes directly to fd 1, bypassing Rich FileProxy."""
+        try:
+            os.write(1, data)
+        except OSError:
+            pass
+
     def start(self) -> None:
         if not _HAS_TERMIOS or self._active:
             return
@@ -161,8 +169,7 @@ class _MouseReader:
         except termios.error:
             return
         self._active = True
-        sys.stdout.write("\033[?1000h\033[?1006h")
-        sys.stdout.flush()
+        self._raw_write(b"\033[?1000h\033[?1006h")
         self._thread = threading.Thread(target=self._run, daemon=True)
         self._thread.start()
 
@@ -170,8 +177,7 @@ class _MouseReader:
         if not self._active:
             return
         self._active = False
-        sys.stdout.write("\033[?1000l\033[?1006l")
-        sys.stdout.flush()
+        self._raw_write(b"\033[?1000l\033[?1006l")
         if self._thread is not None:
             self._thread.join(timeout=0.3)
             self._thread = None

--- a/src/bantz/tools/delegate_task.py
+++ b/src/bantz/tools/delegate_task.py
@@ -1,0 +1,126 @@
+"""
+Bantz — Delegate Task Tool (#321)
+
+Allows the Brain orchestrator to delegate sub-tasks to specialised
+sub-agents (Researcher, Developer, Reviewer) via the AgentManager.
+
+This tool is registered in the global ToolRegistry and is available
+to the CoT router and planner for multi-step task decomposition.
+
+Usage by the LLM:
+    {"tool": "delegate_task", "args": {
+        "agent_role": "researcher",
+        "task_description": "Find the current GDP of Turkey",
+        "context": {"year": 2025}
+    }}
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from bantz.tools import BaseTool, ToolResult, registry
+
+log = logging.getLogger("bantz.tools.delegate")
+
+
+class DelegateTaskTool(BaseTool):
+    """Delegate a sub-task to a specialised agent.
+
+    The orchestrator (Brain) can use this tool to spin up a sub-agent
+    with its own system prompt and restricted tool access, wait for
+    results, and incorporate the findings.
+
+    Parameters:
+        agent_role: "researcher" | "developer" | "reviewer" (or alias)
+        task_description: Natural language description of what to do
+        context: Optional dict with extra context from the orchestrator
+
+    Returns:
+        ToolResult with the agent's summary and structured data.
+    """
+
+    name = "delegate_task"
+    description = (
+        "Delegate a sub-task to a specialised agent. "
+        "Roles: researcher (web search, info gathering), "
+        "developer (code, shell, files), "
+        "reviewer (validation, quality check). "
+        "Use when a task requires focused expertise that a specialist would handle better."
+    )
+    risk_level = "safe"
+
+    async def execute(
+        self,
+        agent_role: str = "",
+        task_description: str = "",
+        context: dict[str, Any] | str | None = None,
+        **kwargs: Any,
+    ) -> ToolResult:
+        # ── Validation ────────────────────────────────────────────
+        if not agent_role:
+            return ToolResult(
+                success=False,
+                output="",
+                error="Missing required parameter: agent_role",
+            )
+        if not task_description:
+            return ToolResult(
+                success=False,
+                output="",
+                error="Missing required parameter: task_description",
+            )
+
+        # Parse context if it's a JSON string (LLMs sometimes serialise)
+        if isinstance(context, str):
+            try:
+                context = json.loads(context)
+            except (json.JSONDecodeError, ValueError):
+                context = {"raw": context}
+
+        context = context or {}
+
+        # ── Delegate via AgentManager ─────────────────────────────
+        from bantz.agent.agent_manager import agent_manager
+
+        if not agent_manager.enabled:
+            return ToolResult(
+                success=False,
+                output="",
+                error=(
+                    "Multi-agent system is disabled. "
+                    "Set BANTZ_MULTI_AGENT_ENABLED=true in your .env file."
+                ),
+            )
+
+        result = await agent_manager.delegate(
+            role=agent_role,
+            task=task_description,
+            context=context,
+        )
+
+        if not result.success:
+            return ToolResult(
+                success=False,
+                output=result.error,
+                error=result.error,
+            )
+
+        # ── Build output ──────────────────────────────────────────
+        output_parts = [result.summary]
+        if result.tools_used:
+            output_parts.append(
+                f"\n[Tools used: {', '.join(result.tools_used)}]"
+            )
+
+        return ToolResult(
+            success=True,
+            output="\n".join(output_parts),
+            data=result.data,
+        )
+
+
+# ── Register ──────────────────────────────────────────────────────────────
+
+registry.register(DelegateTaskTool())

--- a/tests/agent/test_agent_manager.py
+++ b/tests/agent/test_agent_manager.py
@@ -98,6 +98,20 @@ class TestAgentManagerInit:
             mgr.init()
         assert mgr.enabled is True
 
+    def test_init_reads_config_values(self):
+        """init() reads max_concurrent and timeout from config."""
+        mgr = AgentManager()
+        mock_cfg = MagicMock()
+        mock_cfg.multi_agent_enabled = True
+        mock_cfg.multi_agent_max_concurrent = 5
+        mock_cfg.multi_agent_timeout = 60
+        with patch("bantz.agent.agent_manager.config", mock_cfg, create=True), \
+             patch("bantz.config.config", mock_cfg):
+            mgr.init()
+        assert mgr.enabled is True
+        assert mgr.MAX_CONCURRENT == 5
+        assert mgr.DELEGATION_TIMEOUT == 60.0
+
     def test_init_disabled_stays_disabled(self):
         """init() with config.multi_agent_enabled=False keeps disabled."""
         mgr = AgentManager()

--- a/tests/agent/test_agent_manager.py
+++ b/tests/agent/test_agent_manager.py
@@ -1,0 +1,312 @@
+"""Tests for bantz.agent.agent_manager — Issue #321 AgentManager.
+
+Covers:
+  1. init() / enabled flag — reads config, toggles manager on/off
+  2. delegate() — happy path, unknown role, disabled state
+  3. Rate limiting — concurrent limit, per-session limit
+  4. Timeout handling — delegation_timeout enforcement
+  5. DelegationRecord — creation, duration, to_dict
+  6. Stats / reset — statistics tracking and session reset
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bantz.agent.agent_manager import AgentManager, DelegationRecord
+from bantz.agent.sub_agent import SubAgentResult
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# DelegationRecord
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestDelegationRecord:
+    """DelegationRecord dataclass and helpers."""
+
+    def test_duration_completed(self):
+        """Duration when both started and finished are set."""
+        rec = DelegationRecord(
+            role="researcher",
+            task="Find GDP",
+            started_at=100.0,
+            finished_at=103.5,
+        )
+        assert rec.duration_s == pytest.approx(3.5)
+
+    def test_duration_in_progress(self):
+        """Duration when still in progress uses monotonic clock."""
+        rec = DelegationRecord(
+            role="researcher",
+            task="Find GDP",
+            started_at=time.monotonic() - 2.0,
+        )
+        assert rec.duration_s >= 1.5  # at least ~2 secs
+
+    def test_to_dict(self):
+        """to_dict returns JSON-serialisable dict."""
+        rec = DelegationRecord(
+            role="developer",
+            task="Write script",
+            started_at=100.0,
+            finished_at=105.0,
+            success=True,
+            summary="Script written",
+            tools_used=["shell", "filesystem"],
+        )
+        d = rec.to_dict()
+        assert d["role"] == "developer"
+        assert d["success"] is True
+        assert d["duration_s"] == 5.0
+        assert d["tools_used"] == ["shell", "filesystem"]
+
+    def test_to_dict_truncates_long_fields(self):
+        """Long task and summary are truncated in to_dict."""
+        rec = DelegationRecord(
+            role="researcher",
+            task="x" * 500,
+            started_at=0,
+            finished_at=1,
+            summary="y" * 1000,
+        )
+        d = rec.to_dict()
+        assert len(d["task"]) == 200
+        assert len(d["summary"]) == 500
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# AgentManager — Init & Enable
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestAgentManagerInit:
+    """Initialisation and enable/disable logic."""
+
+    def test_disabled_by_default(self):
+        mgr = AgentManager()
+        assert mgr.enabled is False
+
+    def test_init_enables(self):
+        """init() reads config and enables the manager."""
+        mgr = AgentManager()
+        mock_cfg = MagicMock()
+        mock_cfg.multi_agent_enabled = True
+        with patch("bantz.agent.agent_manager.config", mock_cfg, create=True), \
+             patch("bantz.config.config", mock_cfg):
+            mgr.init()
+        assert mgr.enabled is True
+
+    def test_init_disabled_stays_disabled(self):
+        """init() with config.multi_agent_enabled=False keeps disabled."""
+        mgr = AgentManager()
+        mock_cfg = MagicMock()
+        mock_cfg.multi_agent_enabled = False
+        with patch("bantz.agent.agent_manager.config", mock_cfg, create=True), \
+             patch("bantz.config.config", mock_cfg):
+            mgr.init()
+        assert mgr.enabled is False
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# AgentManager — Delegation
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestDelegate:
+    """delegate() — the core delegation method."""
+
+    @pytest.mark.asyncio
+    async def test_delegate_success(self):
+        """Happy path: delegate to researcher, get result."""
+        mgr = AgentManager()
+        mgr._enabled = True
+
+        mock_result = SubAgentResult(
+            success=True,
+            summary="Found the data",
+            tools_used=["web_search"],
+        )
+        mock_agent = MagicMock()
+        mock_agent.run = AsyncMock(return_value=mock_result)
+        mock_agent.display_name = "Researcher"
+
+        with patch("bantz.agent.agent_manager.create_agent", return_value=mock_agent), \
+             patch("bantz.agent.agent_manager.resolve_role", return_value="researcher"):
+            result = await mgr.delegate("researcher", "Find GDP")
+
+        assert result.success is True
+        assert result.summary == "Found the data"
+        assert mgr.total_delegations == 1
+        assert mgr.active_count == 0  # finished
+
+    @pytest.mark.asyncio
+    async def test_delegate_disabled(self):
+        """Delegation when manager is disabled returns failure."""
+        mgr = AgentManager()
+        mgr._enabled = False
+
+        result = await mgr.delegate("researcher", "Find GDP")
+        assert result.success is False
+        assert "disabled" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_delegate_unknown_role(self):
+        """Unknown role returns failure with available roles."""
+        mgr = AgentManager()
+        mgr._enabled = True
+
+        with patch("bantz.agent.agent_manager.resolve_role", return_value=None):
+            result = await mgr.delegate("plumber", "Fix pipes")
+
+        assert result.success is False
+        assert "Unknown" in result.error or "plumber" in result.error
+
+    @pytest.mark.asyncio
+    async def test_delegate_records_history(self):
+        """Delegation is recorded in history."""
+        mgr = AgentManager()
+        mgr._enabled = True
+
+        mock_result = SubAgentResult(success=True, summary="done")
+        mock_agent = MagicMock()
+        mock_agent.run = AsyncMock(return_value=mock_result)
+        mock_agent.display_name = "Developer"
+
+        with patch("bantz.agent.agent_manager.create_agent", return_value=mock_agent), \
+             patch("bantz.agent.agent_manager.resolve_role", return_value="developer"):
+            await mgr.delegate("developer", "Write code")
+
+        assert len(mgr.history) == 1
+        rec = mgr.history[0]
+        assert rec.role == "developer"
+        assert rec.success is True
+        assert rec.finished_at > 0
+
+    @pytest.mark.asyncio
+    async def test_delegate_agent_crash(self):
+        """Agent crash is caught and recorded."""
+        mgr = AgentManager()
+        mgr._enabled = True
+
+        mock_agent = MagicMock()
+        mock_agent.run = AsyncMock(side_effect=RuntimeError("Boom"))
+        mock_agent.display_name = "Researcher"
+
+        with patch("bantz.agent.agent_manager.create_agent", return_value=mock_agent), \
+             patch("bantz.agent.agent_manager.resolve_role", return_value="researcher"):
+            result = await mgr.delegate("researcher", "Find data")
+
+        assert result.success is False
+        assert "crashed" in result.error.lower() or "Boom" in result.error
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Rate Limiting
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestRateLimiting:
+    """Concurrent and per-session rate limits."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_limit(self):
+        """When MAX_CONCURRENT is reached, new delegations are refused."""
+        mgr = AgentManager()
+        mgr._enabled = True
+        mgr.MAX_CONCURRENT = 2
+        mgr._active = 2  # simulate 2 active
+
+        result = await mgr.delegate("researcher", "Another task")
+        assert result.success is False
+        assert "concurrent" in result.error.lower() or "Too many" in result.error
+
+    @pytest.mark.asyncio
+    async def test_session_limit(self):
+        """When MAX_PER_CONVERSATION is reached, delegation is refused."""
+        mgr = AgentManager()
+        mgr._enabled = True
+        mgr.MAX_PER_CONVERSATION = 2
+        # Simulate 2 completed delegations
+        mgr._history = [
+            DelegationRecord("r", "t1", 0, 1, True, "ok"),
+            DelegationRecord("r", "t2", 1, 2, True, "ok"),
+        ]
+
+        result = await mgr.delegate("researcher", "Third task")
+        assert result.success is False
+        assert "limit" in result.error.lower()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Timeout
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestTimeout:
+    """Delegation timeout enforcement."""
+
+    @pytest.mark.asyncio
+    async def test_timeout_enforced(self):
+        """Agent that takes too long is cancelled."""
+        mgr = AgentManager()
+        mgr._enabled = True
+        mgr.DELEGATION_TIMEOUT = 0.1  # 100ms
+
+        async def slow_run(task, context):
+            await asyncio.sleep(10)
+            return SubAgentResult(success=True, summary="too late")
+
+        mock_agent = MagicMock()
+        mock_agent.run = slow_run
+        mock_agent.display_name = "Researcher"
+
+        with patch("bantz.agent.agent_manager.create_agent", return_value=mock_agent), \
+             patch("bantz.agent.agent_manager.resolve_role", return_value="researcher"):
+            result = await mgr.delegate("researcher", "Slow task")
+
+        assert result.success is False
+        assert "timed out" in result.error.lower()
+        assert mgr.active_count == 0  # cleaned up
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Stats & Reset
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestStatsAndReset:
+    """stats() and reset() methods."""
+
+    def test_stats_empty(self):
+        mgr = AgentManager()
+        s = mgr.stats()
+        assert s["total_delegations"] == 0
+        assert s["active"] == 0
+        assert s["successful"] == 0
+        assert "available_roles" in s
+
+    def test_stats_after_delegations(self):
+        mgr = AgentManager()
+        mgr._history = [
+            DelegationRecord("researcher", "t1", 0, 1, True, "ok"),
+            DelegationRecord("developer", "t2", 1, 2, False, "", error="fail"),
+        ]
+        s = mgr.stats()
+        assert s["total_delegations"] == 2
+        assert s["successful"] == 1
+        assert s["failed"] == 1
+
+    def test_reset_clears_state(self):
+        mgr = AgentManager()
+        mgr._history = [
+            DelegationRecord("researcher", "t1", 0, 1, True, "ok"),
+        ]
+        mgr._active = 1
+        mgr.reset()
+        assert mgr.total_delegations == 0
+        assert mgr.active_count == 0
+
+    def test_list_roles(self):
+        mgr = AgentManager()
+        roles = mgr.list_roles()
+        assert len(roles) == 3
+        role_ids = {r["role"] for r in roles}
+        assert "researcher" in role_ids

--- a/tests/agent/test_sub_agent.py
+++ b/tests/agent/test_sub_agent.py
@@ -1,0 +1,552 @@
+"""Tests for bantz.agent.sub_agent — Issue #321 SubAgent base + Roles.
+
+Covers:
+  1. SubAgentResult — creation, failure shorthand, to_dict serialisation
+  2. Role resolution — canonical names, aliases, unknown roles
+  3. Agent creation — factory, allowed_tools, system prompt building
+  4. SubAgent.run() — 3-phase pipeline with mocked LLM and tools
+  5. Parsing helpers — tool call extraction, final result parsing
+  6. Tool access restriction — denied tools produce errors
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bantz.agent.sub_agent import (
+    AGENT_ROLES,
+    ROLE_ALIASES,
+    DeveloperAgent,
+    ResearcherAgent,
+    ReviewerAgent,
+    SubAgent,
+    SubAgentResult,
+    available_roles,
+    create_agent,
+    resolve_role,
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# SubAgentResult
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestSubAgentResult:
+    """Result dataclass and factory methods."""
+
+    def test_success_result(self):
+        """Successful result with summary and data."""
+        r = SubAgentResult(
+            success=True,
+            summary="GDP is $1T",
+            data={"gdp": 1_000_000_000_000},
+            tools_used=["web_search"],
+        )
+        assert r.success is True
+        assert "GDP" in r.summary
+        assert r.data["gdp"] == 1_000_000_000_000
+        assert r.error == ""
+
+    def test_failure_shorthand(self):
+        """SubAgentResult.failure() convenience method."""
+        r = SubAgentResult.failure("LLM timeout")
+        assert r.success is False
+        assert r.summary == ""
+        assert r.error == "LLM timeout"
+        assert r.tools_used == []
+
+    def test_to_dict_roundtrip(self):
+        """to_dict produces a JSON-serialisable dict."""
+        r = SubAgentResult(
+            success=True,
+            summary="ok",
+            data={"key": "val"},
+            tools_used=["shell"],
+        )
+        d = r.to_dict()
+        assert d["success"] is True
+        assert d["summary"] == "ok"
+        assert d["data"] == {"key": "val"}
+        assert d["tools_used"] == ["shell"]
+        # Ensure it's JSON-serialisable
+        json.dumps(d)
+
+    def test_default_fields(self):
+        """Defaults are empty collections."""
+        r = SubAgentResult(success=True, summary="done")
+        assert r.data == {}
+        assert r.tools_used == []
+        assert r.error == ""
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Role Resolution
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestResolveRole:
+    """resolve_role() maps names and aliases to canonical identifiers."""
+
+    def test_canonical_names(self):
+        """Direct role names resolve to themselves."""
+        assert resolve_role("researcher") == "researcher"
+        assert resolve_role("developer") == "developer"
+        assert resolve_role("reviewer") == "reviewer"
+
+    def test_aliases(self):
+        """Common aliases resolve correctly."""
+        assert resolve_role("dev") == "developer"
+        assert resolve_role("search") == "researcher"
+        assert resolve_role("code") == "developer"
+        assert resolve_role("check") == "reviewer"
+        assert resolve_role("verify") == "reviewer"
+        assert resolve_role("audit") == "reviewer"
+
+    def test_case_insensitive(self):
+        """Resolution is case-insensitive."""
+        assert resolve_role("RESEARCHER") == "researcher"
+        assert resolve_role("Dev") == "developer"
+        assert resolve_role("REVIEW") == "reviewer"
+
+    def test_normalisation(self):
+        """Leading/trailing whitespace is stripped."""
+        assert resolve_role(" researcher ") == "researcher"
+        assert resolve_role(" dev ") == "developer"
+        assert resolve_role("  review  ") == "reviewer"
+
+    def test_unknown_returns_none(self):
+        """Unrecognised roles return None."""
+        assert resolve_role("plumber") is None
+        assert resolve_role("") is None
+        assert resolve_role("xyz_unknown") is None
+
+
+class TestCreateAgent:
+    """create_agent() factory function."""
+
+    def test_creates_researcher(self):
+        agent = create_agent("researcher")
+        assert isinstance(agent, ResearcherAgent)
+        assert agent.role == "researcher"
+
+    def test_creates_developer(self):
+        agent = create_agent("developer")
+        assert isinstance(agent, DeveloperAgent)
+
+    def test_creates_reviewer(self):
+        agent = create_agent("reviewer")
+        assert isinstance(agent, ReviewerAgent)
+
+    def test_alias_creates_agent(self):
+        """create_agent works with aliases too."""
+        agent = create_agent("dev")
+        assert isinstance(agent, DeveloperAgent)
+
+    def test_unknown_returns_none(self):
+        assert create_agent("martian") is None
+
+    def test_available_roles_list(self):
+        """available_roles() returns role dicts."""
+        roles = available_roles()
+        assert len(roles) == 3
+        role_names = {r["role"] for r in roles}
+        assert role_names == {"researcher", "developer", "reviewer"}
+        # Each has display_name
+        for r in roles:
+            assert "display_name" in r
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Agent Properties
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestAgentProperties:
+    """Specialised agent configurations."""
+
+    def test_researcher_tools(self):
+        agent = ResearcherAgent()
+        assert "web_search" in agent.allowed_tools
+        assert "read_url" in agent.allowed_tools
+        assert "shell" not in agent.allowed_tools
+
+    def test_developer_tools(self):
+        agent = DeveloperAgent()
+        assert "shell" in agent.allowed_tools
+        assert "filesystem" in agent.allowed_tools
+        assert "web_search" not in agent.allowed_tools
+
+    def test_reviewer_tools(self):
+        agent = ReviewerAgent()
+        assert "web_search" in agent.allowed_tools
+        assert "shell" not in agent.allowed_tools
+        assert agent.max_tool_calls == 3
+
+    def test_reviewer_max_tool_calls_lower(self):
+        """Reviewer has a stricter circuit breaker than default."""
+        researcher = ResearcherAgent()
+        reviewer = ReviewerAgent()
+        assert reviewer.max_tool_calls < researcher.max_tool_calls
+
+
+class TestBuildSystem:
+    """_build_system() injects task-specific context into prompts."""
+
+    def test_researcher_with_language_context(self):
+        agent = ResearcherAgent()
+        prompt = agent._build_system("Find GDP", {"user_language": "Turkish"})
+        assert "Turkish" in prompt
+        assert "Research Agent" in prompt
+
+    def test_developer_with_workdir(self):
+        agent = DeveloperAgent()
+        prompt = agent._build_system("Write script", {"working_directory": "/tmp"})
+        assert "/tmp" in prompt
+
+    def test_reviewer_with_artifact(self):
+        agent = ReviewerAgent()
+        prompt = agent._build_system("Check code", {"artifact": "def foo(): pass"})
+        assert "def foo(): pass" in prompt
+
+    def test_base_prompt_always_present(self):
+        """System prompt text is always included even without context."""
+        agent = ResearcherAgent()
+        prompt = agent._build_system("task", {})
+        assert "Research Agent" in prompt
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Parsing Helpers
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestParseToolCalls:
+    """_parse_tool_calls() extracts structured tool calls from LLM text."""
+
+    def test_json_array(self):
+        """Standard JSON array of tool calls."""
+        agent = ResearcherAgent()
+        raw = '[{"tool": "web_search", "args": {"query": "hello"}}]'
+        calls = agent._parse_tool_calls(raw)
+        assert len(calls) == 1
+        assert calls[0]["tool"] == "web_search"
+
+    def test_embedded_in_text(self):
+        """Tool calls buried in prose text."""
+        agent = ResearcherAgent()
+        raw = (
+            "I will search for that.\n"
+            '[{"tool": "web_search", "args": {"query": "GDP Turkey"}}]\n'
+            "Let me know if you need more."
+        )
+        calls = agent._parse_tool_calls(raw)
+        assert len(calls) == 1
+
+    def test_thinking_block_stripped(self):
+        """<thinking> blocks are removed before parsing."""
+        agent = ResearcherAgent()
+        raw = (
+            "<thinking>I should search</thinking>\n"
+            '[{"tool": "web_search", "args": {"query": "test"}}]'
+        )
+        calls = agent._parse_tool_calls(raw)
+        assert len(calls) == 1
+
+    def test_no_tools_returns_empty(self):
+        """Pure reasoning with no JSON → empty list."""
+        agent = ResearcherAgent()
+        raw = "I already know the answer. The GDP is $1T."
+        calls = agent._parse_tool_calls(raw)
+        assert calls == []
+
+    def test_tools_key_in_object(self):
+        """Tool calls inside a JSON object with 'tools' key."""
+        agent = ResearcherAgent()
+        raw = '{"tools": [{"tool": "news", "args": {"query": "latest"}}]}'
+        calls = agent._parse_tool_calls(raw)
+        assert len(calls) == 1
+        assert calls[0]["tool"] == "news"
+
+    def test_multiple_calls(self):
+        """Multiple tool calls in one array."""
+        agent = ResearcherAgent()
+        raw = json.dumps([
+            {"tool": "web_search", "args": {"query": "a"}},
+            {"tool": "read_url", "args": {"url": "http://x.com"}},
+        ])
+        calls = agent._parse_tool_calls(raw)
+        assert len(calls) == 2
+
+
+class TestParseFinalResult:
+    """_parse_final_result() converts LLM synthesis text to SubAgentResult."""
+
+    def test_valid_json(self):
+        """Clean JSON response is parsed correctly."""
+        agent = ResearcherAgent()
+        raw = '{"summary": "GDP is X", "data": {"gdp": 123}}'
+        result = agent._parse_final_result(raw, ["web_search"])
+        assert result.success is True
+        assert "GDP" in result.summary
+        assert result.data["gdp"] == 123
+        assert result.tools_used == ["web_search"]
+
+    def test_json_in_code_fence(self):
+        """JSON wrapped in markdown code fences."""
+        agent = ResearcherAgent()
+        raw = '```json\n{"summary": "result"}\n```'
+        result = agent._parse_final_result(raw, [])
+        assert result.success is True
+        assert result.summary == "result"
+
+    def test_fallback_to_raw_text(self):
+        """Non-JSON text becomes the summary."""
+        agent = ResearcherAgent()
+        raw = "I couldn't find the GDP data."
+        result = agent._parse_final_result(raw, [])
+        assert result.success is True
+        assert "couldn't find" in result.summary
+
+    def test_thinking_block_stripped(self):
+        """Thinking blocks are removed before parsing."""
+        agent = ResearcherAgent()
+        raw = '<thinking>hmm</thinking>{"summary": "clean result"}'
+        result = agent._parse_final_result(raw, [])
+        assert result.summary == "clean result"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# SubAgent.run() — Full pipeline
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestSubAgentRun:
+    """Integration tests for the 3-phase run() pipeline."""
+
+    @pytest.mark.asyncio
+    async def test_run_with_tools(self):
+        """Full cycle: plan → execute tool → synthesise."""
+        agent = ResearcherAgent()
+
+        # Phase 1: LLM returns a tool call plan
+        plan_response = '[{"tool": "web_search", "args": {"query": "Turkey GDP 2025"}}]'
+        # Phase 3: LLM returns a synthesis
+        synth_response = '{"summary": "Turkey GDP is $1T in 2025"}'
+
+        # Mock LLM to return plan first, then synthesis
+        call_count = 0
+
+        async def mock_chat(messages):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return plan_response
+            return synth_response
+
+        # Mock the tool
+        mock_tool = MagicMock()
+        mock_tool.execute = AsyncMock(return_value=MagicMock(
+            success=True,
+            output="Turkey GDP: $1,000,000,000,000 (2025 estimate)",
+        ))
+
+        mock_registry = MagicMock()
+        mock_registry.get.return_value = mock_tool
+
+        with patch.object(agent, "_llm_chat", side_effect=mock_chat), \
+             patch("bantz.tools.registry", mock_registry):
+            result = await agent.run("Find Turkey GDP 2025")
+
+        assert result.success is True
+        assert "1T" in result.summary
+        assert "web_search" in result.tools_used
+
+    @pytest.mark.asyncio
+    async def test_run_no_tools_needed(self):
+        """LLM can answer directly without tools."""
+        agent = ResearcherAgent()
+
+        # Phase 1: no tool calls in the response
+        plan_response = "I know this already — the answer is 42."
+        # Phase 3: synthesis
+        synth_response = '{"summary": "The answer is 42."}'
+
+        call_count = 0
+
+        async def mock_chat(messages):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return plan_response
+            return synth_response
+
+        with patch.object(agent, "_llm_chat", side_effect=mock_chat):
+            result = await agent.run("What is the meaning of life?")
+
+        assert result.success is True
+        assert "42" in result.summary
+        assert result.tools_used == []
+
+    @pytest.mark.asyncio
+    async def test_run_llm_plan_failure(self):
+        """LLM failure during planning returns error result."""
+        agent = ResearcherAgent()
+
+        async def mock_chat_fail(messages):
+            raise ConnectionError("Ollama unreachable")
+
+        with patch.object(agent, "_llm_chat", side_effect=mock_chat_fail):
+            result = await agent.run("search something")
+
+        assert result.success is False
+        assert "LLM error" in result.error
+
+    @pytest.mark.asyncio
+    async def test_run_tool_denied(self):
+        """Tools outside allowed_tools are rejected."""
+        agent = ResearcherAgent()  # doesn't have "shell"
+
+        plan_response = '[{"tool": "shell", "args": {"command": "rm -rf /"}}]'
+        synth_response = '{"summary": "Tool was denied"}'
+
+        call_count = 0
+
+        async def mock_chat(messages):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return plan_response
+            return synth_response
+
+        with patch.object(agent, "_llm_chat", side_effect=mock_chat):
+            result = await agent.run("Delete everything")
+
+        assert result.success is True  # synth still succeeds
+        assert "shell" not in result.tools_used
+
+    @pytest.mark.asyncio
+    async def test_run_circuit_breaker(self):
+        """Max tool calls limit is respected."""
+        agent = ReviewerAgent()  # max_tool_calls = 3
+
+        # Ask for 10 tool calls — only 3 should execute
+        calls = [{"tool": "web_search", "args": {"query": f"q{i}"}} for i in range(10)]
+        plan_response = json.dumps(calls)
+        synth_response = '{"summary": "done"}'
+
+        call_count = 0
+
+        async def mock_chat(messages):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return plan_response
+            return synth_response
+
+        mock_tool = MagicMock()
+        mock_tool.execute = AsyncMock(return_value=MagicMock(
+            success=True, output="result",
+        ))
+
+        mock_registry = MagicMock()
+        mock_registry.get.return_value = mock_tool
+
+        with patch.object(agent, "_llm_chat", side_effect=mock_chat), \
+             patch("bantz.tools.registry", mock_registry):
+            result = await agent.run("Run many searches")
+
+        # Only 3 calls should have been made
+        assert mock_tool.execute.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_run_synthesis_fails_but_tools_succeed(self):
+        """If synthesis LLM fails but tools worked, return tool results."""
+        agent = ResearcherAgent()
+
+        plan_response = '[{"tool": "web_search", "args": {"query": "test"}}]'
+
+        call_count = 0
+
+        async def mock_chat(messages):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return plan_response
+            raise RuntimeError("Synthesis failed")
+
+        mock_tool = MagicMock()
+        mock_tool.execute = AsyncMock(return_value=MagicMock(
+            success=True, output="Search result: found it",
+        ))
+
+        mock_registry = MagicMock()
+        mock_registry.get.return_value = mock_tool
+
+        with patch.object(agent, "_llm_chat", side_effect=mock_chat), \
+             patch("bantz.tools.registry", mock_registry):
+            result = await agent.run("search test")
+
+        # Should still succeed with combined tool output
+        assert result.success is True
+        assert "web_search" in result.tools_used
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# LLM Abstraction
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestLLMChat:
+    """_llm_chat() — Gemini-first, Ollama-fallback."""
+
+    @pytest.mark.asyncio
+    async def test_gemini_primary(self):
+        """Uses Gemini when available."""
+        agent = ResearcherAgent()
+        mock_gemini = MagicMock()
+        mock_gemini.is_enabled.return_value = True
+        mock_gemini.chat = AsyncMock(return_value="gemini answer")
+
+        with patch("bantz.agent.sub_agent.gemini", mock_gemini, create=True), \
+             patch.dict("sys.modules", {"bantz.llm.gemini": MagicMock(gemini=mock_gemini)}):
+            result = await agent._llm_chat([{"role": "user", "content": "hi"}])
+
+        assert result == "gemini answer"
+
+    @pytest.mark.asyncio
+    async def test_ollama_fallback(self):
+        """Falls back to Ollama if Gemini fails."""
+        agent = ResearcherAgent()
+        mock_ollama = MagicMock()
+        mock_ollama.chat = AsyncMock(return_value="ollama answer")
+
+        # Gemini import fails
+        with patch("bantz.llm.gemini.gemini", side_effect=ImportError), \
+             patch("bantz.llm.ollama.ollama", mock_ollama):
+            result = await agent._llm_chat([{"role": "user", "content": "hi"}])
+
+        assert result == "ollama answer"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Role Registry
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestRoleRegistry:
+    """AGENT_ROLES and ROLE_ALIASES consistency."""
+
+    def test_all_aliases_point_to_valid_roles(self):
+        """Every alias maps to a real role in AGENT_ROLES."""
+        for alias, canonical in ROLE_ALIASES.items():
+            assert canonical in AGENT_ROLES, f"Alias '{alias}' → '{canonical}' not in AGENT_ROLES"
+
+    def test_no_duplicate_aliases(self):
+        """No alias collides with a canonical role name."""
+        for alias in ROLE_ALIASES:
+            # Aliases that ARE canonical names are allowed (e.g. "research" vs "researcher")
+            # but an alias shouldn't shadow a different canonical
+            canonical = ROLE_ALIASES[alias]
+            if alias in AGENT_ROLES:
+                assert AGENT_ROLES[alias] == AGENT_ROLES.get(canonical), \
+                    f"Alias '{alias}' shadows a different canonical role"
+
+    def test_three_roles_registered(self):
+        assert len(AGENT_ROLES) == 3
+        assert set(AGENT_ROLES.keys()) == {"researcher", "developer", "reviewer"}

--- a/tests/tools/test_delegate_task.py
+++ b/tests/tools/test_delegate_task.py
@@ -1,0 +1,246 @@
+"""Tests for bantz.tools.delegate_task — Issue #321 delegate_task tool.
+
+Covers:
+  1. Tool registration — present in registry with correct metadata
+  2. execute() — happy path delegation via AgentManager
+  3. Validation — missing role, missing task_description
+  4. Disabled state — returns error when multi-agent is off
+  5. Context parsing — string context auto-parsed as JSON
+  6. Error propagation — agent failure surfaced correctly
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bantz.tools.delegate_task import DelegateTaskTool
+from bantz.agent.sub_agent import SubAgentResult
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Registration
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestRegistration:
+    """delegate_task tool is properly registered."""
+
+    def test_registered_in_registry(self):
+        """Tool is findable in the global registry."""
+        from bantz.tools import registry
+        tool = registry.get("delegate_task")
+        assert tool is not None
+        assert tool.name == "delegate_task"
+
+    def test_metadata(self):
+        tool = DelegateTaskTool()
+        assert tool.name == "delegate_task"
+        assert tool.risk_level == "safe"
+        assert "researcher" in tool.description.lower()
+        assert "developer" in tool.description.lower()
+        assert "reviewer" in tool.description.lower()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Validation
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestValidation:
+    """Parameter validation."""
+
+    @pytest.mark.asyncio
+    async def test_missing_agent_role(self):
+        tool = DelegateTaskTool()
+        result = await tool.execute(task_description="Find GDP")
+        assert result.success is False
+        assert "agent_role" in result.error
+
+    @pytest.mark.asyncio
+    async def test_missing_task_description(self):
+        tool = DelegateTaskTool()
+        result = await tool.execute(agent_role="researcher")
+        assert result.success is False
+        assert "task_description" in result.error
+
+    @pytest.mark.asyncio
+    async def test_both_missing(self):
+        tool = DelegateTaskTool()
+        result = await tool.execute()
+        assert result.success is False
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Disabled State
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestDisabledState:
+    """Tool returns error when multi-agent is disabled."""
+
+    @pytest.mark.asyncio
+    async def test_disabled_returns_error(self):
+        tool = DelegateTaskTool()
+        mock_mgr = MagicMock()
+        mock_mgr.enabled = False
+
+        with patch("bantz.tools.delegate_task.agent_manager", mock_mgr, create=True), \
+             patch("bantz.agent.agent_manager.agent_manager", mock_mgr):
+            result = await tool.execute(
+                agent_role="researcher",
+                task_description="Find GDP",
+            )
+
+        assert result.success is False
+        assert "disabled" in result.error.lower()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Happy Path
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestHappyPath:
+    """Successful delegation through the tool."""
+
+    @pytest.mark.asyncio
+    async def test_delegate_success(self):
+        tool = DelegateTaskTool()
+        mock_mgr = MagicMock()
+        mock_mgr.enabled = True
+        mock_mgr.delegate = AsyncMock(return_value=SubAgentResult(
+            success=True,
+            summary="GDP of Turkey is $1T",
+            data={"gdp": 1_000_000_000_000},
+            tools_used=["web_search"],
+        ))
+
+        with patch("bantz.agent.agent_manager.agent_manager", mock_mgr):
+            result = await tool.execute(
+                agent_role="researcher",
+                task_description="Find Turkey GDP",
+                context={"year": 2025},
+            )
+
+        assert result.success is True
+        assert "GDP" in result.output or "$1T" in result.output
+        assert result.data["gdp"] == 1_000_000_000_000
+        mock_mgr.delegate.assert_called_once_with(
+            role="researcher",
+            task="Find Turkey GDP",
+            context={"year": 2025},
+        )
+
+    @pytest.mark.asyncio
+    async def test_tools_used_in_output(self):
+        """Tool names appear in the output."""
+        tool = DelegateTaskTool()
+        mock_mgr = MagicMock()
+        mock_mgr.enabled = True
+        mock_mgr.delegate = AsyncMock(return_value=SubAgentResult(
+            success=True,
+            summary="Result found",
+            tools_used=["web_search", "read_url"],
+        ))
+
+        with patch("bantz.agent.agent_manager.agent_manager", mock_mgr):
+            result = await tool.execute(
+                agent_role="researcher",
+                task_description="Search",
+            )
+
+        assert "web_search" in result.output
+        assert "read_url" in result.output
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Context Parsing
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestContextParsing:
+    """Context parameter handling."""
+
+    @pytest.mark.asyncio
+    async def test_string_context_parsed_as_json(self):
+        """JSON string context is auto-parsed to dict."""
+        tool = DelegateTaskTool()
+        mock_mgr = MagicMock()
+        mock_mgr.enabled = True
+        mock_mgr.delegate = AsyncMock(return_value=SubAgentResult(
+            success=True, summary="ok",
+        ))
+
+        with patch("bantz.agent.agent_manager.agent_manager", mock_mgr):
+            await tool.execute(
+                agent_role="dev",
+                task_description="Write code",
+                context='{"lang": "python"}',
+            )
+
+        _, kwargs = mock_mgr.delegate.call_args
+        assert kwargs["context"] == {"lang": "python"}
+
+    @pytest.mark.asyncio
+    async def test_non_json_string_wrapped(self):
+        """Non-JSON string context is wrapped in {"raw": ...}."""
+        tool = DelegateTaskTool()
+        mock_mgr = MagicMock()
+        mock_mgr.enabled = True
+        mock_mgr.delegate = AsyncMock(return_value=SubAgentResult(
+            success=True, summary="ok",
+        ))
+
+        with patch("bantz.agent.agent_manager.agent_manager", mock_mgr):
+            await tool.execute(
+                agent_role="dev",
+                task_description="Write code",
+                context="just some text",
+            )
+
+        _, kwargs = mock_mgr.delegate.call_args
+        assert kwargs["context"] == {"raw": "just some text"}
+
+    @pytest.mark.asyncio
+    async def test_none_context_becomes_empty_dict(self):
+        """None context becomes {}."""
+        tool = DelegateTaskTool()
+        mock_mgr = MagicMock()
+        mock_mgr.enabled = True
+        mock_mgr.delegate = AsyncMock(return_value=SubAgentResult(
+            success=True, summary="ok",
+        ))
+
+        with patch("bantz.agent.agent_manager.agent_manager", mock_mgr):
+            await tool.execute(
+                agent_role="reviewer",
+                task_description="Check code",
+                context=None,
+            )
+
+        _, kwargs = mock_mgr.delegate.call_args
+        assert kwargs["context"] == {}
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Error Propagation
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestErrorPropagation:
+    """Agent failures surfaced correctly via ToolResult."""
+
+    @pytest.mark.asyncio
+    async def test_agent_failure(self):
+        tool = DelegateTaskTool()
+        mock_mgr = MagicMock()
+        mock_mgr.enabled = True
+        mock_mgr.delegate = AsyncMock(return_value=SubAgentResult(
+            success=False,
+            summary="",
+            error="Researcher agent timed out after 120s.",
+        ))
+
+        with patch("bantz.agent.agent_manager.agent_manager", mock_mgr):
+            result = await tool.execute(
+                agent_role="researcher",
+                task_description="Search",
+            )
+
+        assert result.success is False
+        assert "timed out" in result.error

--- a/tests/tui/test_live_ui.py
+++ b/tests/tui/test_live_ui.py
@@ -115,18 +115,18 @@ class TestBuildLayout:
         layout = ui._build_layout()
         assert layout["header"] is not None
 
-    def test_layout_has_main(self, ui):
+    def test_layout_has_bottom(self, ui):
         layout = ui._build_layout()
-        assert layout["main"] is not None
+        assert layout["bottom"] is not None
 
     def test_layout_has_chat(self, ui):
         layout = ui._build_layout()
         assert layout["chat"] is not None
 
-    def test_main_has_stats_and_logs(self, ui):
+    def test_bottom_has_stats_and_logs(self, ui):
         layout = ui._build_layout()
-        assert layout["main"]["stats"] is not None
-        assert layout["main"]["logs"] is not None
+        assert layout["bottom"]["stats"] is not None
+        assert layout["bottom"]["logs"] is not None
 
 
 # ── Tests: Add chat / log ────────────────────────────────────────────────────
@@ -150,6 +150,11 @@ class TestAddChat:
             ui.add_chat("user", f"msg {i}")
         assert len(ui._chat_lines) == ui.CHAT_MAX
 
+    def test_add_chat_resets_chat_scroll(self, ui):
+        ui._chat_scroll_offset = 5
+        ui.add_chat("user", "new msg")
+        assert ui._chat_scroll_offset == 0
+
 
 class TestAddLog:
     def test_add_log_has_timestamp(self, ui):
@@ -171,33 +176,35 @@ class TestAddLog:
 # ── Tests: Scrolling ─────────────────────────────────────────────────────────
 
 class TestScrolling:
+    """_on_scroll now drives _chat_scroll_offset (chat panel)."""
+
     def test_scroll_up(self, ui):
-        ui._log_lines.extend(["line"] * 50)
+        ui._chat_lines.extend([("bantz", "msg")] * 50)
         ui._on_scroll(1)
-        assert ui._scroll_offset == 3
+        assert ui._chat_scroll_offset == 3
 
     def test_scroll_down(self, ui):
-        ui._scroll_offset = 10
+        ui._chat_scroll_offset = 10
         ui._on_scroll(-1)
-        assert ui._scroll_offset == 7
+        assert ui._chat_scroll_offset == 7
 
     def test_scroll_floor_zero(self, ui):
-        ui._scroll_offset = 1
+        ui._chat_scroll_offset = 1
         ui._on_scroll(-1)
-        assert ui._scroll_offset == 0
+        assert ui._chat_scroll_offset == 0
 
     def test_scroll_not_below_zero(self, ui):
         ui._on_scroll(-1)
-        assert ui._scroll_offset == 0
+        assert ui._chat_scroll_offset == 0
 
     def test_scroll_ceiling(self, ui):
         for _ in range(5):
-            ui._log_lines.append("x")
+            ui._chat_lines.append(("bantz", "x"))
         ui._on_scroll(1)
         ui._on_scroll(1)
         ui._on_scroll(1)
-        # should not exceed total lines - 1
-        assert ui._scroll_offset <= len(ui._log_lines) - 1
+        # should not exceed total chat lines - 1
+        assert ui._chat_scroll_offset <= len(ui._chat_lines) - 1
 
 
 # ── Tests: Render panels ────────────────────────────────────────────────────
@@ -300,8 +307,8 @@ class TestUpdatePanels:
         # All slots should now have Panel renderables
         for name in ("header", "chat"):
             assert layout[name] is not None
-        assert layout["main"]["stats"] is not None
-        assert layout["main"]["logs"] is not None
+        assert layout["bottom"]["stats"] is not None
+        assert layout["bottom"]["logs"] is not None
 
 
 # ── Tests: Mouse reader ─────────────────────────────────────────────────────
@@ -592,4 +599,5 @@ class TestDefaults:
         assert ui._busy is False
         assert ui._streaming_text is None
         assert ui._scroll_offset == 0
+        assert ui._chat_scroll_offset == 0
         assert ui._pending is None


### PR DESCRIPTION
## Summary

JARVIS-inspired multi-agent hierarchy allowing the Brain orchestrator to delegate focused sub-tasks to specialised agents with isolated prompts, restricted tool access, and rate-limited execution.

Closes #321

## Architecture

```
Brain.process()
  └── delegate_task tool (BaseTool)
        └── AgentManager.delegate(role, task, context)
              ├── ResearcherAgent  — web search, reading, summarisation
              ├── DeveloperAgent   — shell, filesystem, code tasks
              └── ReviewerAgent    — analysis, validation, quality check
```

### SubAgent 3-Phase Pipeline

1. **Plan** — LLM generates a JSON tool-call plan
2. **Execute** — Tools run sequentially with `allowed_tools` enforcement
3. **Synthesise** — LLM produces a structured `SubAgentResult` from tool outputs

### Rate Limiting & Safety

| Limit | Default | Config Key |
|---|---|---|
| Max concurrent delegations | 3 | `BANTZ_MULTI_AGENT_MAX_CONCURRENT` |
| Max per conversation | 20 | — (hardcoded) |
| Delegation timeout | 120s | `BANTZ_MULTI_AGENT_TIMEOUT` |

Each role has a curated `allowed_tools` set — sub-agents cannot access tools outside their specialisation.

## New Files

| File | Lines | Purpose |
|---|---|---|
| `src/bantz/agent/sub_agent.py` | ~520 | SubAgent ABC + 3 specialised roles + role registry |
| `src/bantz/agent/agent_manager.py` | ~258 | AgentManager orchestrator singleton |
| `src/bantz/tools/delegate_task.py` | ~115 | BaseTool wrapping AgentManager.delegate() |
| `tests/agent/test_sub_agent.py` | ~370 | 44 tests — result, roles, parsing, run pipeline |
| `tests/agent/test_agent_manager.py` | ~220 | 16 tests — init, delegate, rate limits, timeout |
| `tests/tools/test_delegate_task.py` | ~220 | 15 tests — registration, validation, context |

## Modified Files

| File | Change |
|---|---|
| `src/bantz/config.py` | Added `multi_agent_enabled`, `multi_agent_max_concurrent`, `multi_agent_timeout` |
| `src/bantz/core/brain.py` | Import delegate_task tool + init AgentManager in `_ensure_memory()` |
| `.env.example` | Added `BANTZ_MULTI_AGENT_ENABLED=false` section |

## Test Results

```
75 passed in 0.59s
```

Feature is **opt-in** — disabled by default (`BANTZ_MULTI_AGENT_ENABLED=false`).
