### PR TITLE
feat(brain): tool_loop_mode=retry — ablation baseline for the C1 loop

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -313,6 +313,10 @@ BANTZ_MOOD_BIAS=tolerant
 BANTZ_TOOL_LOOP_MAX_STEPS=1
 # Ceiling on extra routing-call tokens per turn while the loop is active.
 BANTZ_TOOL_LOOP_TOKEN_BUDGET=4096
+# Recovery strategy when the loop is active: redecide (default, re-invoke the
+# router with the failure observed) | retry (re-execute the same call — the
+# eval ablation baseline, zero extra LLM calls).
+BANTZ_TOOL_LOOP_MODE=redecide
 
 # ── Google account identity (audit S5) ─────────────────────────────────────
 # Expected Google account for gmail/calendar tokens. When set, Bantz logs a

--- a/eval/loop_eval/runner.py
+++ b/eval/loop_eval/runner.py
@@ -67,7 +67,12 @@ def _now_iso() -> str:
 
 def condition_slug(cond: dict) -> str:
     model = "".join(c if c.isalnum() else "-" for c in cond["model"])
-    return f"{model}_steps{cond['tool_loop_max_steps']}"
+    slug = f"{model}_steps{cond['tool_loop_max_steps']}"
+    # Default mode keeps historical slugs stable so --resume still dedupes
+    # against pre-ablation batches.
+    if cond.get("tool_loop_mode", "redecide") != "redecide":
+        slug += f"_{cond['tool_loop_mode']}"
+    return slug
 
 
 # ── task loading ─────────────────────────────────────────────────────────────
@@ -384,6 +389,7 @@ def _child_env(cond: dict, mock: bool) -> dict:
     env["BANTZ_OLLAMA_MODEL"] = cond["model"]
     env["BANTZ_LLM_PROVIDER"] = cond["provider"]
     env["BANTZ_TOOL_LOOP_MAX_STEPS"] = str(cond["tool_loop_max_steps"])
+    env["BANTZ_TOOL_LOOP_MODE"] = cond.get("tool_loop_mode", "redecide")
     # Disable eval-irrelevant, leak-prone subsystems for EVERY child (mock and
     # real), not just mock. MemPalace writes lock files under the live
     # ~/.mempalace/locks regardless of BANTZ_PALACE_PATH, and voice/observer/RL
@@ -458,8 +464,9 @@ def run_batch(args: argparse.Namespace) -> int:
 
     conditions = [
         {"model": model, "tool_loop_max_steps": steps,
-         "provider": args.provider}
+         "provider": args.provider, "tool_loop_mode": mode}
         for model in args.model for steps in args.steps
+        for mode in args.mode
     ]
 
     batch_dir = results_root / args.batch_id
@@ -529,6 +536,11 @@ def main(argv: list[str] | None = None) -> int:
                                                    s.split(",")],
                         default=[1],
                         help="comma-separated tool_loop_max_steps, e.g. 1,3")
+    parser.add_argument("--mode", type=lambda s: s.split(","),
+                        default=["redecide"],
+                        help="comma-separated tool_loop_mode values "
+                             "(redecide,retry) — retry is the ablation "
+                             "baseline: same call re-executed, no re-decide")
     parser.add_argument("--provider", default="ollama")
     parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT_S)
     parser.add_argument("--resume", action="store_true")

--- a/src/bantz/config.py
+++ b/src/bantz/config.py
@@ -43,6 +43,13 @@ class Config(BaseSettings):
     # Ceiling on EXTRA routing-call tokens per turn once the loop is active;
     # the loop stops re-deciding when exceeded. Irrelevant at max_steps=1.
     tool_loop_token_budget: int = Field(4096, ge=0, alias="BANTZ_TOOL_LOOP_TOKEN_BUDGET")
