### PR TITLE
fix(briefing): apply Gmail category filter to the morning summary (#494)

### DIFF
--- a/src/bantz/core/briefing.py
+++ b/src/bantz/core/briefing.py
@@ -127,14 +127,35 @@ class Briefing:
             return None
         d = data.get("data", {})
         unread = d.get("unread", 0)
-        urgent_count = d.get("urgent_count", 0)
         if unread == 0:
             return "Inbox is clean"
+
+        # Category filter (#494): the briefing surfaces only high-value
+        # categories (personal / institutional) and drops the low-value ones
+        # (notifications / services / payments) that just add morning noise.
+        from bantz.tools.gmail import categorize, _BRIEFING_CATEGORIES
+
+        def _briefing_only(msgs: list) -> list:
+            return [
+                m for m in msgs
+                if categorize(m.get("from", ""), m.get("subject", ""))
+                in _BRIEFING_CATEGORIES
+            ]
+
+        urgent = _briefing_only(d.get("urgent", []))
+        normal = _briefing_only(d.get("normal", []))
+
         parts = [f"{unread} unread emails"]
-        if urgent_count:
-            urgent = d.get("urgent", [])
+        if not urgent and not normal:
+            # Everything sampled was low-value → say so instead of a bare count.
+            parts.append("nothing that needs your attention")
+            return "  ".join(parts)
+        if urgent:
             subjects = [u.get("subject", "?")[:60] for u in urgent[:3]]
-            parts.append(f"🚨 {urgent_count} urgent: " + ", ".join(subjects))
+            parts.append(f"🚨 {len(urgent)} urgent: " + ", ".join(subjects))
+        if normal:
+            subjects = [m.get("subject", "?")[:60] for m in normal[:2]]
+            parts.append("📬 " + ", ".join(subjects))
         return "  ".join(parts)
 
     def _calendar_from_cache(self, data: dict) -> Optional[str]:

--- a/tests/core/test_briefing_category_filter.py
+++ b/tests/core/test_briefing_category_filter.py
@@ -1,0 +1,71 @@
+"""Morning briefing applies the Gmail category filter (issue #494).
+
+The Gmail tool buckets mail into personal / institutional / services /
+payments / notifications, but the briefing never used it — so low-value
+notifications and services cluttered the morning summary. These tests pin
+``Briefing._gmail_from_cache`` to the briefing filter: personal /
+institutional are kept, everything else is dropped.
+"""
+from __future__ import annotations
+
+from bantz.core.briefing import Briefing
+
+
+def _cache(unread: int, urgent: list, normal: list) -> dict:
+    return {"status": "ok", "data": {
+        "unread": unread, "urgent_count": len(urgent),
+        "urgent": urgent, "normal": normal,
+    }}
+
+
+def test_low_value_categories_excluded_high_value_kept():
+    out = Briefing()._gmail_from_cache(_cache(
+        unread=4,
+        urgent=[{"from": "Erasmus Office <office@firat.edu.tr>",
+                 "subject": "Placement decision"}],           # institutional
+        normal=[
+            {"from": "Defne <defne@gmail.com>",
+             "subject": "dinner tonight?"},                    # personal
+            {"from": "GitHub <noreply@github.com>",
+             "subject": "[bantzv2] new pull request"},         # notifications
+            {"from": "Apple <news@apple.com>",
+             "subject": "Your weekly digest"},                 # services
+        ],
+    ))
+    assert out is not None
+    assert "4 unread emails" in out
+    # kept
+    assert "Placement decision" in out
+    assert "dinner tonight?" in out
+    # dropped
+    assert "pull request" not in out.lower()
+    assert "github" not in out.lower()
+    assert "digest" not in out.lower()
+
+
+def test_all_low_value_reports_nothing_important():
+    out = Briefing()._gmail_from_cache(_cache(
+        unread=3, urgent=[],
+        normal=[
+            {"from": "GitHub <noreply@github.com>", "subject": "PR merged"},
+            {"from": "LinkedIn <noreply@linkedin.com>", "subject": "5 new jobs"},
+        ],
+    ))
+    assert out is not None
+    assert "3 unread emails" in out
+    assert "nothing that needs your attention" in out
+    assert "PR merged" not in out
+
+
+def test_inbox_clean_unchanged():
+    assert Briefing()._gmail_from_cache(
+        {"status": "ok", "data": {"unread": 0}}) == "Inbox is clean"
+
+
+def test_auth_error_passthrough():
+    out = Briefing()._gmail_from_cache({"status": "auth_error"})
+    assert out is not None and "re-authenticate" in out.lower()
+
+
+def test_non_ok_status_returns_none():
+    assert Briefing()._gmail_from_cache({"status": "error"}) is None


### PR DESCRIPTION
Closes #494.

The Gmail tool buckets mail into personal / institutional / services / payments / notifications, and `_summary(briefing=True)` filters to the high-value buckets — but the briefing's cache path (`_gmail_from_cache`) never applied it, so low-value notifications and services still cluttered the morning summary.

## Fix
`Briefing._gmail_from_cache` now runs the cached overnight-poll `urgent` + `normal` messages through `categorize()` + `_BRIEFING_CATEGORIES`: **personal / institutional are kept, everything else is dropped**. When every sampled message is low-value it says *"nothing that needs your attention"* instead of a bare unread count. The auth-error and inbox-clean paths are unchanged.

(The live count-only path `_get_gmail` reports just a number with no per-message subjects, so there's no category noise there to filter.)

## Verification
- `tests/core/test_briefing_category_filter.py` (5 new): a notifications (GitHub) and a services (Apple) email are excluded while a personal and an institutional one are kept; all-low-value → "nothing that needs your attention"; inbox-clean and auth-error paths preserved.
- workflows + core suites: **1056 passed, 26 skipped**.
- ruff clean.