### PR TITLE
🔒 Fix command injection in SystemTool (shell=True → shell=False)

### DIFF
--- a/src/bantz/tools/system_tool.py
+++ b/src/bantz/tools/system_tool.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import logging
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import time
@@ -29,22 +30,38 @@ from typing import Any
 log = logging.getLogger("bantz.system_tool")
 
 # ── Denylist patterns ─────────────────────────────────────────────────────────
-# These are regex patterns matched against the full command string.
-# Matches in safe_mode → DangerousCommandError raised before execution.
 
-DENYLIST: list[str] = [
-    r"rm\s+-rf\s+/",        # rm -rf /  (recursive root deletion)
-    r"rm\s+.*--no-preserve-root",
-    r"dd\s+if=",            # disk-level writes
-    r"mkfs",                # filesystem formatting
-    r">\s*/dev/sd",         # direct writes to block device
-    r":\(\)\s*\{",          # fork bomb  :(){:|:&};:
-    r"chmod\s+-R\s+777\s+/",# world-write root
-    r">\s*/etc/passwd",     # overwrite passwd
-    r">\s*/etc/shadow",     # overwrite shadow
+# Commands that are strictly forbidden as the primary executable
+BLOCKED_EXECUTABLES: frozenset[str] = frozenset(
+    {
+        "mkfs",
+        "dd",
+        "fdisk",
+        "parted",
+        "shred",
+        "format",
+    }
+)
+
+# Dangerous argument combinations (regex on the parsed argument list)
+# We check if any argument matches these.
+BLOCKED_ARG_PATTERNS: list[re.Pattern] = [
+    re.compile(r"^--no-preserve-root$"),
+    re.compile(r"^:(\(\)\s*\{|.*\(\)\s*\{)"),  # Potential fork bomb start
 ]
 
-_COMPILED_DENYLIST: list[re.Pattern] = [re.compile(p) for p in DENYLIST]
+# We still use some global regex for patterns that shlex might split but are still dangerous
+# e.g. redirection to sensitive files (if we were using shell=True)
+# Since we are moving to shell=False, many of these won't work anyway,
+# but we keep them for defense-in-depth during validation.
+GLOBAL_DENYLIST: list[re.Pattern] = [
+    re.compile(r"rm\s+.*-rf\s+/"),  # rm -rf /
+    re.compile(r"chmod\s+.*-R\s+777\s+/"),  # world-write root
+    re.compile(r">\s*/etc/(passwd|shadow)"),  # overwrite sensitive files
+    re.compile(r">\s*/dev/sd"),  # direct write to block device
+    re.compile(r"mkfs"),  # filesystem formatting
+    re.compile(r"dd\s+if="),  # disk-level writes
+]
 
 # ── Audit log ─────────────────────────────────────────────────────────────────
 _AUDIT_LOG: Path = Path.home() / ".bantz" / "logs" / "system_audit.log"
@@ -95,12 +112,12 @@ class SystemTool:
         timeout: int = 30,
         safe_mode: bool = True,
     ) -> ShellResult:
-        """Run a shell command and return a structured ShellResult.
+        """Run a command and return a structured ShellResult.
 
         Args:
-            cmd:        Shell command string (passed to bash -c).
+            cmd:        Command string (parsed via shlex.split).
             timeout:    Maximum execution time in seconds.
-            safe_mode:  If True, commands matching DENYLIST raise
+            safe_mode:  If True, commands matching security checks raise
                         DangerousCommandError before execution.
 
         Returns:
