### PR TITLE
⚡ Bolt: O(1) SQLite table existence checks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-18 - [SQLite Bulk Insertion Optimization]
 **Learning:** In `src/bantz/data/migration.py`, data migration functions were looping over dictionaries and running `conn.execute(...)` for each key-value pair or list element. This creates a classic N+1 query performance bottleneck when migrating large datasets.
 **Action:** Replace `conn.execute(...)` loops with a list comprehension paired with `conn.executemany(...)` to run the operations in bulk, reducing database round-trips and significantly improving data loading performance.
+
+## 2024-05-18 - [SQLite Table Existence Check Optimization]
+**Learning:** To check if a table is empty or has data in SQLite, `SELECT COUNT(*) FROM table` performs an O(N) full table/index scan. This becomes a performance bottleneck as the table grows.
+**Action:** Use `SELECT 1 FROM table LIMIT 1` combined with `fetchone() is not None` instead. This is an O(1) operation that returns immediately after finding the first row, avoiding full scans.

--- a/src/bantz/data/sqlite_store.py
+++ b/src/bantz/data/sqlite_store.py
@@ -517,9 +517,9 @@ class SQLiteProfileStore(ProfileStore):
     def exists(self) -> bool:
         with get_pool().connection() as conn:
             row = conn.execute(
-                "SELECT COUNT(*) FROM user_profile"
+                "SELECT 1 FROM user_profile LIMIT 1"
             ).fetchone()
-        return row[0] > 0
+        return row is not None
 
     @property
     def path(self) -> Path:
@@ -606,9 +606,9 @@ class SQLitePlaceStore(PlaceStore):
     def exists(self) -> bool:
         with get_pool().connection() as conn:
             row = conn.execute(
-                "SELECT COUNT(*) FROM places"
+                "SELECT 1 FROM places LIMIT 1"
             ).fetchone()
-        return row[0] > 0
+        return row is not None
 
     @property
     def path(self) -> Path:
@@ -684,9 +684,9 @@ class SQLiteScheduleStore(ScheduleStore):
     def exists(self) -> bool:
         with get_pool().connection() as conn:
             row = conn.execute(
-                "SELECT COUNT(*) FROM schedule_entries"
+                "SELECT 1 FROM schedule_entries LIMIT 1"
             ).fetchone()
-        return row[0] > 0
+        return row is not None
 
     @property
     def path(self) -> Path:


### PR DESCRIPTION
💡 **What:** Replaced `SELECT COUNT(*) FROM table` with `SELECT 1 FROM table LIMIT 1` inside `src/bantz/data/sqlite_store.py` (`exists` methods for `user_profile`, `places`, and `schedule_entries`).

🎯 **Why:** To check if a table is empty, `COUNT(*)` performs an O(N) full table/index scan in SQLite, calculating the total row count. This slows down linearly as table sizes grow. Using `SELECT 1 ... LIMIT 1` is an O(1) operation that stops immediately upon finding the first row.

📊 **Impact:** Table existence checks in the storage layer are now O(1) instead of O(N), preventing a performance bottleneck as the data footprint increases.

🔬 **Measurement:** This optimization can be verified by running `python3 -m pytest tests/data/` or observing reduced database read times on large datasets for these tables.

---
*PR created automatically by Jules for task [18345379269649741476](https://jules.google.com/task/18345379269649741476) started by @miclaldogan*