### PR TITLE
Clear the 3 pre-existing ruff errors (lint fully green)

### DIFF
--- a/src/bantz/tools/input_control.py
+++ b/src/bantz/tools/input_control.py
@@ -33,6 +33,9 @@ import subprocess
 from datetime import datetime
 from typing import Any, Optional
 
+from bantz.config import config
+from bantz.tools import BaseTool, ToolResult, registry
+
 
 def _resolve_bin(name: str) -> str | None:
     """Locate a binary PATH-independently.
@@ -49,9 +52,6 @@ def _resolve_bin(name: str) -> str | None:
         if os.path.exists(cand):
             return cand
     return None
-
-from bantz.config import config
-from bantz.tools import BaseTool, ToolResult, registry
 
 log = logging.getLogger("bantz.input_control")
 

--- a/src/bantz/tools/vision_execute.py
+++ b/src/bantz/tools/vision_execute.py
@@ -375,7 +375,8 @@ class VisionExecuteTool(BaseTool):
             url = (f"{context.get('service_url', 'https://music.youtube.com')}"
                    f"/watch?v={context['video_id']}")
             browser_bin = _shutil.which(browser or "firefox") or "firefox"
-            proc = await _aio.create_subprocess_exec(
+            # Fire-and-forget: the browser owns its lifetime from here.
+            await _aio.create_subprocess_exec(
                 browser_bin, url,
                 stdout=_aio.subprocess.DEVNULL,
                 stderr=_aio.subprocess.DEVNULL,


### PR DESCRIPTION
Stacked on #529 (base = fix/ci-green; GitHub will auto-retarget to main when #529 merges and its branch is deleted).

Fixes the last 3 ruff errors so the Lint & Type Check check goes fully green and stays a meaningful signal:

- E402 x2 in src/bantz/tools/input_control.py — the two bantz imports sat below a helper function definition for no functional reason (no env setup above them); moved to the top of the module. Import graph unchanged (they were already module-level).
- F841 in src/bantz/tools/vision_execute.py:378 — unused proc binding on a fire-and-forget browser launch; the two other proc uses in the file (lines 106/142) are real and untouched.

Verification: ruff check src/ → All checks passed. Both modules import clean; tests/tools/ 319 passed.