+    # Recovery strategy once the loop is active (max_steps>1):
+    #   "redecide" (default) — feed the failure back and re-invoke cot_route
+    #   "retry"             — re-execute the SAME call, no router consult
+    # "retry" is the eval ablation baseline (does re-decision beat a plain
+    # bounded retry?); it costs zero extra LLM calls.
+    tool_loop_mode: str = Field("redecide", pattern="^(redecide|retry)$",
+                                alias="BANTZ_TOOL_LOOP_MODE")
 
     # ── Vision / Remote VLM ───────────────────────────────────────────────
     vlm_enabled: bool = Field(False, alias="BANTZ_VLM_ENABLED")

--- a/src/bantz/core/brain.py
+++ b/src/bantz/core/brain.py
@@ -708,6 +708,11 @@ class Brain:
     ) -> _RecoveryOutcome:
         """Bounded observe→re-decide loop around tool execution (audit C1, #503).
 
+        ``config.tool_loop_mode`` selects the recovery strategy when
+        ``max_steps > 1``: ``"redecide"`` (default) re-invokes cot_route with
+        the failure as an observation; ``"retry"`` re-executes the same call
+        with no router consult (the eval ablation baseline).
+
         Default (``config.tool_loop_max_steps == 1``): the body runs exactly
         once — byte-identical to the historical single-shot path, with ZERO
         extra LLM calls. When ``max_steps > 1``, a tool failure (``success=
@@ -841,9 +846,14 @@ class Brain:
                     # the real error exactly as the single-shot path does today.
                     last_exc = None
 
-            # ── Failure: observe → re-decide (budget & steps permitting) ─
+            # ── Failure: observe → recover (budget & steps permitting) ─
             if index >= max_steps:
                 break
+            if config.tool_loop_mode == "retry":
+                # Ablation baseline: re-execute the SAME call, no router
+                # consult, zero extra LLM calls. tool_name/args/risk (and the
+                # gates re-checked at the top of the loop) stay as-is.
+                continue
             observation = self._observation_block(tool_name, tool_args, result, last_exc)
             est = _estimate_tokens(observation + en_input)
             if overhead_tokens + est > token_budget:

--- a/tests/core/test_recovery_loop.py
+++ b/tests/core/test_recovery_loop.py
@@ -90,7 +90,8 @@ def _quiet_conversation(monkeypatch):
 
 
 def _cfg(monkeypatch, *, max_steps=1, token_budget=4096,
-         autonomy="high", confirm_destructive=True):
+         autonomy="high", confirm_destructive=True, mode="redecide"):
+    monkeypatch.setattr(brain_mod.config, "tool_loop_mode", mode)
     monkeypatch.setattr(brain_mod.config, "tool_loop_max_steps", max_steps)
     monkeypatch.setattr(brain_mod.config, "tool_loop_token_budget", token_budget)
     monkeypatch.setattr(brain_mod.config, "autonomy", autonomy)
@@ -290,6 +291,56 @@ def test_iteration_trace_matches_contract(brain, monkeypatch):
         "transcript_path": "x", "ts": "2026-07-03T00:00:00Z",
     }
     assert loop_schema.validate_result(record) == []
+
+
+
+# ── retry-only ablation mode (tool_loop_mode="retry") ────────────────────────
+
+def test_retry_mode_recovers_transient_without_llm(brain, monkeypatch):
+    """mode=retry re-executes the SAME call on failure — recovery on a
+    transient fault with ZERO cot_route calls (the ablation baseline)."""
+    _cfg(monkeypatch, max_steps=3, mode="retry")
+    flaky = _FakeTool([
+        ToolResult(success=False, output="", error="transient 503"),
+        ToolResult(success=True, output="Created"),
+    ])
+    monkeypatch.setattr(brain_mod, "registry", _FakeRegistry({"calendar": flaky}))
+    cot = AsyncMock()
+    monkeypatch.setattr(brain_mod, "cot_route", cot)
+
+    outcome = _run(_call(brain, tool_name="calendar",
+                         tool_args={"action": "create"}))
+
+    assert outcome.result is not None and outcome.result.success is True
+    assert len(outcome.iterations) == 2
+    cot.assert_not_called()                       # no re-decide in retry mode
+    assert flaky.calls == [{"action": "create"}] * 2   # identical call, twice
+
+
+def test_retry_mode_exhausts_on_consistent_failure(brain, monkeypatch):
+    _cfg(monkeypatch, max_steps=3, mode="retry")
+    tool = _FakeTool([ToolResult(success=False, output="", error="bad args")] * 3)
+    monkeypatch.setattr(brain_mod, "registry", _FakeRegistry({"demo": tool}))
+    cot = AsyncMock()
+    monkeypatch.setattr(brain_mod, "cot_route", cot)
+
+    outcome = _run(_call(brain, tool_name="demo"))
+
+    assert outcome.result is not None and outcome.result.success is False
+    assert len(outcome.iterations) == 3           # all budget spent retrying
+    cot.assert_not_called()
+
+
+def test_default_mode_is_redecide(brain, monkeypatch):
+    """Omitting the mode keeps the #503 behaviour: failure → cot_route."""
+    _cfg(monkeypatch, max_steps=2)                # mode defaults to redecide
+    first = _FakeTool([ToolResult(success=False, output="", error="boom")])
+    monkeypatch.setattr(brain_mod, "registry", _FakeRegistry({"alpha": first}))
+    cot = AsyncMock(return_value=(None, None))
+    monkeypatch.setattr(brain_mod, "cot_route", cot)
+
+    _run(_call(brain))
+    cot.assert_awaited_once()
 
 
 # ── #504: seeded transient-failure recovery ──────────────────────────────────

