### PR TITLE
feat(ui): accent picker recolors the whole ember-* ramp (#493)

### DIFF
--- a/bantz-ui/src/index.css
+++ b/bantz-ui/src/index.css
@@ -7,12 +7,24 @@
    ============================================================ */
 
 :root {
-  /* Accent color — SettingsPage overrides this on documentElement from the
-     accent picker; --ember-500 (the primary accent CSS var) follows it. */
+  /* Accent color — SettingsPage's accent picker overrides --accent AND the
+     whole --ember-* ramp on documentElement (see lib/accentRamp.ts, #493).
+     Each shade has a colour var (--ember-N, for raw CSS var() below) and a
+     channel var (--ember-N-rgb = "r g b", for Tailwind's
+     rgb(var(--ember-N-rgb) / <alpha-value>) utilities). Defaults below match
+     the original palette so first paint is unchanged. */
   --accent: #ff4500;
+  --accent-rgb: 255 69 0;
   --ember-500: var(--accent);
+  --ember-500-rgb: var(--accent-rgb);
   --ember-400: #ff6a2a;
+  --ember-400-rgb: 255 106 42;
   --ember-300: #ff8c00;
+  --ember-300-rgb: 255 140 0;
+  --ember-200: #ffb347;
+  --ember-200-rgb: 255 179 71;
+  --ember-100: #ffd7a8;
+  --ember-100-rgb: 255 215 168;
   --gold-500: #c9a80c;
   --gold-400: #e2bb0b;
   --rose-500: #8b0000;

--- a/bantz-ui/src/lib/accentRamp.ts
+++ b/bantz-ui/src/lib/accentRamp.ts
@@ -1,0 +1,73 @@
+// Derive a coherent ember-* ramp from a single accent hex and apply it as CSS
+// variables, so the Tailwind `ember-*` utility classes follow the picked
+// accent instead of a hardcoded hex palette (#493).
+//
+// Tailwind's `ember` colours are defined as `rgb(var(--ember-N-rgb) /
+// <alpha-value>)`, so opacity utilities (`bg-ember-500/60`) keep working — that
+// requires the channel vars (`--ember-N-rgb`) to be space-separated "r g b".
+// The raw CSS in index.css still reads the colour vars (`--ember-N`), so both
+// forms are set.
+
+export type Shade = 100 | 200 | 300 | 400 | 500;
+
+const SHADES: Shade[] = [100, 200, 300, 400, 500];
+
+// How far each shade is mixed toward white; 500 is the accent itself. Chosen so
+// the default accent (#ff4500) yields a ramp close to the original palette.
+const LIGHTEN: Record<Shade, number> = {
+  500: 0,
+  400: 0.18,
+  300: 0.36,
+  200: 0.55,
+  100: 0.75,
+};
+
+function clampByte(n: number): number {
+  return Math.max(0, Math.min(255, Math.round(n)));
+}
+
+export function hexToRgb(hex: string): [number, number, number] {
+  let h = hex.trim().replace(/^#/, "");
+  if (h.length === 3) h = h.split("").map((c) => c + c).join("");
+  const n = parseInt(h, 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+
+function rgbToHex(r: number, g: number, b: number): string {
+  const v = (clampByte(r) << 16) | (clampByte(g) << 8) | clampByte(b);
+  return "#" + v.toString(16).padStart(6, "0");
+}
+
+export interface RampEntry {
+  hex: string;   // "#rrggbb"      — for raw CSS var() colours
+  rgb: string;   // "r g b" channels — for Tailwind's <alpha-value> utilities
+}
+
+export function emberRamp(accentHex: string): Record<Shade, RampEntry> {
+  const [br, bg, bb] = hexToRgb(accentHex);
+  const out = {} as Record<Shade, RampEntry>;
+  for (const shade of SHADES) {
+    const t = LIGHTEN[shade];
+    const r = clampByte(br + (255 - br) * t);
+    const g = clampByte(bg + (255 - bg) * t);
+    const b = clampByte(bb + (255 - bb) * t);
+    out[shade] = { hex: rgbToHex(r, g, b), rgb: `${r} ${g} ${b}` };
+  }
+  return out;
+}
+
+// Apply an accent and its derived ramp to a root element (defaults to
+// documentElement). Sets both the colour vars and the -rgb channel vars.
+export function applyAccent(
+  accentHex: string,
+  root: HTMLElement = document.documentElement,
+): void {
+  const ramp = emberRamp(accentHex);
+  const style = root.style;
+  style.setProperty("--accent", accentHex);
+  style.setProperty("--accent-rgb", ramp[500].rgb);
+  for (const shade of SHADES) {
+    style.setProperty(`--ember-${shade}`, ramp[shade].hex);
+    style.setProperty(`--ember-${shade}-rgb`, ramp[shade].rgb);
+  }
+}

--- a/bantz-ui/src/pages/SettingsPage.tsx
+++ b/bantz-ui/src/pages/SettingsPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, type ReactNode } from "react";
 import { Eye, EyeOff, Check, Save } from "lucide-react";
 import { PageTitle, PanelHeader } from "../components/primitives";
 import { useAppStore } from "../store/useAppStore";
+import { applyAccent } from "../lib/accentRamp";
 
 // Default Ollama host, used when no base URL has been configured.
 const DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434";
@@ -121,7 +122,7 @@ export function SettingsPage() {
   // Appearance prefs: apply to the DOM immediately and persist to localStorage.
   useEffect(() => {
     const hex = ACCENTS.find((a) => a.key === s.accent)?.hex ?? ACCENTS[0].hex;
-    document.documentElement.style.setProperty("--accent", hex);
+    applyAccent(hex);   // recolor --accent + the whole --ember-* ramp (#493)
     document.body.classList.toggle("night-shift", s.nightShift);
     document.body.classList.toggle("crt", s.crt);
     localStorage.setItem(

--- a/bantz-ui/tailwind.config.js
+++ b/bantz-ui/tailwind.config.js
@@ -17,13 +17,15 @@ export default {
           200: "#888888",
           100: "#BBBBBB",
         },
-        // Radiant Ember
+        // Radiant Ember — driven by CSS vars so the accent picker recolors
+        // every ember-* utility (#493). Channel vars + <alpha-value> keep
+        // opacity utilities (bg-ember-500/60) working.
         ember: {
-          100: "#FFD7A8",
-          200: "#FFB347",
-          300: "#FF8C00",
-          400: "#FF6A2A",
-          500: "#FF4500",
+          100: "rgb(var(--ember-100-rgb) / <alpha-value>)",
+          200: "rgb(var(--ember-200-rgb) / <alpha-value>)",
+          300: "rgb(var(--ember-300-rgb) / <alpha-value>)",
+          400: "rgb(var(--ember-400-rgb) / <alpha-value>)",
+          500: "rgb(var(--ember-500-rgb) / <alpha-value>)",
         },
         // Imperial Gold
         gold: {
@@ -65,8 +67,8 @@ export default {
         wide: "0.08em",
       },
       boxShadow: {
-        ember: "0 0 12px rgba(255, 69, 0, 0.6)",
-        "ember-soft": "0 0 24px rgba(255, 69, 0, 0.25)",
+        ember: "0 0 12px rgb(var(--ember-500-rgb) / 0.6)",
+        "ember-soft": "0 0 24px rgb(var(--ember-500-rgb) / 0.25)",
         gold: "0 0 8px rgba(212, 175, 55, 0.4)",
         "inner-well": "inset 0 0 20px rgba(0, 0, 0, 0.8)",
       },
@@ -82,10 +84,10 @@ export default {
           "100%": { opacity: "1", transform: "skewX(0deg)" },
         },
         "bantz-pulse": {
-          "0%, 100%": { filter: "drop-shadow(0 0 6px #FF4500)" },
+          "0%, 100%": { filter: "drop-shadow(0 0 6px var(--ember-500))" },
           "50%": {
             filter:
-              "drop-shadow(0 0 18px #FF6A2A) drop-shadow(0 0 4px #C9A80C)",
+              "drop-shadow(0 0 18px var(--ember-400)) drop-shadow(0 0 4px #C9A80C)",
           },
         },
         "bantz-waveform": {


### PR DESCRIPTION
Closes #493.

The Settings accent picker only set `--accent` (and `--ember-500` followed it), but the Tailwind `ember-*` utilities were **hardcoded hex** in `tailwind.config.js` — so `text-ember-400`, `bg-ember-500`, `border-ember-500/60`, the ember box-shadows, and the pulse glow never followed the picked accent.

## Change
- **`tailwind.config.js`**: the `ember` palette is now `rgb(var(--ember-N-rgb) / <alpha-value>)`, so opacity utilities (`bg-ember-500/60`) keep working via channel vars. The `ember` / `ember-soft` box-shadows and the `bantz-pulse` keyframe glow reference the vars too.
- **`index.css`**: full `--ember-100..500` ramp defined as colour vars (`--ember-N`, for the raw CSS `var()` usages) **and** channel vars (`--ember-N-rgb` = `"r g b"`, for Tailwind). Defaults match the original palette so first paint is unchanged.
- **`lib/accentRamp.ts`** (new): `emberRamp()` derives a coherent ramp from any accent hex (500 = the accent; lighter shades mixed toward white); `applyAccent()` writes `--accent` + the whole ramp (both colour and channel vars) to `documentElement`.
- **`SettingsPage.tsx`**: the picker calls `applyAccent()` instead of only setting `--accent`.

## Verification
- `vite build` compiles the var-based palette cleanly; the built CSS emits `rgb(var(--ember-500-rgb) / .6)` for opacity utilities and `.../ var(--tw-text-opacity,1)` for solid ones — every ember shade/opacity/gradient/shadow now resolves through the picker-updated vars.
- Ramp math checked: `500 == accent` exactly, valid `"r g b"` channels for arbitrary accents (ember, gold, velvet, rose).
- `tsc` clean on the changed files.
- **Not done headless**: the actual in-app live recolor (sidebar active state, slash menu, focus rings, shadows) still wants a visual pass in the running Tauri app — the mechanism is proven at the build/CSS level but I can't eyeball it here.

Note: CI here is Python-only, so it won't exercise the frontend; the verification above was run locally.