### PR TITLE
feat(ui): structured web_research progress + Cancel button (#490, #491)

### DIFF
--- a/bantz-ui/src/App.tsx
+++ b/bantz-ui/src/App.tsx
@@ -155,6 +155,7 @@ export default function App() {
   const setServices      = useAppStore((s) => s.setServices);
   const setConfigValues  = useAppStore((s) => s.setConfigValues);
   const setAnomalies     = useAppStore((s) => s.setAnomalies);
+  const setResearch      = useAppStore((s) => s.setResearch);
   const setWsSend        = useAppStore((s) => s.setWsSend);
   const alertCount       = useAppStore((s) => s.anomalies.length);
 
@@ -270,12 +271,31 @@ export default function App() {
           break;
         }
 
+        case "research_progress": {
+          const r = d as {
+            stage?: string; detail?: string; elapsed?: number; state?: string;
+          };
+          const state =
+            r.state === "done" || r.state === "cancelled" ? r.state : "running";
+          setResearch({
+            stage:   String(r.stage ?? ""),
+            detail:  String(r.detail ?? ""),
+            elapsed: Number(r.elapsed ?? 0),
+            state,
+          });
+          // Leave the terminal state visible briefly, then clear the indicator.
+          if (state !== "running") {
+            setTimeout(() => setResearch(null), 4000);
+          }
+          break;
+        }
+
         default:
           break;
       }
     },
     [pushChat, pushVital, setStreamingText, pushLog, pushAlert,
-     setTasks, setServices, setConfigValues, setAnomalies],
+     setTasks, setServices, setConfigValues, setAnomalies, setResearch],
   );
 
   const { status, attempts, send } = useWebSocket({

--- a/bantz-ui/src/pages/ChatPage.tsx
+++ b/bantz-ui/src/pages/ChatPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { Send, CornerDownLeft, Loader2, CheckCircle2, XCircle } from "lucide-react";
+import { Send, CornerDownLeft, Loader2, CheckCircle2, XCircle, Ban } from "lucide-react";
 import { useAppStore } from "../store/useAppStore";
 import type { ResearchProgress } from "../store/useAppStore";
 import { PageTitle, PanelHeader, fmtTime } from "../components/primitives";
@@ -23,12 +23,24 @@ const STAGE_LABEL: Record<string, string> = {
 };
 
 function ResearchProgressCard({ research }: { research: ResearchProgress }) {
+  const wsSend      = useAppStore((s) => s.wsSend);
+  const setResearch = useAppStore((s) => s.setResearch);
   const { stage, detail, elapsed, state } = research;
   const label = STAGE_LABEL[stage] ?? STAGE_LABEL[state] ?? "RESEARCHING";
   const accent =
     state === "cancelled" ? "text-obsidian-200 border-obsidian-500"
     : state === "done"    ? "text-gold-400 border-gold-500/60"
     :                       "text-ember-400 border-ember-500/60";
+
+  // #491: the backend cancel path already exists (WS "cancel_research"); this
+  // is the missing UI trigger. The run only polls its cancel flag every ~30s,
+  // so reflect the request immediately and let the indicator self-clear.
+  function cancel() {
+    wsSend?.({ type: "cancel_research" });
+    setResearch({ stage: "cancelled", detail: "Cancelling…", elapsed, state: "cancelled" });
+    setTimeout(() => setResearch(null), 4000);
+  }
+
   return (
     <div className="grid grid-cols-[88px_1fr] gap-4">
       <div className="pt-1 font-terminal text-[10px] tracking-widest text-ember-500">
@@ -48,6 +60,16 @@ function ResearchProgressCard({ research }: { research: ResearchProgress }) {
           <span className="shrink-0 font-terminal text-[10px] tabular-nums text-obsidian-200">
             {elapsed}s
           </span>
+        )}
+        {state === "running" && wsSend && (
+          <button
+            type="button"
+            onClick={cancel}
+            className="flex shrink-0 items-center gap-1 border border-obsidian-500 px-1.5 py-0.5 font-ui text-[9px] font-bold uppercase tracking-widest text-obsidian-200 transition-colors duration-150 ease-bantz hover:border-ember-500 hover:text-ember-400"
+            aria-label="Cancel research"
+          >
+            <Ban size={10} strokeWidth={1.75} /> Cancel
+          </button>
         )}
       </div>
     </div>

--- a/bantz-ui/src/pages/ChatPage.tsx
+++ b/bantz-ui/src/pages/ChatPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
-import { Send, CornerDownLeft } from "lucide-react";
+import { Send, CornerDownLeft, Loader2, CheckCircle2, XCircle } from "lucide-react";
 import { useAppStore } from "../store/useAppStore";
+import type { ResearchProgress } from "../store/useAppStore";
 import { PageTitle, PanelHeader, fmtTime } from "../components/primitives";
 import { SlashMenu } from "../components/SlashMenu";
 import { DoctorModal } from "../components/DoctorModal";
@@ -12,10 +13,52 @@ interface ChatPageProps {
   onSend: (text: string) => void;
 }
 
+// Compact deep-research progress indicator (#490). Replaces the old raw ⏳
+// text that used to interleave with the chat transcript.
+const STAGE_LABEL: Record<string, string> = {
+  searching: "SEARCHING",
+  working:   "RESEARCHING",
+  done:      "COMPLETE",
+  cancelled: "CANCELLED",
+};
+
+function ResearchProgressCard({ research }: { research: ResearchProgress }) {
+  const { stage, detail, elapsed, state } = research;
+  const label = STAGE_LABEL[stage] ?? STAGE_LABEL[state] ?? "RESEARCHING";
+  const accent =
+    state === "cancelled" ? "text-obsidian-200 border-obsidian-500"
+    : state === "done"    ? "text-gold-400 border-gold-500/60"
+    :                       "text-ember-400 border-ember-500/60";
+  return (
+    <div className="grid grid-cols-[88px_1fr] gap-4">
+      <div className="pt-1 font-terminal text-[10px] tracking-widest text-ember-500">
+        RESEARCH
+      </div>
+      <div className={`flex items-center gap-3 border-l-2 ${accent} bg-obsidian-800/50 px-3 py-2`}>
+        {state === "running" && <Loader2 size={13} strokeWidth={1.75} className="animate-spin shrink-0" />}
+        {state === "done"     && <CheckCircle2 size={13} strokeWidth={1.75} className="shrink-0" />}
+        {state === "cancelled"&& <XCircle size={13} strokeWidth={1.75} className="shrink-0" />}
+        <span className="font-terminal text-[10px] font-bold tracking-widest shrink-0">
+          {label}
+        </span>
+        <span className="min-w-0 flex-1 truncate font-terminal text-[13px] leading-relaxed text-fg-secondary">
+          {detail}
+        </span>
+        {elapsed > 0 && (
+          <span className="shrink-0 font-terminal text-[10px] tabular-nums text-obsidian-200">
+            {elapsed}s
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
 export function ChatPage({ wsStatus, onSend }: ChatPageProps) {
   const chat          = useAppStore((s) => s.chat);
   const pushChat      = useAppStore((s) => s.pushChat);
   const streamingText = useAppStore((s) => s.streamingText);
+  const research      = useAppStore((s) => s.research);
   const [draft, setDraft] = useState("");
   const [modal, setModal] = useState<"doctor" | "setup" | null>(null);
   const ref = useRef<HTMLDivElement>(null);
@@ -23,10 +66,10 @@ export function ChatPage({ wsStatus, onSend }: ChatPageProps) {
   // Show slash menu when draft starts with "/" and has no space yet.
   const showSlashMenu = draft.startsWith("/") && !draft.includes(" ");
 
-  // Auto-scroll on new messages and on each streaming token.
+  // Auto-scroll on new messages, streaming tokens, and research progress.
   useEffect(() => {
     if (ref.current) ref.current.scrollTop = ref.current.scrollHeight;
-  }, [chat.length, streamingText]);
+  }, [chat.length, streamingText, research]);
 
   function submit() {
     const v = draft.trim();
@@ -124,6 +167,9 @@ export function ChatPage({ wsStatus, onSend }: ChatPageProps) {
                 </div>
               </div>
             )}
+
+            {/* Deep-research progress — structured indicator, not raw text (#490) */}
+            {research && <ResearchProgressCard research={research} />}
           </div>
 
           {/* Input bar */}

--- a/bantz-ui/src/store/useAppStore.ts
+++ b/bantz-ui/src/store/useAppStore.ts
@@ -71,6 +71,16 @@ export interface Anomaly {
   timestamp: number;
 }
 
+// Live deep-research (web_research) progress, pushed as structured
+// "research_progress" frames (#490). Null when no run is active; the terminal
+// states ("done"/"cancelled") clear it shortly after arriving.
+export interface ResearchProgress {
+  stage: string;   // "searching" | "working" | "done" | "cancelled"
+  detail: string;  // readable one-liner
+  elapsed: number; // seconds since the run started
+  state: "running" | "done" | "cancelled";
+}
+
 export type ServiceStatus = "online" | "degraded" | "offline";
 
 export interface ServiceItem {
@@ -113,6 +123,7 @@ interface AppState {
   activePage: string;
   services: ServiceItem[];
   configValues: ConfigValues | null;
+  research: ResearchProgress | null;
   wsSend: ((msg: Record<string, unknown>) => boolean) | null;
 
   pushChat: (turn: Omit<ChatTurn, "id" | "ts"> & Partial<Pick<ChatTurn, "ts">>) => void;
@@ -129,6 +140,7 @@ interface AppState {
   setActivePage: (page: string) => void;
   setServices: (services: ServiceItem[]) => void;
   setConfigValues: (cv: ConfigValues) => void;
+  setResearch: (progress: ResearchProgress | null) => void;
   setWsSend: (fn: ((msg: Record<string, unknown>) => boolean) | null) => void;
 }
 
@@ -258,6 +270,7 @@ export const useAppStore = create<AppState>((set) => ({
   activePage:   "chat",
   services:     SEED_SERVICES,
   configValues: null,
+  research:     null,
   wsSend:       null,
 
   pushChat: (turn) =>
@@ -337,6 +350,8 @@ export const useAppStore = create<AppState>((set) => ({
   setServices: (services) => set({ services }),
 
   setConfigValues: (cv) => set({ configValues: cv }),
+
+  setResearch: (progress) => set({ research: progress }),
 
   setWsSend: (fn) => set({ wsSend: fn }),
 }));

--- a/src/bantz/interface/ws_server.py
+++ b/src/bantz/interface/ws_server.py
@@ -139,7 +139,7 @@ class WsBroadcastServer:
         bus.bind_loop()
         bus.on("health_alert", self._on_health_alert)
         bus.on("observer_error", self._on_observer_error)
-        bus.on("chat_token", self._on_chat_token)
+        bus.on("research_progress", self._on_research_progress)
 
         self._tasks = [
             asyncio.create_task(self._vitals_loop(),        name="ws-vitals"),
@@ -450,12 +450,21 @@ class WsBroadcastServer:
         }
         asyncio.create_task(self._broadcast(payload))
 
-    def _on_chat_token(self, event: Event) -> None:
-        """Bridge a 'chat_token' bus event (e.g. web_research progress) to a
-        chat token frame so it streams into the Broadcast Channel."""
-        token = event.data.get("token", "")
-        if token:
-            asyncio.create_task(self._broadcast({"type": "token", "text": token}))
+    def _on_research_progress(self, event: Event) -> None:
+        """Bridge a 'research_progress' bus event to a structured frame (#490).
+
+        The Broadcast Channel renders these as a compact progress indicator
+        instead of interleaving raw text with the chat transcript. ``state`` is
+        "running" | "done" | "cancelled"; the UI clears the indicator on the
+        terminal states."""
+        d = event.data
+        asyncio.create_task(self._broadcast({
+            "type": "research_progress",
+            "stage": d.get("stage", ""),
+            "detail": d.get("detail", ""),
+            "elapsed": int(d.get("elapsed", 0) or 0),
+            "state": d.get("state", "running"),
+        }))
 
     def _handle_cancel_research(self) -> None:
         """Set the web_research tool's cancel flag (WS 'cancel_research')."""

--- a/src/bantz/tools/web_search.py
+++ b/src/bantz/tools/web_search.py
@@ -51,16 +51,35 @@ def _silence_bantz_web_git() -> None:
 DEFAULT_RESEARCH_RESULTS = 15
 
 
-def _emit_progress(message: str) -> None:
-    """Stream a research progress line to the Broadcast Channel (chat stream).
+def _emit_research_progress(
+    stage: str,
+    detail: str,
+    *,
+    elapsed: int = 0,
+    state: str = "running",
+) -> None:
+    """Emit a *structured* deep-research progress update (#490).
 
-    ws_server bridges the "chat_token" bus event to a {"type":"token"} frame.
+    ws_server bridges the "research_progress" bus event to a
+    ``{"type": "research_progress", stage, detail, elapsed, state}`` WS frame,
+    which the Broadcast Channel renders as a compact labeled step/elapsed
+    indicator instead of interleaving raw ``⏳`` text with chat tokens.
+
+    ``state`` is ``"running" | "done" | "cancelled"``. ``detail`` doubles as a
+    readable one-liner and is echoed to the log so non-UI clients
+    (terminal/journald) still get legible progress.
     """
     try:
-        bus.emit_threadsafe("chat_token", token=f"\n⏳ {message}")
+        bus.emit_threadsafe(
+            "research_progress",
+            stage=stage,
+            detail=detail,
+            elapsed=elapsed,
+            state=state,
+        )
     except Exception:
         pass
-    log.info("[web_research] %s", message)
+    log.info("[web_research] %s: %s (%ss, %s)", stage, detail, elapsed, state)
 
 
 # ── wrapped functions ───────────────────────────────────────────────────────
@@ -168,24 +187,33 @@ class WebResearchTool(BaseTool):
         self._research_cancelled.clear()
         fut = asyncio.ensure_future(asyncio.to_thread(execute_web_research, topic))
         start = time.time()
-        _emit_progress(f"Researching: {topic} — expanding query & searching…")
+        _emit_research_progress(
+            "searching", f"Researching “{topic}” — expanding query & searching…",
+        )
         try:
             while True:
                 try:
                     report = await asyncio.wait_for(asyncio.shield(fut), timeout=30)
                     break
                 except asyncio.TimeoutError:
+                    elapsed = int(time.time() - start)
                     if self._research_cancelled.is_set():
-                        _emit_progress("Research cancelled.")
+                        _emit_research_progress(
+                            "cancelled", "Research cancelled.",
+                            elapsed=elapsed, state="cancelled",
+                        )
                         # The worker thread can't be force-killed; it finishes
                         # in the background but we stop waiting/reporting.
                         return ToolResult(success=False, output="",
                                           error="Research cancelled by user.")
-                    elapsed = int(time.time() - start)
-                    _emit_progress(f"still working on '{topic}' — {elapsed}s elapsed…")
+                    _emit_research_progress(
+                        "working", f"Still working on “{topic}”…", elapsed=elapsed,
+                    )
         except Exception as exc:
             return ToolResult(success=False, output="", error=f"web research failed: {exc}")
-        _emit_progress("Writing report… done.")
+        _emit_research_progress(
+            "done", "Report ready.", elapsed=int(time.time() - start), state="done",
+        )
         return ToolResult(success=True, output=report, data={"topic": topic})
 
 

--- a/tests/tools/test_web_search.py
+++ b/tests/tools/test_web_search.py
@@ -129,3 +129,48 @@ class TestWebResearchTool:
         assert result.success is True
         assert result.output == "REPORT"
         assert result.data["topic"] == "quantum computing"
+
+    def test_research_emits_structured_progress_not_chat_tokens(self):
+        """web_research streams structured research_progress events (#490),
+        never raw chat_token text, so the UI can render a progress widget."""
+        events: list[tuple[str, dict]] = []
+        with patch(
+            "bantz.tools.web_search.execute_web_research", return_value="REPORT"
+        ), patch(
+            "bantz.tools.web_search.bus.emit_threadsafe",
+            side_effect=lambda name, **kw: events.append((name, kw)),
+        ):
+            _run(WebResearchTool().execute(topic="tea"))
+
+        names = [n for n, _ in events]
+        # A fast (mocked) run emits exactly a start + a terminal event…
+        assert names == ["research_progress", "research_progress"]
+        # …and never the old noisy chat_token path.
+        assert "chat_token" not in names
+
+        start = events[0][1]
+        assert start["stage"] == "searching"
+        assert start["state"] == "running"
+        assert "tea" in start["detail"]
+
+        done = events[-1][1]
+        assert done["stage"] == "done"
+        assert done["state"] == "done"
+        assert done["elapsed"] >= 0
+
+    def test_emit_research_progress_payload_shape(self):
+        from bantz.tools.web_search import _emit_research_progress
+
+        events: list[tuple[str, dict]] = []
+        with patch(
+            "bantz.tools.web_search.bus.emit_threadsafe",
+            side_effect=lambda name, **kw: events.append((name, kw)),
+        ):
+            _emit_research_progress(
+                "cancelled", "Research cancelled.", elapsed=12, state="cancelled"
+            )
+        assert events == [(
+            "research_progress",
+            {"stage": "cancelled", "detail": "Research cancelled.",
+             "elapsed": 12, "state": "cancelled"},
+        )]


### PR DESCRIPTION
Closes #490 and #491 — both concern the deep-research (`web_research`) experience in the Broadcast Channel.

## #490 — structured progress, not raw text
Deep-research progress was streamed as raw `⏳ …` text via the `chat_token` bus event, interleaved with normal chat tokens — noisy and easy to miss.

- `web_search.py`: replace the `chat_token` text path with a structured `research_progress` bus event carrying `stage` / `detail` / `elapsed` / `state` (`running`|`done`|`cancelled`). `log.info` stays as the terminal/non-UI text fallback.
- `ws_server.py`: bridge `research_progress` → a `{"type":"research_progress", …}` WS frame (replaces the old `chat_token`→`token` bridge, which had no other users).
- `bantz-ui`: a compact progress indicator in the Broadcast Channel (spinner + stage label + detail + elapsed), cleared shortly after a terminal state.

## #491 — Cancel research button
The backend cancel path (`cancel_research` → sets the run's cancel flag) already existed but had no UI trigger.

- A **Cancel** button on the progress card, shown only while a run is active, sends `{"type":"cancel_research"}` and optimistically flips the indicator to *cancelled* (the run only polls its flag every ~30s).

## Verification
- `tests/tools/test_web_search.py`: +2 tests asserting `web_research` emits structured `research_progress` events (start + terminal) and never the old `chat_token` path; 16 pass.
- Full `tests/tools` + `tests/interface`: 443 passed, 6 skipped.
- `tsc --noEmit`: no errors in changed files (`App.tsx`, `ChatPage.tsx`, `useAppStore.ts`).

Note: the desktop widget itself still wants a visual check in the running Tauri app; the WS contract and backend are covered by tests.