### PR TITLE
S3: tool-loop step/token budget config (#501)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -301,6 +301,13 @@ BANTZ_AUTONOMY=high
 # Default temperament: tolerant | impatient | resigned
 BANTZ_MOOD_BIAS=tolerant
 
+# ── Tool loop budget (audit S3 / C1 recovery loop) ─────────────────────────
+# Max tool executions per turn: 1 = single-shot (current behaviour, no loop);
+# 2-3 = bounded observe→re-decide recovery loop. Keep 1 unless experimenting.
+BANTZ_TOOL_LOOP_MAX_STEPS=1
+# Ceiling on extra routing-call tokens per turn while the loop is active.
+BANTZ_TOOL_LOOP_TOKEN_BUDGET=4096
+
 # ── Google account identity (audit S5) ─────────────────────────────────────
 # Expected Google account for gmail/calendar tokens. When set, Bantz logs a
 # WARNING if a token authenticates as a different account (the wrong-account

--- a/src/bantz/config.py
+++ b/src/bantz/config.py
@@ -36,6 +36,14 @@ class Config(BaseSettings):
     autonomy: str = Field("high", alias="BANTZ_AUTONOMY")             # low|medium|high|absolute
     mood_bias: str = Field("tolerant", alias="BANTZ_MOOD_BIAS")       # tolerant|impatient|resigned
 
+    # ── Tool loop budget (audit S3; consumed by the C1 recovery loop) ─────
+    # Max tool EXECUTIONS per turn: 1 = single-shot (exact current
+    # behaviour, the loop never re-decides); 2-3 = bounded observe→re-decide.
+    tool_loop_max_steps: int = Field(1, ge=1, alias="BANTZ_TOOL_LOOP_MAX_STEPS")
+    # Ceiling on EXTRA routing-call tokens per turn once the loop is active;
+    # the loop stops re-deciding when exceeded. Irrelevant at max_steps=1.
+    tool_loop_token_budget: int = Field(4096, ge=0, alias="BANTZ_TOOL_LOOP_TOKEN_BUDGET")
+
     # ── Vision / Remote VLM ───────────────────────────────────────────────
     vlm_enabled: bool = Field(False, alias="BANTZ_VLM_ENABLED")
     vlm_endpoint: str = Field("http://localhost:8090", alias="BANTZ_VLM_ENDPOINT")

--- a/tests/core/test_tool_loop_config.py
+++ b/tests/core/test_tool_loop_config.py
@@ -1,0 +1,38 @@
+"""Tool-loop budget config (audit S3, issue #501).
+
+The C1 recovery loop is bounded by config, not constants, so eval
+conditions (steps=1 vs 3) are pure env flips. max_steps counts tool
+EXECUTIONS: 1 = single-shot = exact current behaviour.
+"""
+import pytest
+from pydantic import ValidationError
+
+from bantz.config import Config
+
+
+class TestToolLoopConfig:
+    def test_defaults_are_single_shot(self, monkeypatch):
+        monkeypatch.delenv("BANTZ_TOOL_LOOP_MAX_STEPS", raising=False)
+        monkeypatch.delenv("BANTZ_TOOL_LOOP_TOKEN_BUDGET", raising=False)
+        cfg = Config()
+        assert cfg.tool_loop_max_steps == 1
+        assert cfg.tool_loop_token_budget == 4096
+
+    def test_env_overrides(self, monkeypatch):
+        monkeypatch.setenv("BANTZ_TOOL_LOOP_MAX_STEPS", "3")
+        monkeypatch.setenv("BANTZ_TOOL_LOOP_TOKEN_BUDGET", "2048")
+        cfg = Config()
+        assert cfg.tool_loop_max_steps == 3
+        assert cfg.tool_loop_token_budget == 2048
+
+    def test_zero_steps_rejected(self, monkeypatch):
+        # 0 would mean "never execute the tool" — must be a config error,
+        # not a silently-dead pipeline.
+        monkeypatch.setenv("BANTZ_TOOL_LOOP_MAX_STEPS", "0")
+        with pytest.raises(ValidationError):
+            Config()
+
+    def test_negative_budget_rejected(self, monkeypatch):
+        monkeypatch.setenv("BANTZ_TOOL_LOOP_TOKEN_BUDGET", "-1")
+        with pytest.raises(ValidationError):
+            Config()


### PR DESCRIPTION
Closes #501. Stacked on #529 (auto-retargets to main when it merges).

- tool_loop_max_steps: int, default 1 (= exact current single-shot behaviour), ge=1 — 0 would mean 'never execute', rejected at construction
- tool_loop_token_budget: int, default 4096, ge=0 — ceiling on extra routing tokens once the loop is active
- .env.example lines added in the same commit (the completeness test in tests/core/test_config_cli.py requires them — the trap that bit S5)
- tests/core/test_tool_loop_config.py: defaults, env overrides, both rejection paths

Verification: 47 passed (new tests + full test_config_cli including env-completeness).