### PR TITLE
fix(summarizer): route LLM calls through get_llm() instead of Gemini/Ollama hardcode (#461)

### DIFF
--- a/src/bantz/tools/summarizer.py
+++ b/src/bantz/tools/summarizer.py
@@ -73,24 +73,17 @@ class SummarizerTool(BaseTool):
             {"role": "user", "content": instruction},
         ]
 
-        # Try Gemini Flash first (lower latency for summarization)
+        # Use the configured LLM provider (respects BANTZ_LLM_PROVIDER)
         raw: str | None = None
         try:
-            from bantz.llm.gemini import gemini
-            if gemini.is_enabled():
-                raw = await gemini.chat(messages, temperature=0.2)
-        except Exception:
-            pass  # fall through to Ollama
-
-        if raw is None:
-            try:
-                from bantz.llm.ollama import ollama
-                raw = await ollama.chat(messages)
-            except Exception as exc:
-                return ToolResult(
-                    success=False, output="",
-                    error=f"LLM unavailable: {exc}",
-                )
+            from bantz.llm.router import get_llm
+            llm = get_llm()
+            raw = await llm.chat(messages)
+        except Exception as exc:
+            return ToolResult(
+                success=False, output="",
+                error=f"LLM unavailable: {exc}",
+            )
 
         # Strip leaked <thinking> blocks (#214)
         try:


### PR DESCRIPTION
## Summary
Fixes #461

## Root Cause
`SummarizerTool.execute()` had a Gemini-first → Ollama fallback that bypassed `BANTZ_LLM_PROVIDER` entirely. Users on Claude or OpenAI got silent Ollama fallbacks (or crashes when Ollama was offline).

## Change
Replaced the two-try provider-selection block with a single call through the shared router:
```python
# Before
from bantz.llm.gemini import gemini
if gemini.is_enabled():
    raw = await gemini.chat(messages, temperature=0.2)
# fallback
from bantz.llm.ollama import ollama
raw = await ollama.chat(messages)

# After
from bantz.llm.router import get_llm
llm = get_llm()
raw = await llm.chat(messages)
```

**Note on temperature**: `ollama.chat()` has no `temperature` parameter; the `temperature=0.2` previously passed only to Gemini is dropped — all providers use their sensible defaults.

## Verification
`python -m py_compile src/bantz/tools/summarizer.py` — clean.