### PR TITLE
fix(finalizer): route LLM calls through get_llm() instead of hardcoded Ollama (#460)

### DIFF
--- a/src/bantz/core/finalizer.py
+++ b/src/bantz/core/finalizer.py
@@ -120,8 +120,9 @@ async def finalize(
 
     raw = None
     try:
-        from bantz.llm.ollama import ollama
-        raw = await ollama.chat(messages)
+        from bantz.llm.router import get_llm
+        llm = get_llm()
+        raw = await llm.chat(messages)
     except Exception:
         return output[:1500]
 
@@ -187,8 +188,9 @@ async def finalize_stream(
 
     async def _stream() -> AsyncIterator[str]:
         try:
-            from bantz.llm.ollama import ollama
-            async for token in ollama.chat_stream(messages):
+            from bantz.llm.router import get_llm
+            llm = get_llm()
+            async for token in llm.chat_stream(messages):
                 yield token
         except Exception:
             yield output[:1500]
@@ -297,8 +299,9 @@ async def finalize_plan(
     ]
 
     try:
-        from bantz.llm.ollama import ollama
-        raw = await ollama.chat(messages)
+        from bantz.llm.router import get_llm
+        llm = get_llm()
+        raw = await llm.chat(messages)
         cleaned = strip_markdown(raw)
         # Strip outer quotation marks some models wrap their response in.
         if len(cleaned) > 2 and cleaned[0] in ('"', '“') and cleaned[-1] in ('"', '”'):

--- a/src/bantz/llm/router.py
+++ b/src/bantz/llm/router.py
@@ -65,3 +65,7 @@ def get_provider():
 
     from bantz.llm.ollama import ollama
     return ollama
+
+
+# Alias used by finalizer and other call-sites
+get_llm = get_provider


### PR DESCRIPTION
## Summary
Fixes #460

## Root Cause
All three call-sites in `finalizer.py` hardcoded `from bantz.llm.ollama import ollama`, ignoring the `BANTZ_LLM_PROVIDER` setting entirely.  Users who configured Claude, OpenAI, or Gemini still got Ollama responses (or crashes when Ollama was not running).

## Changes
### `llm/router.py`
- Added `get_llm = get_provider` alias so call-sites can import the clearly-named helper

### `core/finalizer.py`  (3 sites)
| Location | Before | After |
|---|---|---|
| `finalize()` line 123 | `from bantz.llm.ollama import ollama` + `ollama.chat()` | `llm = get_llm()` + `llm.chat()` |
| `finalize_stream()` line 190 | `from bantz.llm.ollama import ollama` + `ollama.chat_stream()` | `llm = get_llm()` + `llm.chat_stream()` |
| `synthesize_plan_response()` line 300 | `from bantz.llm.ollama import ollama` + `ollama.chat()` | `llm = get_llm()` + `llm.chat()` |

## Verification
`python -m py_compile` clean on both files.