### PR TITLE
fix(tests): repair main CI — session-key isolation, S5 env alias, prune contract

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -126,6 +126,12 @@ BANTZ_OVERNIGHT_POLL_HOURS=0,2,4,6
 # Comma-separated keywords that mark an email as urgent (case-insensitive).
 BANTZ_URGENT_KEYWORDS=urgent,acil,deadline,final,emergency,important
 
+# ── Google Account Identity (audit S5) ────────────────────────────────────────
+# Optional expected Google account email. When set, gmail/calendar warn loudly
+# if the authenticated token belongs to a different account — catches the
+# silent "wrote OK but invisible" wrong-account bug.
+BANTZ_GOOGLE_ACCOUNT=
+
 # ── Telegram Bot (optional — for notifications + remote control) ──────────────
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_ALLOWED_USERS=

--- a/tests/agent/test_planner.py
+++ b/tests/agent/test_planner.py
@@ -568,6 +568,8 @@ class TestBrainPlannerIntegration:
             brain._turn_counter = 0
             brain._context_turn = 0
             brain._CONTEXT_TTL = 3
+            brain._state_owner = ""
+            brain._recall_cache = None
             brain._last_screen_description = ""
             brain._screen_description_turn = -1
             brain._pending_vlm_task = None
@@ -618,6 +620,8 @@ class TestBrainPlannerIntegration:
             brain._turn_counter = 0
             brain._context_turn = 0
             brain._CONTEXT_TTL = 3
+            brain._state_owner = ""
+            brain._recall_cache = None
             brain._last_screen_description = ""
             brain._screen_description_turn = -1
             brain._pending_vlm_task = None
@@ -689,6 +693,8 @@ class TestBrainPlannerIntegration:
             brain._turn_counter = 0
             brain._context_turn = 0
             brain._CONTEXT_TTL = 3
+            brain._state_owner = ""
+            brain._recall_cache = None
             brain._last_screen_description = ""
             brain._screen_description_turn = -1
             brain._pending_vlm_task = None

--- a/tests/agent/test_proactive.py
+++ b/tests/agent/test_proactive.py
@@ -379,6 +379,8 @@ class TestProactiveBrainHandler:
         b._turn_counter = 0
         b._context_turn = 0
         b._CONTEXT_TTL = 3
+        b._state_owner = ""
+        b._recall_cache = None
         b._last_screen_description = ""
         b._screen_description_turn = -1
         b._pending_vlm_task = None

--- a/tests/agent/test_tts.py
+++ b/tests/agent/test_tts.py
@@ -628,6 +628,8 @@ class TestBrainTTSStopHandler:
         b._turn_counter = 0
         b._context_turn = 0
         b._CONTEXT_TTL = 3
+        b._state_owner = ""
+        b._recall_cache = None
         b._last_screen_description = ""
         b._screen_description_turn = -1
         b._pending_vlm_task = None
@@ -705,6 +707,8 @@ class TestBrainBriefingWithTTS:
         b._turn_counter = 0
         b._context_turn = 0
         b._CONTEXT_TTL = 3
+        b._state_owner = ""
+        b._recall_cache = None
         b._last_screen_description = ""
         b._screen_description_turn = -1
         b._pending_vlm_task = None

--- a/tests/interface/test_telegram_llm.py
+++ b/tests/interface/test_telegram_llm.py
@@ -269,7 +269,9 @@ class TestHandleMessage:
                 with patch.dict("sys.modules", {"bantz.core.brain": MagicMock(brain=mock_brain)}):
                     await mod.handle_message(update, ctx)
 
-            mock_brain.process.assert_awaited_once_with("Tell me a joke", is_remote=True)
+            mock_brain.process.assert_awaited_once_with(
+                "Tell me a joke", is_remote=True, session_key="tg:111"
+            )
         finally:
             mod._ALLOWED = original_allowed
 

--- a/tests/workflows/test_reflection.py
+++ b/tests/workflows/test_reflection.py
@@ -555,14 +555,11 @@ class TestPruneOldMessages:
 
         msgs_deleted, vecs_deleted = _prune_old_messages(keep_days=30)
         assert msgs_deleted == 2
-        assert vecs_deleted == 2
+        # Vector drawers live in ChromaDB and are intentionally NOT pruned
+        # here (audit M2/M3) — the reported count is always 0.
+        assert vecs_deleted == 0
 
-        # Verify vectors are actually gone
         with pool.connection() as conn:
-            remaining = conn.execute(
-                "SELECT COUNT(*) FROM message_vectors WHERE message_id IN (100, 101)"
-            ).fetchone()[0]
-            assert remaining == 0
 
             # Distillation should STILL exist (we keep summaries)
             dist = conn.execute(


### PR DESCRIPTION
Main's required **Tests** workflow has been red since 4eb844c / f334613 landed without test updates — which blocks every PR on the REALM board (#501–#527). This repairs the 11 failures:

- **8× `Brain._state_owner` AttributeError** (test_planner, test_proactive, test_tts): the `Brain.__new__` hand-built instances now set `_state_owner` (4eb844c, Telegram C2 isolation) and `_recall_cache` (f12b29a, per-turn recall memo).
- **telegram test**: `brain.process` is now legitimately called with `session_key='tg:111'` — expectation updated.
- **env-example completeness**: added the `BANTZ_GOOGLE_ACCOUNT` alias entry for the new audit-S5 field (f334613).
- **reflection prune**: `vectors_deleted` is intentionally always 0 since a8e6a5f (embeddings live in ChromaDB, not SQLite) — assertion aligned with the documented contract.

All 446 tests in the touched files pass locally; no product code changed.