### PR TITLE
fix(ws_server): use self._q in _WSLogHandler.emit() (#462)

### DIFF
--- a/src/bantz/interface/ws_server.py
+++ b/src/bantz/interface/ws_server.py
@@ -731,7 +731,7 @@ class _WSLogHandler(logging.Handler):
                 except RuntimeError:
                     return
             if loop and not loop.is_closed():
-                loop.call_soon_threadsafe(self._log_q.put_nowait, payload)
+                loop.call_soon_threadsafe(self._q.put_nowait, payload)
         except Exception:
             pass
 


### PR DESCRIPTION
## Summary
Fixes #462

## Root Cause
`_WSLogHandler` stored the asyncio queue as `self._q` in `__init__` (line 719) but `emit()` referenced `self._log_q` (line 734) — a name that was never set.  The bare `except Exception: pass` swallowed the resulting `AttributeError` silently, so **every** log record was dropped.  The Tauri Operations Center log panel received no live `bantz.*` logs as a result.

## Fix
One-character rename on line 734:
```python
- loop.call_soon_threadsafe(self._log_q.put_nowait, payload)
+ loop.call_soon_threadsafe(self._q.put_nowait, payload)
```

## Verification
`python -m py_compile src/bantz/interface/ws_server.py` — clean.