### PR TITLE
cot_route: skip_fastpath for C1 re-decide calls (#502)

### DIFF
--- a/src/bantz/core/intent.py
+++ b/src/bantz/core/intent.py
@@ -669,38 +669,15 @@ _CLICK_FAST_TR = re.compile(
 )
 
 
-async def cot_route(
-    en_input: str,
-    tool_schemas: list[dict],
-    *,
-    recent_history: list[dict] | None = None,
-    tool_context: str = "",
-    confidence_threshold: float = 0.4,
-) -> tuple[dict | None, str | None]:
-    """
-    Chain-of-Thought routing via Ollama **streaming** (#273).
+def _fastpath_route(en_input: str) -> tuple[dict, None] | None:
+    """Deterministic pre-route regexes, checked BEFORE the LLM call.
 
-    Returns ``(plan, routing_error)``:
-
-    - ``(plan_dict, None)``     — successful routing (tool or chat).
-    - ``(None, None)``          — pure chat / refusal / low confidence
-                                  (no tool was attempted).
-    - ``(None, error_string)``  — a tool route was *attempted* but JSON
-                                  parsing or validation failed.  The
-                                  caller **must not** silently fall back
-                                  to chat — it should inform the user
-                                  (#253 People-Pleaser fix).
-
-    Now streams via ``ollama.chat_stream()`` and emits ``thinking_token``
-    events on the EventBus so the TUI can display the chain-of-thought
-    in real-time.
-
-    Parameters
-    ----------
-    tool_context : str
-        Optional dynamic context block (e.g. recent email IDs, calendar
-        events) injected only when relevant (#275 — avoids bloating the
-        prompt when unrelated queries are asked).
+    Returns a ``(plan, None)`` tuple exactly like a successful cot_route
+    verdict, or ``None`` to fall through to the LLM. Extracted from
+    cot_route so the C1 recovery loop can bypass the whole family with
+    ``skip_fastpath=True`` (#502) — these match on input text, which does
+    not change after a tool failure, so re-entering them from a re-decide
+    call would re-select the same failed tool forever.
     """
     # "investigate: <anomaly> — <detail>" comes from the Anomaly Watch
     # Investigate button — Bantz should analyze it conversationally, never
@@ -780,6 +757,58 @@ async def cot_route(
             "risk_level": "moderate", "confidence": 0.95,
             "reasoning": "pre-route: click-by-description",
         }, None
+
+    return None
+
+
+async def cot_route(
+    en_input: str,
+    tool_schemas: list[dict],
+    *,
+    recent_history: list[dict] | None = None,
+    tool_context: str = "",
+    confidence_threshold: float = 0.4,
+    skip_fastpath: bool = False,
+) -> tuple[dict | None, str | None]:
+    """
+    Chain-of-Thought routing via Ollama **streaming** (#273).
+
+    Returns ``(plan, routing_error)``:
+
+    - ``(plan_dict, None)``     — successful routing (tool or chat).
+    - ``(None, None)``          — pure chat / refusal / low confidence
+                                  (no tool was attempted).
+    - ``(None, error_string)``  — a tool route was *attempted* but JSON
+                                  parsing or validation failed.  The
+                                  caller **must not** silently fall back
+                                  to chat — it should inform the user
+                                  (#253 People-Pleaser fix).
+
+    Now streams via ``ollama.chat_stream()`` and emits ``thinking_token``
+    events on the EventBus so the TUI can display the chain-of-thought
+    in real-time.
+
+    Parameters
+    ----------
+    tool_context : str
+        Optional dynamic context block (e.g. recent email IDs, calendar
+        events) injected only when relevant (#275 — avoids bloating the
+        prompt when unrelated queries are asked).
+    skip_fastpath : bool
+        Bypass ALL pre-route regexes (including the ``investigate:``
+        pre-route) and go straight to the LLM. REQUIRED for the C1
+        recovery loop's re-decide calls (audit C1, #502): the fast-paths
+        match on the *input text*, which does not change after a tool
+        failure — re-entering them would re-select the same failed tool
+        every iteration (an infinite same-tool loop, not a re-decision).
+        Do not remove this parameter or default it to True.
+    """
+    # Pre-route regexes live in _fastpath_route; the C1 recovery loop's
+    # re-decide calls MUST bypass them (see skip_fastpath in the docstring).
+    if not skip_fastpath:
+        fast = _fastpath_route(en_input)
+        if fast is not None:
+            return fast
 
     schema_str = _build_compact_schemas(tool_schemas)
 

--- a/tests/core/test_skip_fastpath.py
+++ b/tests/core/test_skip_fastpath.py
@@ -1,0 +1,102 @@
+"""cot_route skip_fastpath (audit C1 prerequisite, issue #502).
+
+The pre-route regexes match on the *input text*, which does not change
+after a tool failure — so the C1 recovery loop's re-decide calls must
+bypass the whole family or they re-select the same failed tool forever.
+These tests pin both directions: default False = fast-paths fire exactly
+as before; True = every pre-route (including ``investigate:``) is skipped
+and the LLM is consulted.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from bantz.core.intent import _fastpath_route, cot_route
+
+# A canned LLM verdict, so tests can detect "the LLM path was reached"
+# without a live model.
+_LLM_VERDICT = json.dumps({
+    "route": "chat",
+    "tool_name": None,
+    "tool_args": {},
+    "risk_level": "safe",
+    "confidence": 0.9,
+})
+
+
+async def _aiter_tokens(text: str):
+    for char in text:
+        yield char
+
+
+def _mock_stream(text: str):
+    async def _stream(messages, **kwargs):
+        async for tok in _aiter_tokens(text):
+            yield tok
+    return _stream
+
+
+# Inputs that MUST hit a fast-path by default, with the route/tool the
+# pre-route family is contractually expected to produce.
+FASTPATH_CASES = [
+    ("investigate: high swap usage — 92%", "chat", None),
+    ("remind me in 10 minutes to stretch", "tool", "reminder"),
+    ("do you remember my sister's name?", "chat", None),
+    ("i want to listen to AC/DC", "tool", "vision_execute"),
+    ("let's watch lofi videos on youtube", "tool", "vision_execute"),
+    ("workspace 3", "tool", "desktop"),
+    ("next workspace", "tool", "desktop"),
+    ("click the send button", "tool", "visual_click"),
+]
+
+
+class TestFastpathExtraction:
+    """_fastpath_route preserves each family's pre-#502 verdict."""
+
+    @pytest.mark.parametrize("text,route,tool", FASTPATH_CASES)
+    def test_families_still_match(self, text, route, tool):
+        result = _fastpath_route(text)
+        assert result is not None, f"expected a fast-path match for {text!r}"
+        plan, err = result
+        assert err is None
+        assert plan["route"] == route
+        assert plan.get("tool_name") == tool
+
+    def test_no_match_falls_through(self):
+        assert _fastpath_route("what's the weather in Elazig?") is None
+
+
+class TestSkipFastpath:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("text,route,tool", FASTPATH_CASES)
+    async def test_default_uses_fastpath_without_llm(self, text, route, tool):
+        """skip_fastpath omitted → fast-path verdict, zero LLM calls."""
+        with patch("bantz.core.intent.ollama") as mock_llm, \
+             patch("bantz.core.intent.bus") as mock_bus:
+            mock_llm.chat_stream = AsyncMock(
+                side_effect=AssertionError("LLM must not be called on a fast-path"),
+            )
+            mock_bus.emit = AsyncMock()
+            plan, error = await cot_route(text, [])
+        assert error is None
+        assert plan["route"] == route
+        assert plan.get("tool_name") == tool
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("text,_route,_tool", FASTPATH_CASES)
+    async def test_skip_reaches_llm_for_every_family(self, text, _route, _tool):
+        """skip_fastpath=True → every pre-route family is bypassed and the
+        LLM is consulted — including the investigate: pre-route, which does
+        not look like a pattern fast-path but is one (#502 gotcha)."""
+        with patch("bantz.core.intent.ollama") as mock_llm, \
+             patch("bantz.core.intent.bus") as mock_bus:
+            mock_llm.chat_stream = _mock_stream(_LLM_VERDICT)
+            mock_bus.emit = AsyncMock()
+            plan, error = await cot_route(text, [], skip_fastpath=True)
+        # The canned verdict (not the fast-path plan) must come back:
+        # fast-path plans carry a "pre-route:" reasoning marker.
+        assert plan is not None
+        assert "pre-route" not in (plan.get("reasoning") or "")


### PR DESCRIPTION
Closes #502. Stacked on #529 (auto-retargets to main when it merges). Disjoint files from #530 and #531.

## What
- All pre-route regexes moved verbatim from cot_route's body into _fastpath_route (same module) — including the investigate: pre-route, which does not look like a pattern fast-path but is one (the #502 gotcha).
- cot_route gains keyword-only skip_fastpath: bool = False. Default = byte-identical behaviour for every existing caller; True = straight to the LLM.
- Docstrings on both symbols explain WHY (the fast-path re-selection trap: patterns match input text, which does not change after a tool failure — a re-decide that re-enters them re-selects the same failed tool forever).

## Verification
- New tests (tests/core/test_skip_fastpath.py): all 8 fast-path families pinned both ways — default fires the fast-path with an LLM-call tripwire asserting zero model calls; skip_fastpath=True reaches the (mocked) LLM for every family including investigate:.
- Extraction is behaviour-preserving: full tests/core green (757 passed) including all pre-existing intent tests untouched.
- ruff clean.