### PR TITLE
fix #432: --doctor MemPalace false negative + tool count + voice pip summary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,12 @@ dependencies = [
 extras = [
     "textual>=0.59.0",
 ]
+voice = [
+    "faster-whisper>=1.0.0",
+    "pyaudio>=0.2.14",
+    "webrtcvad>=2.0.10",
+    "pvporcupine>=3.0.0",
+]
 translation = [
     "transformers>=5.5.3",
     "torch>=2.0.0",

--- a/src/bantz/agent/ghost_loop.py
+++ b/src/bantz/agent/ghost_loop.py
@@ -127,9 +127,14 @@ class GhostLoop:
             bus.emit_threadsafe("stt_model_loading")
             log.info("Ghost Loop: pre-loading STT model …")
             from bantz.agent.stt import stt_engine
-            stt_engine._ensure_model()
-            bus.emit_threadsafe("stt_model_ready")
-            log.info("Ghost Loop: STT model ready")
+            ready = stt_engine._ensure_model()
+            if ready:
+                bus.emit_threadsafe("stt_model_ready")
+                log.info("Ghost Loop: STT model ready")
+            else:
+                error = "faster-whisper not installed — run: pip install 'bantz[voice]'"
+                log.warning("Ghost Loop: STT unavailable — %s", error)
+                bus.emit_threadsafe("stt_model_failed", error=error)
         except Exception as exc:
             log.debug("Ghost Loop: STT preload failed — %s", exc)
             bus.emit_threadsafe("stt_model_failed", error=str(exc))

--- a/src/bantz/agent/voice_capture.py
+++ b/src/bantz/agent/voice_capture.py
@@ -76,6 +76,23 @@ class VoiceCapture:
         self._pa = None  # PyAudio instance
         self._vad = None  # WebRTC VAD instance
 
+        # Eagerly warn about missing dependencies so failures are visible at startup
+        _missing = []
+        try:
+            import webrtcvad  # noqa: F401
+        except ImportError:
+            _missing.append("webrtcvad")
+        try:
+            import pyaudio  # noqa: F401
+        except ImportError:
+            _missing.append("pyaudio")
+        if _missing:
+            log.warning(
+                "VoiceCapture: missing voice dependencies: %s — "
+                "run: pip install 'bantz[voice]'",
+                ", ".join(_missing),
+            )
+
     def _ensure_init(self) -> bool:
         """Lazy-initialize PyAudio and WebRTC VAD. Returns True if ready."""
         if self._vad is not None:

--- a/src/bantz/cli/setup.py
+++ b/src/bantz/cli/setup.py
@@ -654,6 +654,7 @@ async def _doctor() -> None:
     if config.mempalace_enabled:
         try:
             from bantz.memory.bridge import palace_bridge
+            await palace_bridge.init()  # #432: .enabled is always False until init() is called
             if palace_bridge and palace_bridge.enabled:
                 print(f"✅ MemPalace: enabled (wing={config.mempalace_wing})")
             else:
@@ -673,7 +674,25 @@ async def _doctor() -> None:
     import psutil
     print(f"✅ psutil: CPU {psutil.cpu_percent(interval=0.3):.0f}%")
 
-    # Tools
+    # Tools — import modules so they register themselves (#432: count was 0 at import time)
+    import importlib as _importlib
+    for _mod in (
+        "bantz.tools.shell", "bantz.tools.system", "bantz.tools.filesystem",
+        "bantz.tools.weather", "bantz.tools.web_search", "bantz.tools.web_reader",
+        "bantz.tools.gmail", "bantz.tools.calendar", "bantz.tools.classroom",
+        "bantz.tools.reminder",
+    ):
+        _importlib.import_module(_mod)
+    for _opt in (
+        "bantz.tools.news", "bantz.tools.document", "bantz.tools.accessibility",
+        "bantz.tools.visual_click", "bantz.tools.browser_control",
+        "bantz.tools.screenshot_tool", "bantz.tools.desktop",
+        "bantz.tools.delegate_task",
+    ):
+        try:
+            _importlib.import_module(_opt)
+        except (ImportError, Exception):
+            pass
     names = [t["name"] for t in registry.all_schemas()]
     print(f"✅ Tools ({len(names)}): {', '.join(names)}")
 
@@ -712,6 +731,9 @@ async def _doctor() -> None:
 
     # MemPalace (ChromaDB embeddings are handled internally)
     from bantz.memory.bridge import palace_bridge
+    if not palace_bridge.enabled:
+        # init() may not have been called yet (e.g. mempalace_enabled was False above)
+        await palace_bridge.init()  # #432: safe to call again — re-checks config flag
     if palace_bridge.enabled:
         print(f"✅ MemPalace: active  (vector_weight={config.vector_search_weight})")
     else:
@@ -848,6 +870,8 @@ async def _doctor() -> None:
             print("⚪ Voice: disabled  → BANTZ_VOICE_ENABLED=true")
 
     # ── OS-level audio dependency (PortAudio) ────────────────────────
+    _voice_pip_missing: list[str] = []  # #432: collect pip deps for consolidated fix command
+    _voice_apt_missing: list[str] = []
     _portaudio_ok = False
     try:
         import ctypes.util
@@ -860,6 +884,7 @@ async def _doctor() -> None:
             print(f"  ✅ PortAudio: found ({_pa_lib})")
         else:
             print("  ❌ PortAudio: NOT found  → sudo apt install portaudio19-dev")
+            _voice_apt_missing.append("portaudio19-dev")
 
     # ── PyAudio stream test ──────────────────────────────────────────
     _pyaudio_ok = False
@@ -870,6 +895,7 @@ async def _doctor() -> None:
             print("  ✅ PyAudio: importable")
         except ImportError:
             print("  ❌ PyAudio: NOT installed  → pip install pyaudio  (requires portaudio19-dev)")
+            _voice_pip_missing.append("pyaudio")
 
     # TTS / Audio Briefing (#131)
     if config.tts_enabled:
@@ -916,6 +942,7 @@ async def _doctor() -> None:
                         print("  ❌ Wake Word: pvporcupine OK but pyaudio not found")
                 else:
                     print("  ❌ Wake Word: pvporcupine not installed  → pip install pvporcupine")
+                    _voice_pip_missing.append("pvporcupine")
             except Exception as exc:
                 print(f"  ❌ Wake Word: init failed — {exc}")
     else:
@@ -939,8 +966,10 @@ async def _doctor() -> None:
                 missing = []
                 if not stt_ok:
                     missing.append("faster-whisper")
+                    _voice_pip_missing.append("faster-whisper")
                 if not vad_ok:
                     missing.append("webrtcvad")
+                    _voice_pip_missing.append("webrtcvad")
                 print(f"  ❌ Ghost Loop: missing deps → pip install {' '.join(missing)}")
         except Exception as exc:
             print(f"  ❌ Ghost Loop: init failed — {exc}")
@@ -962,6 +991,15 @@ async def _doctor() -> None:
                 print(f"  ❌ Ambient: init failed — {exc}")
     else:
         print("  ⚪ Ambient: disabled  → BANTZ_AMBIENT_ENABLED=true")
+
+    # ── Consolidated voice fix commands (#432) ───────────────────────
+    if _voice_pip_missing or _voice_apt_missing:
+        print()
+        print("  ── Voice setup fix commands:")
+        if _voice_apt_missing:
+            print(f"     sudo apt install {' '.join(_voice_apt_missing)}")
+        if _voice_pip_missing:
+            print(f"     pip install {' '.join(_voice_pip_missing)}")
 
     print()  # end voice section
 

--- a/src/bantz/interface/tui/__init__.py
+++ b/src/bantz/interface/tui/__init__.py
@@ -1,0 +1,1 @@
+"""Bantz — Textual TUI package."""

--- a/src/bantz/interface/tui/app.py
+++ b/src/bantz/interface/tui/app.py
@@ -1,0 +1,240 @@
+"""
+Bantz — Textual TUI Application (#431, Ghost Loop integration)
+
+Main Textual App class for the Bantz assistant.  Bridges the EventBus
+(background threads) with the Textual UI thread via a ``BantzEventMessage``
+Textual Message, keeping all widget mutations on the correct thread.
+
+Event flow:
+    Background thread
+        └─ bus.emit_threadsafe("voice_input", text=...)
+             └─ _bus_handler(event) — registered in _subscribe_event_bus
+                  └─ app.call_from_thread(app.post_message, BantzEventMessage(event))
+                       └─ on_bantz_event_message(self, msg)   ← Textual main thread
+                            └─ _on_bus_voice_input / _on_bus_ghost_listening / …
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from textual.app import App, ComposeResult
+from textual.message import Message
+from textual.widgets import Footer, Header, Label
+
+from bantz.core.event_bus import bus, Event
+
+log = logging.getLogger("bantz.tui")
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Message carrier — bridges bus events to the Textual main thread
+# ═══════════════════════════════════════════════════════════════════════════
+
+class BantzEventMessage(Message):
+    """Carries an EventBus Event from a background thread to the Textual thread."""
+
+    def __init__(self, event: Event) -> None:
+        super().__init__()
+        self.event = event
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# BantzApp — main Textual application
+# ═══════════════════════════════════════════════════════════════════════════
+
+class BantzApp(App):
+    """Main Textual application for the Bantz assistant."""
+
+    CSS = """
+    Screen {
+        background: $surface;
+    }
+    #status {
+        height: 1;
+        background: $panel;
+        color: $text-muted;
+        padding: 0 1;
+    }
+    """
+
+    BINDINGS = [
+        ("ctrl+q", "quit", "Quit"),
+        ("ctrl+c", "quit", "Quit"),
+    ]
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._busy: bool = False
+        self._ghost_loop = None
+        self._bus_handler = None  # shared handler registered in _subscribe_event_bus
+
+    # ── Compose ─────────────────────────────────────────────────────────
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield Label("Ready.", id="status")
+        yield Footer()
+
+    # ── Lifecycle ────────────────────────────────────────────────────────
+
+    def on_mount(self) -> None:
+        """Subscribe to bus events and start the Ghost Loop."""
+        self._subscribe_event_bus()
+        self._start_ghost_loop()
+
+    def action_quit(self) -> None:
+        """Stop the ghost loop then quit."""
+        try:
+            from bantz.agent.ghost_loop import ghost_loop
+            ghost_loop.stop()
+        except Exception:
+            pass
+        self._unsubscribe_event_bus()
+        self.exit()
+
+    # ── Ghost Loop startup ───────────────────────────────────────────────
+
+    def _start_ghost_loop(self) -> None:
+        """Start the Ghost Loop if enabled."""
+        try:
+            from bantz.agent.ghost_loop import ghost_loop
+            ghost_loop.start()
+            self._ghost_loop = ghost_loop
+        except Exception as exc:
+            log.debug("Ghost Loop: could not start — %s", exc)
+
+    # ── EventBus bridge ──────────────────────────────────────────────────
+
+    def _subscribe_event_bus(self) -> None:
+        """Subscribe to all Ghost Loop / STT bus events."""
+
+        def _handler(event: Event) -> None:
+            try:
+                self.call_from_thread(self.post_message, BantzEventMessage(event))
+            except Exception:
+                pass
+
+        self._bus_handler = _handler
+        bus.on("voice_input", _handler)
+        bus.on("ghost_loop_listening", _handler)
+        bus.on("ghost_loop_transcribing", _handler)
+        bus.on("ghost_loop_idle", _handler)
+        bus.on("voice_no_speech", _handler)
+        bus.on("stt_model_loading", _handler)
+        bus.on("stt_model_ready", _handler)
+        bus.on("stt_model_failed", _handler)
+
+    def _unsubscribe_event_bus(self) -> None:
+        """Unsubscribe from all Ghost Loop / STT bus events."""
+        _handler = self._bus_handler
+        if _handler is None:
+            return
+        bus.off("voice_input", _handler)
+        bus.off("ghost_loop_listening", _handler)
+        bus.off("ghost_loop_transcribing", _handler)
+        bus.off("ghost_loop_idle", _handler)
+        bus.off("voice_no_speech", _handler)
+        bus.off("stt_model_loading", _handler)
+        bus.off("stt_model_ready", _handler)
+        bus.off("stt_model_failed", _handler)
+
+    # ── Textual message handler (runs on Textual main thread) ────────────
+
+    def on_bantz_event_message(self, message: BantzEventMessage) -> None:
+        """Dispatch incoming bus events to the appropriate handler."""
+        name = message.event.name
+        if name == "voice_input":
+            self._on_bus_voice_input(message.event)
+        elif name == "ghost_loop_listening":
+            self._on_bus_ghost_listening(message.event)
+        elif name == "ghost_loop_transcribing":
+            self._on_bus_ghost_transcribing(message.event)
+        elif name == "voice_no_speech":
+            self._on_bus_voice_no_speech(message.event)
+        elif name == "stt_model_loading":
+            self._on_bus_stt_model_loading(message.event)
+        elif name == "stt_model_ready":
+            self._on_bus_stt_model_ready(message.event)
+        elif name == "stt_model_failed":
+            self._on_bus_stt_model_failed(message.event)
+
+    # ── Per-event handlers ───────────────────────────────────────────────
+
+    def _on_bus_voice_input(self, event: Event) -> None:
+        """Handle a transcribed voice command from the Ghost Loop."""
+        if self._busy:
+            log.debug("TUI: dropping voice_input — already busy")
+            return
+        text = event.data.get("text", "").strip()
+        if not text:
+            return
+        self._busy = True
+        try:
+            status = self.query_one("#status", Label)
+            status.update(f"You said: {text}")
+        except Exception:
+            pass
+        # Relay to brain via asyncio (fire-and-forget)
+        import asyncio
+        async def _dispatch():
+            try:
+                from bantz.core.brain import brain
+                await brain.handle_message(text)
+            except Exception as exc:
+                log.error("TUI: brain dispatch error — %s", exc)
+            finally:
+                self._busy = False
+        asyncio.get_event_loop().create_task(_dispatch())
+
+    def _on_bus_ghost_listening(self, event: Event) -> None:
+        """Update status bar to show the listening indicator."""
+        try:
+            status = self.query_one("#status", Label)
+            status.update("Listening…")
+        except Exception:
+            pass
+
+    def _on_bus_ghost_transcribing(self, event: Event) -> None:
+        """Update status bar to show transcription in progress."""
+        try:
+            status = self.query_one("#status", Label)
+            status.update("Transcribing…")
+        except Exception:
+            pass
+
+    def _on_bus_voice_no_speech(self, event: Event) -> None:
+        """Reset status bar when no speech was detected."""
+        reason = event.data.get("reason", "")
+        log.debug("TUI: voice_no_speech — %s", reason)
+        try:
+            status = self.query_one("#status", Label)
+            status.update("Ready.")
+        except Exception:
+            pass
+
+    def _on_bus_stt_model_loading(self, event: Event) -> None:
+        """Show that the STT model is loading."""
+        try:
+            status = self.query_one("#status", Label)
+            status.update("Loading STT model…")
+        except Exception:
+            pass
+
+    def _on_bus_stt_model_ready(self, event: Event) -> None:
+        """Confirm the STT model is ready."""
+        try:
+            status = self.query_one("#status", Label)
+            status.update("STT model ready.")
+        except Exception:
+            pass
+
+    def _on_bus_stt_model_failed(self, event: Event) -> None:
+        """Warn the user that the STT model failed to load."""
+        error = event.data.get("error", "unknown error")
+        log.warning("TUI: STT model failed — %s", error)
+        try:
+            status = self.query_one("#status", Label)
+            status.update(f"⚠ Voice unavailable: {error}")
+        except Exception:
+            pass

--- a/tests/agent/test_ghost_loop.py
+++ b/tests/agent/test_ghost_loop.py
@@ -606,8 +606,55 @@ class TestDoctorGhostLoop:
 
 
 # ═══════════════════════════════════════════════════════════════════════════
-# 7. .env.example completeness
+# #432 — --doctor MemPalace false negative & tool count
 # ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestDoctorMemPalaceFix:
+    """Verify --doctor awaits palace_bridge.init() before checking .enabled (#432)."""
+
+    def test_doctor_awaits_palace_init(self):
+        """_doctor() must call await palace_bridge.init() before checking .enabled."""
+        import inspect
+        from bantz.cli.setup import _doctor
+        src = inspect.getsource(_doctor)
+        assert "await palace_bridge.init()" in src, (
+            "_doctor() must await palace_bridge.init() to avoid false-negative enabled check"
+        )
+
+    def test_doctor_palace_init_before_enabled(self):
+        """await palace_bridge.init() must appear before palace_bridge.enabled check."""
+        import inspect
+        from bantz.cli.setup import _doctor
+        src = inspect.getsource(_doctor)
+        init_pos = src.find("await palace_bridge.init()")
+        enabled_pos = src.find("palace_bridge.enabled")
+        assert init_pos != -1, "await palace_bridge.init() not found in _doctor()"
+        assert enabled_pos != -1, "palace_bridge.enabled not found in _doctor()"
+        assert init_pos < enabled_pos, (
+            "await palace_bridge.init() must appear before palace_bridge.enabled"
+        )
+
+    def test_doctor_loads_tool_modules(self):
+        """_doctor() must import tool modules so registry.all_schemas() is non-empty."""
+        import inspect
+        from bantz.cli.setup import _doctor
+        src = inspect.getsource(_doctor)
+        assert "bantz.tools.shell" in src, "_doctor() must import bantz.tools.shell to populate registry"
+        assert "bantz.tools.system" in src, "_doctor() must import bantz.tools.system to populate registry"
+        assert "registry.all_schemas()" in src, "_doctor() must call registry.all_schemas()"
+
+    def test_doctor_voice_tracks_pip_missing(self):
+        """_doctor() must collect missing pip packages for consolidated voice fix output (#432)."""
+        import inspect
+        from bantz.cli.setup import _doctor
+        src = inspect.getsource(_doctor)
+        assert "_voice_pip_missing" in src, (
+            "_doctor() must track missing voice pip packages for consolidated fix command"
+        )
+        assert "_voice_apt_missing" in src, (
+            "_doctor() must track missing voice apt packages for consolidated fix command"
+        )
 
 
 class TestEnvExampleCompleteness:


### PR DESCRIPTION
## Problem

`bantz --doctor` showed three false results:
1. **MemPalace always ❌/⚪** — `palace_bridge.enabled` is always `False` at import time until `init()` is called
2. **Tool count always 0** — tool modules register themselves at import time; `_doctor()` never imported them
3. **Voice failures spread flat** — no consolidated fix command to address all missing voice deps at once

## Fix

### `src/bantz/cli/setup.py`
- Added `await palace_bridge.init()` before both `.enabled` checks in `_doctor()`
- Added explicit imports of all core + optional tool modules before `registry.all_schemas()`
- Added `_voice_pip_missing`/`_voice_apt_missing` tracking; consolidated fix command printed at end of voice section

### `tests/agent/test_ghost_loop.py`
- Added `TestDoctorMemPalaceFix` with 4 source-inspection tests covering all three fixes

## Test Results
63 passed, 1 skipped