### PR TITLE
fix(routing): carry prior-tool context into terse follow-ups (#495)

### DIFF
--- a/src/bantz/core/brain.py
+++ b/src/bantz/core/brain.py
@@ -347,6 +347,25 @@ class Brain:
         "calendar", "event", "meeting", "schedule", "appointment",
         "today", "tomorrow", "week", "upcoming",
     })
+    # Terse follow-up markers: short, context-dependent replies right after a
+    # tool turn ("u sure?", "from medium daily?", "which one?") that carry no
+    # topic keyword but are really about the previous tool's result (#495).
+    _FOLLOWUP_MARKERS = frozenset({
+        "u sure", "you sure", "are you sure", "sure?", "really", "which",
+        "from ", "filter", "only ", "just ", "sender", "what about",
+        "how about", "the first", "the second", "the third", "the last",
+        "that one", "the one",
+    })
+
+    def _is_tool_followup(self, lower: str) -> bool:
+        """A terse, context-dependent follow-up about the previous tool turn —
+        anaphora ('it', 'that', 'again') or a short clarifier ('u sure?',
+        'from medium daily?', 'which one?'). Keeps prior-tool context alive
+        across replies that carry no topic keyword, so the router re-routes to
+        that tool instead of falling back to chat (#495)."""
+        if _ANAPHORA.search(lower):
+            return True
+        return any(m in lower for m in self._FOLLOWUP_MARKERS)
 
     def _is_context_expired(self) -> bool:
         """Check if stored tool context has expired (turn-based TTL #276)."""
@@ -467,9 +486,17 @@ class Brain:
         self._clear_stale_context()
         parts: list[str] = []
         lower = en_input.lower()
+        # A terse follow-up ("u sure? from medium daily?") right after a tool
+        # turn carries no topic keyword; still surface that tool's context so
+        # the router doesn't drop to chat (#495).
+        is_followup = self._is_tool_followup(lower)
 
-        # Inject recent email IDs only if query relates to email
-        if self._last_messages and any(h in lower for h in self._EMAIL_HINTS):
+        # Inject recent email IDs if the query relates to email OR is a terse
+        # follow-up to the last (gmail) tool turn.
+        if self._last_messages and (
+            any(h in lower for h in self._EMAIL_HINTS)
+            or (is_followup and self._last_tool_name == "gmail")
+        ):
             lines = ["RECENT EMAIL RESULTS (use these IDs for follow-ups):"]
             for m in self._last_messages[:5]:
                 mid = m.get("id", "?")
@@ -479,8 +506,12 @@ class Brain:
             parts.append("\n".join(lines))
             self._context_turn = self._turn_counter  # refresh TTL on use
 
-        # Inject recent calendar events only if query relates to calendar
-        if self._last_events and any(h in lower for h in self._CALENDAR_HINTS):
+        # Inject recent calendar events if the query relates to calendar OR is
+        # a terse follow-up to the last (calendar) tool turn.
+        if self._last_events and (
+            any(h in lower for h in self._CALENDAR_HINTS)
+            or (is_followup and self._last_tool_name == "calendar")
+        ):
             lines = ["RECENT CALENDAR EVENTS (use these for follow-ups):"]
             for ev in self._last_events[:5]:
                 eid = ev.get("id", "?")

