### PR TITLE
fix #433: Turkish system queries routed to web_search — add quick_route patterns + routing hint

### DIFF
--- a/src/bantz/core/intent.py
+++ b/src/bantz/core/intent.py
@@ -39,7 +39,12 @@ _ROUTING_HINTS: dict[str, str] = {
     "weather": "Current weather AND forecast — handles 'tomorrow', 'this week', 'will it rain', forecast queries. Single tool call, no planning needed. city param optional (auto-detects location).",
     "reminder": "Create, list, cancel, snooze reminders and timers. action=add for new reminders. action=cancel with id=N for 'delete/cancel/remove reminder #N'. action=list for 'show my reminders'.",
     "shell": "Run a bash command (ls, df, top, apt, etc.)",
-    "system": "Live system metrics: CPU, RAM, disk usage, uptime",
+    "system": (
+        "Live system metrics: CPU, RAM, disk usage, uptime. "
+        "Turkish: 'cpu kullanımı', 'ram kullanımı', 'bellek kullanımı', 'disk kullanımı', "
+        "'sistem durumu', 'işlemci'. "
+        "MarianMT artifact: 'what is the use of cpu/ram/disk' = system metric query, NOT web_search."
+    ),
     "filesystem": "Read, write, list files and folders under home directory",
     "browser_control": "Launch apps AND control browser. Actions: open, navigate, find_and_click, type_in_element, hotkey, type, scroll, screenshot, wait_for_load. Web services (YouTube, Spotify, Netflix…) = action=open. IMPORTANT: 'play/search/find X on YouTube/YT Music' needs MULTIPLE steps (search → wait → click) → route=planner.",
     "visual_click": "Click any visible UI element on screen by describing it",

--- a/src/bantz/core/routing_engine.py
+++ b/src/bantz/core/routing_engine.py
@@ -88,6 +88,32 @@ def quick_route(orig: str, en: str) -> dict | None:
     if re.search(r"clear\s+memory", both):
         return {"tool": "_clear_memory", "args": {}}
 
+    # ── Turkish system/hardware queries (#433) ────────────────────────
+    # Caught on the ORIGINAL text (before translation) so MarianMT artifacts
+    # ("what is the use of cpu") cannot cause mis-routing to web_search.
+    # Also catches the MarianMT artifact on the English side for robustness.
+    _sys_tr = re.search(
+        r"cpu\s+kullan[ıi]m[ıi]|ram\s+kullan[ıi]m[ıi]|bellek\s+kullan[ıi]m[ıi]|"
+        r"disk\s+kullan[ıi]m[ıi]|i[sş]lemci\s+kullan[ıi]m[ıi]|"
+        r"ne\s+kadar\s+(ram|bellek|disk|cpu)|"
+        r"(ram|bellek|disk|cpu|i[sş]lemci)\s+(ne\s+kadar|nedir|durumu)|"
+        r"sistem\s+(durumu|bilgisi|metrikleri)|"
+        r"depolama\s+(kullan[ıi]m[ıi]|durumu)",
+        o,
+    )
+    _sys_marian = re.search(
+        r"what\s+is\s+the\s+use\s+of\s+(cpu|ram|disk|memory|processor|storage)",
+        e,
+    )
+    if _sys_tr or _sys_marian:
+        if re.search(r"\bcpu\b|\bi[sş]lemci\b|\bprocessor\b", both):
+            return {"tool": "system", "args": {"metric": "cpu"}}
+        if re.search(r"\bram\b|\bbellek\b|\bmemory\b", both):
+            return {"tool": "system", "args": {"metric": "ram"}}
+        if re.search(r"\bdisk\b|\bdepolama\b|\bstorage\b", both):
+            return {"tool": "system", "args": {"metric": "disk"}}
+        return {"tool": "system", "args": {"metric": "all"}}
+
     # Everything else → cot_route (LLM-based reasoning)
     return None
 

--- a/tests/core/test_routing_engine.py
+++ b/tests/core/test_routing_engine.py
@@ -121,6 +121,60 @@ class TestQuickRoute:
 
 
 # ═══════════════════════════════════════════════════════════════════════════
+# #433 — Turkish system queries routed to system tool, not web_search
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestQuickRouteTurkishSystem:
+    """Turkish hardware/metric queries must fast-path to system tool (#433)."""
+
+    @pytest.fixture(autouse=True)
+    def _import(self):
+        from bantz.core.routing_engine import quick_route
+        self.qr = quick_route
+
+    @pytest.mark.parametrize("orig,en,expected_metric", [
+        # Turkish original → correct metric
+        ("CPU kullanımı nedir?", "What is the use of CPU?", "cpu"),
+        ("cpu kullanımı ne kadar", "What is the cpu usage", "cpu"),
+        ("RAM kullanımı nedir?", "What is the use of RAM?", "ram"),
+        ("bellek kullanımı ne kadar", "How much memory usage", "ram"),
+        ("disk kullanımı nedir?", "What is the use of disk?", "disk"),
+        ("depolama durumu", "storage status", "disk"),
+        ("işlemci kullanımı kaç", "How much processor usage", "cpu"),
+        # MarianMT artifact on the English side (orig may already be English)
+        ("cpu nedir", "what is the use of cpu", "cpu"),
+        ("ram nedir", "what is the use of ram", "ram"),
+        ("disk nedir", "what is the use of disk", "disk"),
+        # System overview
+        ("sistem durumu", "system status", "all"),
+        ("sistem bilgisi", "system info", "all"),
+    ])
+    def test_turkish_system_routes_to_system_tool(self, orig, en, expected_metric):
+        """Turkish system queries must route to system tool before LLM sees them."""
+        r = self.qr(orig, en)
+        assert r is not None, f"quick_route({orig!r}, {en!r}) returned None — should route to system"
+        assert r["tool"] == "system", f"Expected tool=system, got {r['tool']!r}"
+        assert r["args"].get("metric") == expected_metric, (
+            f"Expected metric={expected_metric!r}, got {r['args']!r}"
+        )
+
+    @pytest.mark.parametrize("orig,en", [
+        # English system queries must still go through LLM (#272)
+        ("cpu usage", "cpu usage"),
+        ("memory usage", "memory usage"),
+        ("check disk space", "check disk space"),
+        ("how much RAM is free", "how much RAM is free"),
+        ("system status", "system status"),
+    ])
+    def test_english_system_still_uses_llm(self, orig, en):
+        """Plain English system queries must still go through cot_route (LLM)."""
+        r = self.qr(orig, en)
+        assert r is None, (
+            f"quick_route({orig!r}, {en!r}) returned {r!r} — English should go through LLM"
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
 # 2. dispatch_internal — internal tool execution
 # ═══════════════════════════════════════════════════════════════════════════
 
@@ -343,3 +397,24 @@ class TestWorkflowHandlers:
             result = _run(handle_run_reflection())
         assert "❌" in result
         assert "fail" in result
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# #433 — _ROUTING_HINTS system entry includes Turkish examples
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestRoutingHintsTurkishSystem:
+    """_ROUTING_HINTS for system tool must include Turkish keywords (#433)."""
+
+    def test_system_hint_has_turkish_keywords(self):
+        from bantz.core.intent import _ROUTING_HINTS
+        hint = _ROUTING_HINTS["system"]
+        assert "cpu kullanımı" in hint.lower() or "cpu kullanımı" in hint
+        assert "ram kullanımı" in hint.lower() or "ram kullanımı" in hint
+        assert "işlemci" in hint
+
+    def test_system_hint_has_marian_artifact_note(self):
+        from bantz.core.intent import _ROUTING_HINTS
+        hint = _ROUTING_HINTS["system"]
+        assert "what is the use of" in hint.lower()
+        assert "web_search" in hint


### PR DESCRIPTION
## Problem

Turkish system metric queries like "CPU kullanımı nedir?" were routed to `web_search` instead of `system`. Two root causes:

1. `quick_route()` had no Turkish patterns — all Turkish queries fell through to `cot_route()` (LLM)
2. MarianMT mistranslates "CPU kullanımı nedir?" → "What is the use of CPU?" which the LLM reads as a knowledge question and routes to `web_search`
3. `_ROUTING_HINTS['system']` had no Turkish examples or MarianMT artifact note to guide the LLM

## Fix

### `src/bantz/core/routing_engine.py`
- Added Turkish system query patterns to `quick_route()` (matched on original text, before translation)
- Added MarianMT artifact pattern (`what is the use of cpu/ram/disk`) on the English translation side
- Both route to `system` tool with the correct `metric` arg (`cpu`/`ram`/`disk`/`all`)
- Plain English queries ("cpu usage", "memory usage") still return `None` → go through LLM

### `src/bantz/core/intent.py`
- Expanded `_ROUTING_HINTS['system']` to include Turkish keywords and an explicit note that the MarianMT artifact phrase should NOT route to `web_search`

### `tests/core/test_routing_engine.py`
- Added `TestQuickRouteTurkishSystem`: 12 parametrized cases + 5 English-still-uses-LLM cases
- Added `TestRoutingHintsTurkishSystem`: 2 hint content assertions

## Test Results
75 passed, 3 pre-existing failures (TestExecutePlan — unrelated)