### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF vulnerability in FeedTool

### DIFF
--- a/src/bantz/tools/feed_tool.py
+++ b/src/bantz/tools/feed_tool.py
@@ -273,6 +273,8 @@ def parse_feed(xml_text: str, source_name: str = "") -> list[FeedItem]:
 
 def _fetch_raw(url: str, timeout: int = 12) -> str:
     """Fetch raw XML from a feed URL using curl."""
+    if not url.startswith(("http://", "https://")):
+        raise FeedToolError(f"Invalid feed URL (must be http/https): {url}")
     try:
         result = subprocess.run(
             ["curl", "-sL", "--max-time", str(timeout), url],


### PR DESCRIPTION
🚨 Severity
CRITICAL

💡 Vulnerability
The `_fetch_raw` function in `FeedTool` (`src/bantz/tools/feed_tool.py`) calls `curl` via `subprocess.run` with a user-provided URL without validating the protocol.

🎯 Impact
An attacker or malicious user could provide URLs with unexpected protocols like `file://` or `-o/tmp/` to trigger Local File Inclusion (LFI), Server-Side Request Forgery (SSRF), or `curl` argument injection. This could expose sensitive local files (e.g., `/etc/passwd`) or allow interaction with internal networking components.

🔧 Fix
Added an explicit check to ensure that the URL starts with `http://` or `https://` before it is passed to the `curl` subprocess. Invalid URLs now raise a `FeedToolError`.

✅ Verification
Ran the `FeedTool` test suite and executed a custom script demonstrating that payloads like `file:///etc/passwd` and `-o /tmp/pwnd http://example.com` are successfully blocked with an `Invalid feed URL` error before `curl` is invoked.

---
*PR created automatically by Jules for task [10853991196892817480](https://jules.google.com/task/10853991196892817480) started by @miclaldogan*