### PR TITLE
fix(eval): unblock real batch execution for #513 (loop telemetry + sandbox isolation)

### DIFF
--- a/eval/loop_eval/runner.py
+++ b/eval/loop_eval/runner.py
@@ -274,9 +274,12 @@ def run_child() -> int:
             if result.stream is not None:
                 async for token in result.stream:
                     text += token
-            return text, bool(result.needs_confirm)
+            # The C1 loop's per-iteration trace (#503) is authoritative for
+            # what the loop actually did; carry it out for the record.
+            trace = [dict(it) for it in (getattr(result, "iterations", None) or [])]
+            return text, bool(result.needs_confirm), trace
 
-    response, needs_confirm = asyncio.run(drive())
+    response, needs_confirm, brain_iters = asyncio.run(drive())
     wall_ms = int((time.perf_counter() - t0) * 1000)
 
     live_writes = sandbox.live_writes_since(marker)
@@ -293,36 +296,42 @@ def run_child() -> int:
         outcome = "completed"
 
     calls = world.call_log.calls()
-    iterations = []
-    for i, rec in enumerate(calls):
-        iterations.append({
-            "index": i + 1,
-            "route": "tool",
-            "tool_name": rec.tool,
-            "tool_args": rec.args,
-            # C1 loop telemetry (#503) will refine this; until then the
-            # first execution is the initial decision, later ones are
-            # LLM re-decisions by construction.
-            "decision_source": "initial" if i == 0 else "llm",
-            "result": {"success": rec.success, "error": rec.error,
-                       "output_excerpt": rec.output_excerpt},
-            "exception": rec.exception,
-            "gated": ("needs_confirm"
-                      if needs_confirm and i == len(calls) - 1 else None),
-            "tokens_in": 0, "tokens_out": 0, "wall_ms": 0,
-        })
-    if not iterations:  # routed to chat / never reached a tool
-        iterations.append({
-            "index": 1, "route": "chat", "tool_name": "", "tool_args": {},
-            "decision_source": "initial",
-            "result": {"success": False, "error": None,
-                       "output_excerpt": response[:500]},
-            "exception": None,
-            "gated": "needs_confirm" if needs_confirm else None,
-            "tokens_in": 0, "tokens_out": 0, "wall_ms": 0,
-        })
+    # Prefer the authoritative C1 loop trace from BrainResult (#503): it
+    # directly encodes each iteration's decision + result, so loop_triggered /
+    # recovery reflect what the loop actually did. Fall back to the fixture
+    # call log for no-tool (chat) paths that never enter the loop.
+    if brain_iters:
+        iterations = brain_iters
+    else:
+        iterations = []
+        for i, rec in enumerate(calls):
+            iterations.append({
+                "index": i + 1,
+                "route": "tool",
+                "tool_name": rec.tool,
+                "tool_args": rec.args,
+                "decision_source": "initial" if i == 0 else "llm",
+                "result": {"success": rec.success, "error": rec.error,
+                           "output_excerpt": rec.output_excerpt},
+                "exception": rec.exception,
+                "gated": ("needs_confirm"
+                          if needs_confirm and i == len(calls) - 1 else None),
+                "tokens_in": 0, "tokens_out": 0, "wall_ms": 0,
+            })
+        if not iterations:  # routed to chat / never reached a tool
+            iterations.append({
+                "index": 1, "route": "chat", "tool_name": "", "tool_args": {},
+                "decision_source": "initial",
+                "result": {"success": False, "error": None,
+                           "output_excerpt": response[:500]},
+                "exception": None,
+                "gated": "needs_confirm" if needs_confirm else None,
+                "tokens_in": 0, "tokens_out": 0, "wall_ms": 0,
+            })
 
-    loop_triggered = False  # C1 loop not landed (#503); baseline semantics
+    # The loop re-decided iff more than one iteration was recorded (steps=1
+    # baseline always has exactly one → loop_triggered stays False).
+    loop_triggered = len(iterations) > 1
     record = {
         "schema_version": "1.0",
         "batch_id": payload["batch_id"],
@@ -375,11 +384,17 @@ def _child_env(cond: dict, mock: bool) -> dict:
     env["BANTZ_OLLAMA_MODEL"] = cond["model"]
     env["BANTZ_LLM_PROVIDER"] = cond["provider"]
     env["BANTZ_TOOL_LOOP_MAX_STEPS"] = str(cond["tool_loop_max_steps"])
-    if mock:  # keep test children lean and network-free
-        env["BANTZ_MEMPALACE_ENABLED"] = "false"
-        env["BANTZ_VOICE_ENABLED"] = "false"
-        env["BANTZ_OBSERVER_ENABLED"] = "false"
-        env["BANTZ_RL_ENABLED"] = "false"
+    # Disable eval-irrelevant, leak-prone subsystems for EVERY child (mock and
+    # real), not just mock. MemPalace writes lock files under the live
+    # ~/.mempalace/locks regardless of BANTZ_PALACE_PATH, and voice/observer/RL
+    # touch live paths too — any of which trips the sandbox guard (#505) on a
+    # real run. None affect the measured routing/recovery on fresh sandboxed
+    # tasks (no stored memory to recall); only the model call stays real when
+    # mock is off.
+    env["BANTZ_MEMPALACE_ENABLED"] = "false"
+    env["BANTZ_VOICE_ENABLED"] = "false"
+    env["BANTZ_OBSERVER_ENABLED"] = "false"
+    env["BANTZ_RL_ENABLED"] = "false"
     return env
 
 

--- a/tests/eval/test_preflight.py
+++ b/tests/eval/test_preflight.py
@@ -24,13 +24,17 @@ def _run(*args: str, timeout: int = 900) -> subprocess.CompletedProcess:
         cwd=str(REPO))
 
 
