### PR TITLE
fix: secure-write sensitive local files with 0o600 (close TOCTOU window)

### DIFF
--- a/src/bantz/core/gps_server.py
+++ b/src/bantz/core/gps_server.py
@@ -30,6 +30,8 @@ from http.server import HTTPServer, BaseHTTPRequestHandler
 from pathlib import Path
 from typing import Optional
 
+from bantz.core.secure_io import secure_write_text
+
 log = logging.getLogger("bantz.gps")
 
 GPS_PORT = 9777
@@ -746,8 +748,8 @@ class GPSServer:
         """Save received GPS data to memory and disk, feed place manager."""
         self._latest = data
         LOCATION_FILE.parent.mkdir(parents=True, exist_ok=True)
-        LOCATION_FILE.write_text(
-            json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8"
+        secure_write_text(
+            LOCATION_FILE, json.dumps(data, indent=2, ensure_ascii=False)
         )
         log.info(
             "GPS updated: %.6f, %.6f (±%sm)",

--- a/src/bantz/core/location.py
+++ b/src/bantz/core/location.py
@@ -32,6 +32,7 @@ from typing import Optional
 import httpx
 
 from bantz.config import config
+from bantz.core.secure_io import secure_write_text
 
 logger = logging.getLogger(__name__)
 
@@ -258,11 +259,11 @@ class LocationService:
         try:
             import time
             GPS_CITY_CACHE.parent.mkdir(parents=True, exist_ok=True)
-            GPS_CITY_CACHE.write_text(_json_mod.dumps({
+            secure_write_text(GPS_CITY_CACHE, _json_mod.dumps({
                 "city": loc.city, "country": loc.country,
                 "timezone": loc.timezone, "region": loc.region,
                 "lat": loc.lat, "lon": loc.lon, "ts": time.time(),
-            }, ensure_ascii=False), encoding="utf-8")
+            }, ensure_ascii=False))
         except Exception as exc:
             logger.debug(f"GPS city cache write failed: {exc}")
 

--- a/src/bantz/core/places.py
+++ b/src/bantz/core/places.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 from bantz.core.location import location_service
+from bantz.core.secure_io import secure_write_text
 
 if TYPE_CHECKING:
     from bantz.data.store import PlaceStore
@@ -325,9 +326,9 @@ class PlaceService:
             self._store.save_all(self._data)
         else:
             PLACES_PATH.parent.mkdir(parents=True, exist_ok=True)
-            PLACES_PATH.write_text(
+            secure_write_text(
+                PLACES_PATH,
                 json.dumps(self._data, ensure_ascii=False, indent=2),
-                encoding="utf-8",
             )
         self._loaded = True
 

--- a/src/bantz/core/profile.py
+++ b/src/bantz/core/profile.py
@@ -26,6 +26,8 @@ import json
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from bantz.core.secure_io import secure_write_text
+
 if TYPE_CHECKING:
     from bantz.data.store import ProfileStore as _ProfileStore
 
@@ -91,9 +93,9 @@ class Profile:
             return
         # JSON fallback
         _PROFILE_PATH.parent.mkdir(parents=True, exist_ok=True)
-        _PROFILE_PATH.write_text(
+        secure_write_text(
+            _PROFILE_PATH,
             json.dumps(self._data, ensure_ascii=False, indent=2),
-            encoding="utf-8",
         )
 
     def reload(self) -> None:

--- a/src/bantz/core/secure_io.py
+++ b/src/bantz/core/secure_io.py
@@ -1,0 +1,36 @@
+"""
+Bantz — secure local file writes.
+
+Sensitive data files (GPS coordinates, saved places, user profile, session
+state) must never exist on disk — even momentarily — with world-readable
+permissions. ``Path.write_text()`` creates files with the process umask
+(typically ``0o644``), then any ``chmod`` happens afterwards, leaving a brief
+Time-of-Check-to-Time-of-Use (TOCTOU) window where another local user can read
+the contents.
+
+``secure_write_text`` creates the file with ``0o600`` from the very first
+syscall, mirroring the pattern already used in ``auth/token_store.py``.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def secure_write_text(path: Path | str, text: str, *, encoding: str = "utf-8") -> None:
+    """Write *text* to *path*, creating it owner-only (``0o600``) atomically.
+
+    Uses ``os.open(O_CREAT|O_WRONLY|O_TRUNC, 0o600)`` + ``os.fchmod`` so the
+    file is never momentarily world-readable — closing the TOCTOU window that
+    ``Path.write_text()`` followed by ``chmod`` leaves open.
+    """
+    fd = os.open(os.fspath(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.fchmod(fd, 0o600)
+        f = os.fdopen(fd, "w", encoding=encoding)
+    except BaseException:
+        # fdopen never took ownership of the descriptor — close it ourselves.
+        os.close(fd)
+        raise
+    with f:
+        f.write(text)

--- a/src/bantz/core/session.py
+++ b/src/bantz/core/session.py
@@ -17,6 +17,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from bantz.core.secure_io import secure_write_text
+
 if TYPE_CHECKING:
     from bantz.data.store import SessionStore
 
@@ -104,9 +106,9 @@ class SessionTracker:
             return
         # JSON fallback
         _SESSION_PATH.parent.mkdir(parents=True, exist_ok=True)
-        _SESSION_PATH.write_text(
+        secure_write_text(
+            _SESSION_PATH,
             json.dumps(data, ensure_ascii=False, indent=2),
-            encoding="utf-8",
         )
 
     @property

--- a/tests/core/test_secure_io.py
+++ b/tests/core/test_secure_io.py
@@ -1,0 +1,43 @@
+"""Tests for secure_write_text — files must be created 0o600, no TOCTOU window."""
+from __future__ import annotations
+
+import json
+import os
+import stat
+
+import pytest
+
+from bantz.core.secure_io import secure_write_text
+
+
+def _mode(path) -> int:
+    return stat.S_IMODE(os.stat(path).st_mode)
+
+
+def test_creates_file_owner_only(tmp_path):
+    p = tmp_path / "secret.json"
+    secure_write_text(p, json.dumps({"lat": 38.68, "lon": 39.22}))
+    assert _mode(p) == 0o600
+    assert json.loads(p.read_text())["lat"] == 38.68
+
+
+def test_overwrite_keeps_restrictive_mode(tmp_path):
+    p = tmp_path / "secret.json"
+    p.write_text("old")          # pre-existing, possibly world-readable
+    os.chmod(p, 0o644)
+    secure_write_text(p, "new")  # O_TRUNC overwrite
+    assert _mode(p) == 0o600
+    assert p.read_text() == "new"
+
+
+def test_accepts_str_path(tmp_path):
+    p = tmp_path / "s.txt"
+    secure_write_text(str(p), "hello")
+    assert p.read_text() == "hello"
+    assert _mode(p) == 0o600
+
+
+def test_unicode_roundtrip(tmp_path):
+    p = tmp_path / "u.json"
+    secure_write_text(p, json.dumps({"city": "Elâzığ"}, ensure_ascii=False))
+    assert json.loads(p.read_text())["city"] == "Elâzığ"


### PR DESCRIPTION
## What
Sensitive data files (GPS coordinates, saved places, user profile, session state) were created with `Path.write_text()` → process umask (`0o644`), restricting perms only afterward. That leaves a brief **TOCTOU window** where another local user can read private location/PII.

## Fix
New `core/secure_io.secure_write_text()` creates files `0o600` from the first syscall (`os.open(O_CREAT|O_WRONLY|O_TRUNC, 0o600)` + `os.fchmod` + `os.fdopen`), mirroring the existing `auth/token_store` pattern. Applied to all 5 sites:
- `gps_server.py` — `live_location.json`
- `places.py` — `places.json`
- `profile.py` — `profile.json`
- `session.py` — `session.json`
- `location.py` — `gps_city.json` (the newer cache the auto-PRs missed)

## Notes
- Clean single PR replacing the duplicated/junky auto-generated Sentinel PRs (#480/#482/#484/#487) — no `.jules/` agent-log files.
- Tests: `tests/core/test_secure_io.py` (mode 0o600, overwrite, str path, unicode).