### PR TITLE
feat(brain): complete the autonomy-dial ladder — medium tier (#492)

### DIFF
--- a/src/bantz/core/brain.py
+++ b/src/bantz/core/brain.py
@@ -708,9 +708,14 @@ class Brain:
                     log.info("shell.is_destructive promoted risk safe/moderate → destructive")
                 risk = "destructive"
 
-            # Autonomy dial (audit S1). The user's confirmation authorises ONLY
-            # the first decision; a re-decided (substituted) action must earn
-            # its own confirmation — never auto-approve it.
+            # Autonomy dial (audit S1, #492). Monotonic caution ladder:
+            #   absolute → never confirm (run everything)
+            #   high (default) → confirm destructive only (legacy toggle applies)
+            #   medium → confirm moderate + destructive
+            #   low → confirm every tool action (even safe)
+            # The user's confirmation authorises ONLY the first decision; a
+            # re-decided (substituted) action must earn its own confirmation —
+            # never auto-approve it.
             iter_confirmed = confirmed if index == 1 else False
             rc = requires_confirm
             if rc is None:  # older verdict without the field
@@ -719,7 +724,9 @@ class Brain:
                 need_confirm = False
             elif autonomy == "low":
                 need_confirm = rc and not iter_confirmed
-            else:  # medium / high (default): destructive only, legacy toggle
+            elif autonomy == "medium":
+                need_confirm = risk in ("moderate", "destructive") and not iter_confirmed
+            else:  # high (default): destructive only, legacy toggle applies
                 need_confirm = (
                     risk == "destructive"
                     and config.shell_confirm_destructive

--- a/src/bantz/core/intent.py
+++ b/src/bantz/core/intent.py
@@ -377,9 +377,12 @@ def _extract_json(text: str, utterance: str = "") -> dict:
             except Exception:  # registry unavailable (e.g. bare unit tests)
                 pass
 
-    # Autonomy dial → whether the user must confirm before this tool runs.
-    # low: always confirm any tool/planner action. absolute: never confirm,
-    # even destructive. medium/high (default): confirm only destructive tools.
+    # Autonomy dial (#492) → whether the user must confirm before this tool
+    # runs. Monotonic caution ladder:
+    #   low      → always confirm any tool/planner action (even safe)
+    #   medium   → confirm moderate + destructive
+    #   high     → confirm destructive only (default)
+    #   absolute → never confirm, even destructive
     if isinstance(data, dict):
         try:
             from bantz.config import config
@@ -387,12 +390,15 @@ def _extract_json(text: str, utterance: str = "") -> dict:
         except Exception:
             autonomy = "high"
         if data.get("route") in ("tool", "planner"):
+            risk = data.get("risk_level")
             if autonomy == "low":
                 data["requires_confirm"] = True
             elif autonomy == "absolute":
                 data["requires_confirm"] = False
-            else:
-                data["requires_confirm"] = data.get("risk_level") == "destructive"
+            elif autonomy == "medium":
+                data["requires_confirm"] = risk in ("moderate", "destructive")
+            else:  # high (default)
+                data["requires_confirm"] = risk == "destructive"
         else:
             data["requires_confirm"] = False
 

--- a/tests/core/test_autonomy_dial.py
+++ b/tests/core/test_autonomy_dial.py
@@ -1,0 +1,158 @@
+"""Autonomy dial enforcement across all four tiers (issue #492).
+
+The dial is a monotonic caution ladder — each lower tier confirms a superset
+of the tier above:
+
+    absolute → confirm nothing (run everything, even destructive)
+    high     → confirm destructive only (default; legacy shell toggle applies)
+    medium   → confirm moderate + destructive
+    low      → confirm every tool action (even safe)
+
+Two layers must agree: the routing layer (`intent._extract_json` sets the
+`requires_confirm` flag) and the executor gate (`Brain._execute_with_recovery`
+actually stops for confirmation). Both are pinned here per (tier × risk).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import bantz.config as bantz_config
+import bantz.core.brain as brain_mod
+from bantz.core.brain import Brain
+from bantz.core.intent import _extract_json
+from bantz.tools import ToolResult
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# Expected confirmation per (autonomy, risk). True = must stop and ask.
+EXPECT = {
+    ("absolute", "safe"): False, ("absolute", "moderate"): False, ("absolute", "destructive"): False,
+    ("high", "safe"): False,     ("high", "moderate"): False,     ("high", "destructive"): True,
+    ("medium", "safe"): False,   ("medium", "moderate"): True,    ("medium", "destructive"): True,
+    ("low", "safe"): True,       ("low", "moderate"): True,       ("low", "destructive"): True,
+}
+
+
+def _intent_requires_confirm(autonomy: str, risk: str) -> bool:
+    """What intent._extract_json sets requires_confirm to for a tool verdict."""
+    return {
+        "absolute": False,
+        "high": risk == "destructive",
+        "medium": risk in ("moderate", "destructive"),
+        "low": True,
+    }[autonomy]
+
+
+# ── routing layer: intent._extract_json sets requires_confirm per the ladder ──
+
+@pytest.mark.parametrize("autonomy,risk", list(EXPECT))
+def test_intent_sets_requires_confirm(autonomy, risk, monkeypatch):
+    monkeypatch.setattr(bantz_config.config, "autonomy", autonomy)
+    verdict = json.dumps({
+        "route": "tool", "tool_name": "shell", "tool_args": {},
+        "risk_level": risk, "confidence": 0.9,
+    })
+    plan = _extract_json(verdict)
+    assert plan["requires_confirm"] is EXPECT[(autonomy, risk)]
+
+
+def test_intent_chat_route_never_confirms(monkeypatch):
+    monkeypatch.setattr(bantz_config.config, "autonomy", "low")
+    verdict = json.dumps({"route": "chat", "tool_name": None, "tool_args": {},
+                          "risk_level": "safe", "confidence": 0.9})
+    assert _extract_json(verdict)["requires_confirm"] is False
+
+
+# ── executor gate: Brain._execute_with_recovery honours the dial ─────────────
+
+class _FakeTool:
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    async def execute(self, **kwargs):
+        self.calls.append(kwargs)
+        return ToolResult(success=True, output="ran")
+
+
+class _FakeRegistry:
+    def __init__(self, tool):
+        self._tool = tool
+
+    def get(self, name):
+        return self._tool
+
+    def all_schemas(self):
+        return []
+
+
+@pytest.fixture
+def brain():
+    return Brain.__new__(Brain)
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch):
+    monkeypatch.setattr(brain_mod, "data_layer", MagicMock())
+    monkeypatch.setattr(brain_mod, "cot_route", AsyncMock())
+    # single-shot: the dial decision happens on iteration 1
+    monkeypatch.setattr(brain_mod.config, "tool_loop_max_steps", 1)
+    monkeypatch.setattr(brain_mod.config, "shell_confirm_destructive", True)
+
+
+@pytest.mark.parametrize("autonomy,risk", list(EXPECT))
+def test_gate_confirms_per_autonomy(autonomy, risk, brain, monkeypatch):
+    monkeypatch.setattr(brain_mod.config, "autonomy", autonomy)
+    tool = _FakeTool()
+    monkeypatch.setattr(brain_mod, "registry", _FakeRegistry(tool))
+    # a non-shell tool so is_destructive promotion doesn't override the risk
+    outcome = _run(brain._execute_with_recovery(
+        tool_name="demo", tool_args={}, risk=risk,
+        requires_confirm=_intent_requires_confirm(autonomy, risk),
+        confirmed=False, en_input="do it", recent_history=[], tool_ctx="",
+    ))
+
+    should_confirm = EXPECT[(autonomy, risk)]
+    if should_confirm:
+        assert outcome.terminal is not None
+        assert outcome.terminal.needs_confirm is True
+        assert tool.calls == []                    # gated → never executed
+        assert outcome.iterations[-1]["gated"] == "needs_confirm"
+    else:
+        assert outcome.terminal is None
+        assert outcome.result is not None and outcome.result.success is True
+        assert len(tool.calls) == 1                 # ran without confirmation
+
+
+def test_absolute_runs_destructive_without_confirm(brain, monkeypatch):
+    monkeypatch.setattr(brain_mod.config, "autonomy", "absolute")
+    tool = _FakeTool()
+    monkeypatch.setattr(brain_mod, "registry", _FakeRegistry(tool))
+    outcome = _run(brain._execute_with_recovery(
+        tool_name="demo", tool_args={}, risk="destructive",
+        requires_confirm=False, confirmed=False,
+        en_input="wipe it", recent_history=[], tool_ctx="",
+    ))
+    assert outcome.terminal is None
+    assert len(tool.calls) == 1
+
+
+def test_confirmed_bypasses_first_iteration(brain, monkeypatch):
+    # A user who already said "yes" (confirmed=True) is not re-prompted for the
+    # first decision, even at low autonomy.
+    monkeypatch.setattr(brain_mod.config, "autonomy", "low")
+    tool = _FakeTool()
+    monkeypatch.setattr(brain_mod, "registry", _FakeRegistry(tool))
+    outcome = _run(brain._execute_with_recovery(
+        tool_name="demo", tool_args={}, risk="moderate",
+        requires_confirm=True, confirmed=True,
+        en_input="do it", recent_history=[], tool_ctx="",
+    ))
+    assert outcome.terminal is None
+    assert len(tool.calls) == 1


### PR DESCRIPTION
Closes #492.

The autonomy dial is persisted and enforced (audit S1 wired `requires_confirm` + `config.autonomy` into the executor gate), but **`medium` behaved identically to `high`** (destructive-only) — the middle rung of the ladder was missing, and there were no per-tier tests.

This makes the four tiers a proper **monotonic caution ladder** in both places that decide confirmation:

| tier | confirms |
|------|----------|
| `absolute` | nothing (runs everything, even destructive) |
| `high` (default) | destructive only — **unchanged** |
| `medium` | moderate + destructive ← **new** |
| `low` | every tool action (even safe) |

- `src/bantz/core/intent.py` (`_extract_json`): sets `requires_confirm` per the ladder (medium → moderate|destructive).
- `src/bantz/core/brain.py` (`_execute_with_recovery`): the executor gate gains an explicit `medium` branch. The `high` branch (destructive-only, gated by `shell_confirm_destructive`) is untouched, so **default behaviour is byte-identical**. Re-decided actions inside the C1 loop are still gated per iteration and never auto-approved.

## Verification
- `tests/core/test_autonomy_dial.py` (new, 27 cases): pins both layers across every (tier × risk) combination, plus `absolute` runs destructive without confirm and `confirmed=True` bypasses the first iteration.
- Core suite: **796 passed, 26 skipped**; default `high` path unchanged.
- ruff clean.