--- a/tests/core/test_terse_followup_routing.py
+++ b/tests/core/test_terse_followup_routing.py
@@ -1,0 +1,105 @@
+"""Terse follow-ups keep prior-tool context (issue #495).
+
+A short, context-dependent reply right after a Gmail turn — e.g.
+"u sure? from medium daily?" — carries no email keyword, so the old
+``_build_tool_context`` (gated purely on ``_EMAIL_HINTS``) dropped the email
+context and the router fell back to chat. These tests pin the fix: a terse
+follow-up to the last tool re-surfaces that tool's context, while a genuine
+topic switch still does not.
+"""
+from __future__ import annotations
+
+import pytest
+
+import bantz.core.brain as brain_mod
+from bantz.core.brain import Brain
+
+
+@pytest.fixture(autouse=True)
+def _no_awareness(monkeypatch):
+    # The tail of _build_tool_context consults config.awareness_enabled; keep
+    # it off so the helper stays hermetic.
+    monkeypatch.setattr(brain_mod.config, "awareness_enabled", False, raising=False)
+
+
+def _brain(*, last_tool="gmail", messages=None, events=None, tool_output=""):
+    b = Brain.__new__(Brain)
+    b._turn_counter = 5
+    b._context_turn = 5            # fresh — within TTL
+    b._CONTEXT_TTL = 3
+    b._last_messages = messages or []
+    b._last_events = events or []
+    b._last_tool_output = tool_output
+    b._last_tool_name = last_tool
+    b._last_screen_description = ""
+    b._screen_description_turn = 0
+    return b
+
+
+_MSGS = [
+    {"id": "m1", "from": "Medium Daily <noreply@medium.com>", "subject": "Today's picks"},
+    {"id": "m2", "from": "Defne <defne@gmail.com>", "subject": "dinner?"},
+]
+
+
+# ── _is_tool_followup unit ───────────────────────────────────────────────────
+
+@pytest.mark.parametrize("text", [
+    "u sure? from medium daily?",
+    "u sure?",
+    "from medium daily?",
+    "which one?",
+    "reply to that one",          # anaphora "that"
+    "just the unread ones",
+])
+def test_is_followup_true(text):
+    assert Brain._is_tool_followup(_brain(), text.lower()) is True
+
+
+@pytest.mark.parametrize("text", [
+    "what's the weather in elazig?",
+    "play some music",
+    "run maintenance",
+])
+def test_is_followup_false(text):
+    assert Brain._is_tool_followup(_brain(), text.lower()) is False
+
+
+# ── context injection for terse Gmail follow-ups ─────────────────────────────
+
+def test_terse_followup_after_gmail_injects_email_context():
+    b = _brain(last_tool="gmail", messages=_MSGS)
+    ctx = b._build_tool_context("u sure? from medium daily?")
+    assert "RECENT EMAIL RESULTS" in ctx
+    assert "m1" in ctx and "Medium Daily" in ctx
+
+
+def test_topic_switch_after_gmail_does_not_inject():
+    # A genuine new topic (no anaphora / follow-up marker) must NOT drag the
+    # stale email context along — the pre-#495 discipline is preserved.
+    b = _brain(last_tool="gmail", messages=_MSGS)
+    ctx = b._build_tool_context("what's the weather in elazig?")
+    assert "RECENT EMAIL RESULTS" not in ctx
+
+
+def test_email_keyword_still_injects():
+    # Regression: the original keyword path is unchanged.
+    b = _brain(last_tool="gmail", messages=_MSGS)
+    ctx = b._build_tool_context("any new emails?")
+    assert "RECENT EMAIL RESULTS" in ctx
+
+
+def test_terse_followup_gated_to_matching_tool():
+    # Terse follow-up but the last tool was NOT gmail → don't inject email
+    # context off a stale message list.
+    b = _brain(last_tool="weather", messages=_MSGS)
+    ctx = b._build_tool_context("u sure?")
+    assert "RECENT EMAIL RESULTS" not in ctx
+
+
+def test_terse_followup_after_calendar_injects_events():
+    events = [{"id": "e1", "summary": "Standup", "start": "09:00"}]
+    b = _brain(last_tool="calendar", events=events)
+    ctx = b._build_tool_context("which one?")
+    assert "RECENT CALENDAR EVENTS" in ctx
+    assert "Standup" in ctx


### PR DESCRIPTION
Closes #495.

A terse, context-dependent follow-up right after a Gmail turn — e.g. **"u sure? from medium daily?"** (meaning "re-check Gmail, filter to the *medium daily* sender") — carries no email keyword. `Brain._build_tool_context` only injected email context on an `_EMAIL_HINTS` match, so the context was dropped and `cot_route` fell back to a plain chat reply.

## Fix
- New `Brain._is_tool_followup(lower)`: detects anaphora (via `_ANAPHORA`) or a terse-clarifier marker (`"u sure"`, `"from "`, `"which"`, `"the first"`, …).
- The email and calendar injection gates now also fire when the input **is a follow-up AND the last tool was that tool** — re-surfacing the recent IDs so the router re-routes to gmail/calendar instead of chatting.
- A genuine topic switch (no anaphora/marker — e.g. "what's the weather?") still injects nothing, preserving the #276 anti-bloat discipline; and a terse follow-up whose last tool wasn't gmail won't drag a stale message list along.

## Verification
- `tests/core/test_terse_followup_routing.py` (14 new): the issue's `"u sure? from medium daily?"` case injects the email IDs; `_is_tool_followup` true/false matrix; topic-switch and wrong-last-tool negatives; keyword regression; calendar symmetry.
- Core suite: **810 passed, 26 skipped**.
- ruff clean.

Note: the fix is the deterministic context-injection mechanism (unit-tested); the final routing decision is still the LLM's, now correctly given the prior-tool context.