--- a/tests/core/test_tool_loop_config.py
+++ b/tests/core/test_tool_loop_config.py
@@ -36,3 +36,14 @@ class TestToolLoopConfig:
         monkeypatch.setenv("BANTZ_TOOL_LOOP_TOKEN_BUDGET", "-1")
         with pytest.raises(ValidationError):
             Config()
+
+    def test_mode_default_and_env_override(self, monkeypatch):
+        monkeypatch.delenv("BANTZ_TOOL_LOOP_MODE", raising=False)
+        assert Config().tool_loop_mode == "redecide"
+        monkeypatch.setenv("BANTZ_TOOL_LOOP_MODE", "retry")
+        assert Config().tool_loop_mode == "retry"
+
+    def test_mode_invalid_rejected(self, monkeypatch):
+        monkeypatch.setenv("BANTZ_TOOL_LOOP_MODE", "yolo")
+        with pytest.raises(ValidationError):
+            Config()


### PR DESCRIPTION
Follow-up to #503/#513. The measured C1 recoveries are dominated by **transient** faults where the re-decision picks the *same* call again — which a plain bounded retry would also fix. Without a retry-only condition the +14.6/+17.1-point gains can't be attributed to re-*deciding*; a reviewer will ask for exactly this ablation.

## Change
- **config**: `tool_loop_mode: redecide|retry` (`BANTZ_TOOL_LOOP_MODE`, default `redecide` = exact #503 behaviour, pattern-validated).
- **brain** `_execute_with_recovery`: `retry` re-executes the same call on failure with **no `cot_route` consult** (zero extra LLM calls). The destructive + autonomy gates are still re-checked every iteration.
- **runner**: `--mode redecide,retry` builds conditions × modes, passes the env to children, and suffixes non-default modes in the condition slug (historical slugs unchanged so `--resume` still dedupes against existing batches).
- `.env.example` entry (env-completeness test).

## Verification
- New tests: retry recovers a transient fault with `cot_route` **never called** and byte-identical repeated args; retry exhausts on a consistent failure; default mode stays `redecide` (`cot_route` awaited once). Config default/override/invalid-value.
- `tests/core` + `tests/eval`: 1024 passed.
- Mock-LLM runner smoke with `--mode retry,redecide`: two condition files (`…_steps3_retry.jsonl`, `…_steps3.jsonl`), both complete.
- ruff clean.

The retry-condition eval batches (both backbones) run next; results go to the paper's ablation table.