-def test_preflight_green_baseline_only(tmp_path):
+def test_preflight_green_with_loop(tmp_path):
+    """With the C1 loop landed (#503), the UNWAIVED gate is GREEN: check #4
+    shows a real steps=3 recovery end-to-end, so no --allow-no-loop is needed.
+    (Before the loop landed this same call correctly returned RED.)"""
     report = tmp_path / "report.md"
-    proc = _run("--allow-no-loop", "--report", str(report))
+    proc = _run("--report", str(report))
     assert proc.returncode == 0, proc.stdout[-2000:] + proc.stderr[-1000:]
     text = report.read_text(encoding="utf-8")
-    assert "GREEN (BASELINE-ONLY)" in text
+    assert "GREEN — full batch may proceed" in text
     assert text.count("✅ PASS") == 5
+    assert "recovery=True" in text
     assert "git SHA" in text
     # every one of the five checks is present in the archived report
     for marker in ("1. mini-batch", "2. hard-kill", "3. zero writes",
@@ -38,12 +42,14 @@ def test_preflight_green_baseline_only(tmp_path):
         assert marker in text, marker
 
 
-def test_preflight_red_without_loop_waiver(tmp_path):
-    """Until the C1 loop (#503) lands, an unwaived gate must refuse the
-    batch — that is the gate doing its job, not a bug."""
+def test_preflight_baseline_only_waiver_accepted(tmp_path):
+    """--allow-no-loop remains a valid (now redundant) waiver: the gate still
+    passes and archives all five checks. Because the loop recovers the
+    transient task, the verdict is full GREEN rather than BASELINE-ONLY."""
     report = tmp_path / "report.md"
-    proc = _run("--report", str(report))
-    assert proc.returncode == 1
+    proc = _run("--allow-no-loop", "--report", str(report))
+    assert proc.returncode == 0, proc.stdout[-2000:] + proc.stderr[-1000:]
     text = report.read_text(encoding="utf-8")
-    assert "RED — do NOT start a full batch" in text
-    assert "loop" in text.lower()
+    assert "GREEN" in text
+    assert text.count("✅ PASS") == 5
+    assert "git SHA" in text


### PR DESCRIPTION
Toward #513 (execute full eval batches). Running the runner on **real** gemma4:e4b surfaced two harness bugs — both stale since before #503 landed — that made real batches impossible. Fixed both; verified with a green real-model pre-flight and a sandboxed pilot.

## Bug 1 — recovery was never measurable
`runner.py` hardcoded `loop_triggered = False` (comment: *"C1 loop not landed"*) and reconstructed `iterations` from the fixture call log. So `recovery = success AND loop_triggered` was **always False** — the experiment had no signal. The runner now consumes the authoritative `BrainResult.iterations` trace that #503 provides and derives `loop_triggered = len(iterations) > 1`. Pre-flight check #4 flips **RED→GREEN** (`recovery=True, iterations=2`).

## Bug 2 — real runs violated the sandbox
Real (non-mock) children left MemPalace/voice/observer/RL enabled, and MemPalace writes lock files under the live `~/.mempalace/locks` regardless of `BANTZ_PALACE_PATH` → **every real task tripped the sandbox guard** (`outcome=sandbox_violation`). `_child_env` now disables those eval-irrelevant, leak-prone subsystems for **all** children (only the model call stays real). Real runs are now zero-live-write.

## Tests
`tests/eval/test_preflight.py` updated to the post-#503 reality: the unwaived gate is GREEN now that the loop recovers end-to-end (this exact call correctly returned RED before the loop landed). `tests/eval` green.

## Pilot verification (real gemma4:e4b, sandboxed, daemon stopped per RUNBOOK, restarted after)
2 tasks × steps{1,3} → 4 records, **0 schema errors, 0 live writes**. The transient task shows `selection_correct_first=True`, the loop firing (iter1 503-fail → iter2 succeeds), and `success=False` because the 4B **malforms the args** (`start_time` instead of `date`+`time`, missing `action:create`) — genuine signal for the paper's thesis (routing accuracy ≠ execution reliability; the loop can't fix a *consistent* arg-schema error), not a harness fault.

## Scope
This makes #513 **executable** and verifies the pipeline on real data; the **full-corpus batch is the remaining GPU-night run** (hours, daemon down throughout) — #513 stays open for that. Generated `results/` + `manifests/` are gitignored, so only the runner fix + test updates are committed.