@@ -110,19 +127,41 @@ class SystemTool:
             DangerousCommandError: if safe_mode=True and cmd is dangerous.
             subprocess.TimeoutExpired: re-raised after logging.
         """
+        if not cmd.strip():
+            return ShellResult(
+                stdout="",
+                stderr="Command cannot be empty.",
+                returncode=1,
+                duration_ms=0,
+            )
+
+        try:
+            args = shlex.split(cmd)
+        except ValueError as exc:
+            log.warning("SystemTool.run: shlex.split failed for cmd: %s", cmd)
+            if safe_mode:
+                raise DangerousCommandError(f"Invalid command string: {exc}") from exc
+            # Fallback for safe_mode=False
+            args = cmd.split()
+
+        if not args:
+            return ShellResult(
+                stdout="",
+                stderr="No command arguments found.",
+                returncode=1,
+                duration_ms=0,
+            )
+
         if safe_mode:
-            for pattern in _COMPILED_DENYLIST:
-                if pattern.search(cmd):
-                    log.warning("SystemTool.run: BLOCKED dangerous command: %s", cmd)
-                    raise DangerousCommandError(
-                        f"Command blocked by safety denylist: {cmd!r}"
-                    )
+            self._validate_command(cmd, args)
 
         t0 = time.monotonic()
         try:
+            # shell=False is preferred for security.
+            # args is already a list from shlex.split.
             proc = subprocess.run(
-                cmd,
-                shell=True,
+                args,
+                shell=False,
                 capture_output=True,
                 text=True,
                 timeout=timeout,
@@ -138,9 +177,56 @@ class SystemTool:
             duration_ms = int((time.monotonic() - t0) * 1000)
             self._audit(cmd, -1, duration_ms, note="TIMEOUT")
             raise
+        except FileNotFoundError as exc:
+            # Executable not found
+            duration_ms = int((time.monotonic() - t0) * 1000)
+            result = ShellResult(
+                stdout="",
+                stderr=str(exc),
+                returncode=127,
+                duration_ms=duration_ms,
+            )
 
         self._audit(cmd, result.returncode, result.duration_ms)
         return result
+
+    def _validate_command(self, cmd: str, args: list[str]) -> None:
+        """Check command and arguments against security policies."""
+        if not args:
+            return
+
+        exe = args[0]
+        # 1. Blocked executables - exact name match or base name match
+        exe_base = os.path.basename(exe)
+        if exe in BLOCKED_EXECUTABLES or exe_base in BLOCKED_EXECUTABLES:
+            self._block(cmd, f"Executable {exe!r} is blocked")
+
+        # Variant blocking for mkfs.*
+        if exe_base.startswith("mkfs."):
+            self._block(cmd, f"Executable {exe!r} is blocked")
+
+        # 2. Argument patterns
+        for arg in args:
+            for pattern in BLOCKED_ARG_PATTERNS:
+                if pattern.search(arg):
+                    self._block(cmd, f"Argument {arg!r} matches blocked pattern")
+
+        # 3. rm -rf / check (more robustly)
+        if exe_base == "rm":
+            combined_args = "".join(args[1:])
+            # Check for recursive flag and force flag
+            if ("r" in combined_args and "f" in combined_args) or "R" in combined_args:
+                if any(p in args for p in ("/", "//", "/./")):
+                    self._block(cmd, "Attempted recursive root deletion")
+
+        # 4. Global regex patterns (fallback/defense-in-depth)
+        for pattern in GLOBAL_DENYLIST:
+            if pattern.search(cmd):
+                self._block(cmd, f"Command matches blocked pattern: {pattern.pattern}")
+
+    def _block(self, cmd: str, reason: str) -> None:
+        log.warning("SystemTool.run: BLOCKED dangerous command: %s (Reason: %s)", cmd, reason)
+        raise DangerousCommandError(f"Command blocked: {reason}")
 
     # ── Process listing ───────────────────────────────────────────────────
 

--- a/tests/tools/test_system_tool.py
+++ b/tests/tools/test_system_tool.py
@@ -85,6 +85,32 @@ class TestRunSafeMode:
         with pytest.raises(DangerousCommandError):
             tool.run("echo 'evil' > /etc/passwd", safe_mode=True)
 
+    def test_blocks_bypass_attempts(self):
+        from bantz.tools.system_tool import DangerousCommandError
+        tool = self._tool()
+        # Bypass with quotes
+        with pytest.raises(DangerousCommandError):
+            tool.run("rm '-rf' /", safe_mode=True)
+        # Bypass with flag variants
+        with pytest.raises(DangerousCommandError):
+            tool.run("rm -fr /", safe_mode=True)
+        # Bypass with path variants
+        with pytest.raises(DangerousCommandError):
+            tool.run("rm -rf //", safe_mode=True)
+
+    def test_allows_non_blocked_substrings(self):
+        """Regression test for the 'add-user' bug where 'dd' is a substring."""
+        from bantz.tools.system_tool import SystemTool
+        tool = SystemTool()
+        # If we have a command like 'add-user' it shouldn't be blocked by 'dd'
+        # Since I don't have 'add-user' likely in this environment, I'll use a mock check
+        # Or just verify that 'dd-something' doesn't trigger 'dd' if it's not the exact executable.
+        # Actually my implementation checks os.path.basename(exe) == 'dd'
+        # So 'dd-something' is fine.
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
+            tool.run("dd-something", safe_mode=True)
+
     def test_safe_mode_false_skips_denylist(self):
         """safe_mode=False: dangerous-looking command is attempted (we pass echo to avoid actual harm)."""
         from bantz.tools.system_tool import SystemTool
@@ -105,9 +131,24 @@ class TestRunSafeMode:
     def test_failed_command_captures_returncode(self):
         from bantz.tools.system_tool import SystemTool
         tool = SystemTool()
-        result = tool.run("exit 42", safe_mode=False)
+        # Use sh -c because 'exit' is a shell builtin, not an executable
+        result = tool.run("sh -c 'exit 42'", safe_mode=False)
         assert result.returncode == 42
         assert not result.success
+
+    def test_empty_command_returns_error(self):
+        from bantz.tools.system_tool import SystemTool
+        tool = SystemTool()
+        result = tool.run("   ")
+        assert not result.success
+        assert "empty" in result.stderr.lower()
+
+    def test_nonexistent_executable_returns_127(self):
+        from bantz.tools.system_tool import SystemTool
+        tool = SystemTool()
+        result = tool.run("nonexistent_command_999", safe_mode=False)
+        assert result.returncode == 127
+        assert "No such file or directory" in result.stderr
 
 
 # ── SystemTool.run() — timeout ────────────────────────────────────────────────
@@ -138,7 +179,7 @@ class TestAuditLog:
         from bantz.tools.system_tool import SystemTool
         tool = SystemTool()
         tool.AUDIT_LOG = tmp_path / "audit.log"
-        tool.run("exit 1", safe_mode=False)
+        tool.run("sh -c 'exit 1'", safe_mode=False)
         log_content = tool.AUDIT_LOG.read_text()
         assert "rc=1" in log_content
 


### PR DESCRIPTION
## Security Fix

**Severity: HIGH** — `SystemTool.run()` was using `shell=True` which allows command injection via unsanitised user input passed to the LLM tool layer.

### Changes
- Switch `subprocess.run(..., shell=True)` to `shell=False`  
- Use `shlex.split()` for safe command parsing
- Add multi-layered validation to block dangerous commands

Cherry-picked from `fix/security-command-injection-system-tool-3638800537177675550` (originally by Jules) onto current main.